### PR TITLE
[WIP] Fix #484 - Update to use asynchronous strategy for menu window

### DIFF
--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -2,7 +2,9 @@ import * as os from "os"
 
 import { app, dialog, Menu, shell } from "electron"
 
-export const buildMenu = (mainWindow, loadInit) => {
+export type BrowserWindowFunction = () => Promise<any>
+
+export const buildMenu = (mainWindowFunction: BrowserWindowFunction, loadInit) => {
     const menu = []
 
     // On Windows, both the forward slash `/` and the backward slash `\` are accepted as path delimiters.
@@ -10,11 +12,37 @@ export const buildMenu = (mainWindow, loadInit) => {
     // for VIM as it sees escape keys.
     const normalizePath = (fileName) => fileName.split("\\").join("/")
 
-    const executeVimCommand = (command) => mainWindow.webContents.send("menu-item-click", command)
+    const executeVimCommand = async (command) => {
+        const mainWindow = await mainWindowFunction()
+        mainWindow.webContents.send("menu-item-click", command)
+    }
 
-    const executeVimCommandForMultipleFiles = (command, files) => mainWindow.webContents.send("open-files", command, files)
+    const executeVimCommandForMultipleFiles = async (command, files) => {
+        const mainWindow = await mainWindowFunction()
+        mainWindow.webContents.send("open-files", command, files)
+    }
 
-    const executeOniCommand = (command) => mainWindow.webContents.send("execute-command", command)
+    const executeOniCommand = async (command) => {
+        const mainWindow = await mainWindowFunction()
+        mainWindow.webContents.send("execute-command", command)
+    }
+
+    const showOpenDialogAndExecuteCommandForFiles = async (command) => {
+        const mainWindow = await mainWindowFunction()
+        const opts: any = ["openFile", "multiSelections"]
+        dialog.showOpenDialog(mainWindow, opts, (files) => {
+            executeVimCommandForFiles(command, files)
+        })
+    }
+
+    const showSaveDialogAndExecuteCommandForFile = async (command) => {
+        const mainWindow = await mainWindowFunction()
+        dialog.showSaveDialog(mainWindow, {}, (name) => {
+            if (name) {
+                executeVimCommand(command + " " + normalizePath(name))
+            }
+        })
+    }
 
     const executeVimCommandForFiles = (command, files) => {
         if (!files || !files.length) {
@@ -79,7 +107,8 @@ export const buildMenu = (mainWindow, loadInit) => {
             {
                 label: "Open File…",
                 click(item, focusedWindow) {
-                    dialog.showOpenDialog(mainWindow, { properties: ["openFile", "multiSelections"] }, (files) => executeVimCommandForMultipleFiles(":tabnew ", files))
+                    showOpenDialogAndExecuteCommandForFiles(":tabnew")
+                    // dialog.showOpenDialog(mainWindow, { properties: ["openFile", "multiSelections"] }, (files) => executeVimCommandForMultipleFiles(":tabnew ", files))
                 },
             },
             {
@@ -92,28 +121,33 @@ export const buildMenu = (mainWindow, loadInit) => {
             {
                 label: "Split Open…",
                 click(item, focusedWindow) {
-                    dialog.showOpenDialog(mainWindow, { properties: ["openFile"] }, (files) => executeVimCommandForFiles(":sp", files))
+                    showOpenDialogAndExecuteCommandForFiles(":sp")
+                    // dialog.showOpenDialog(mainWindow, { properties: ["openFile"] }, (files) => executeVimCommandForFiles(":sp", files))
                 },
             },
             {
                 type: "separator",
             },
+            // TODO: Conditional on being active...
             {
                 label: "Save",
                 click(item, focusedWindow) {
                     executeVimCommand(":w")
                 },
             },
+            // TODO: Conditional on being active...
             {
                 label: "Save As…",
                 click(item, focusedWindow) {
-                    dialog.showSaveDialog(mainWindow, {}, (name) => {
-                        if (name) {
-                            executeVimCommand(":save " + normalizePath(name))
-                        }
-                    })
+                    showSaveDialogAndExecuteCommandForFile(":save")
+                    // dialog.showSaveDialog(mainWindow, {}, (name) => {
+                    //     if (name) {
+                    //         executeVimCommand(":save " + normalizePath(name))
+                    //     }
+                    // })
                 },
             },
+            // TODO: Conditional on being active...
             {
                 label: "Save All",
                 click(item, focusedWindow) {


### PR DESCRIPTION
__Issue:__ Many of the menu options rely on there being an Oni window active - which isn't always the case in OS X. 

__Fix:__ Extract out an asynchronous strategy for fetching the current window. This is basically a `getOrCreate` - if there is an existing window, we use that, otherwise we create a new one.

There is an open issue though - there are some menu options that make sense to have when there is no window open (like new file, or open file), but there are also some that _only_ make sense in the context of a window or active editor context - like saving a file. As part of this, I'm investigating having aspects of the menu be controlled by the active editor - so in the case where a window is not active, we'd show a limited set of hardcoded options. However, I'd like to integrate this with the set of commands, and have the active editor "push up" available commands (so that even plugins could register their own commands). I think it makes sense to have the browser window be able to augment this set of commands, by exposing an `ApplicationMenu` concept on the renderer side, and hooking in the command manager to it (so as part of the metadata of a command, the menu path could also be specified..)
