### PR TITLE
[WIP] Markdown language server

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -79,6 +79,8 @@ const BaseConfiguration: IConfigurationValues = {
     "language.cpp.languageServer.command": "clangd",
     "language.c.languageServer.command": "clangd",
 
+    "language.markdown.languageServer.command": path.join(__dirname, "languages", "markdown", "server.js"),
+
     "language.reason.languageServer.command": ocamlLanguageServerPath,
     "language.reason.languageServer.arguments": ["--stdio"],
     "language.reason.languageServer.rootFiles": [".merlin", "bsconfig.json"],

--- a/languages/markdown/server.ts
+++ b/languages/markdown/server.ts
@@ -1,0 +1,151 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import {
+	StreamMessageReader, StreamMessageWriter, createConnection, IConnection, TextDocuments, TextDocument,
+	Diagnostic, DiagnosticSeverity, InitializeResult, TextDocumentPositionParams, CompletionItem,
+	CompletionItemKind
+} from 'vscode-languageserver';
+
+// Create a connection for the server. The connection uses Node's IPC as a transport
+let connection: IConnection = createConnection(new StreamMessageReader(process.stdin), new StreamMessageWriter(process.stdout));
+
+// Create a simple text document manager. The text document manager
+// supports full document sync only
+let documents: TextDocuments = new TextDocuments();
+// Make the text document manager listen on the connection
+// for open, change and close text document events
+documents.listen(connection);
+
+// After the server has started the client sends an initilize request. The server receives
+// in the passed params the rootPath of the workspace plus the client capabilites.
+let workspaceRoot: string;
+connection.onInitialize((params): InitializeResult => {
+	workspaceRoot = params.rootPath;
+	return {
+		capabilities: {
+			// Tell the client that the server works in FULL text document sync mode
+			textDocumentSync: documents.syncKind,
+			// Tell the client that the server support code complete
+			completionProvider: {
+				resolveProvider: true
+			}
+		}
+	}
+});
+
+// The content of a text document has changed. This event is emitted
+// when the text document first opened or when its content has changed.
+documents.onDidChangeContent((change) => {
+	validateTextDocument(change.document);
+});
+
+// The settings interface describe the server relevant settings part
+interface Settings {
+	lspSample: ExampleSettings;
+}
+
+// These are the example settings we defined in the client's package.json
+// file
+interface ExampleSettings {
+	maxNumberOfProblems: number;
+}
+
+// hold the maxNumberOfProblems setting
+let maxNumberOfProblems: number = 100
+// The settings have changed. Is send on server activation
+// as well.
+connection.onDidChangeConfiguration((change) => {
+	let settings = <Settings>change.settings;
+	maxNumberOfProblems = settings.lspSample.maxNumberOfProblems || 100;
+	// Revalidate any open text documents
+	documents.all().forEach(validateTextDocument);
+});
+
+function validateTextDocument(textDocument: TextDocument): void {
+	let diagnostics: Diagnostic[] = [];
+	let lines = textDocument.getText().split(/\r?\n/g);
+	let problems = 0;
+	for (var i = 0; i < lines.length && problems < maxNumberOfProblems; i++) {
+		let line = lines[i];
+		let index = line.indexOf('typescript');
+		if (index >= 0) {
+			problems++;
+			diagnostics.push({
+				severity: DiagnosticSeverity.Warning,
+				range: {
+					start: { line: i, character: index },
+					end: { line: i, character: index + 10 }
+				},
+				message: `${line.substr(index, 10)} should be spelled TypeScript`,
+				source: 'ex'
+			});
+		}
+	}
+	// Send the computed diagnostics to VSCode.
+	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+}
+
+connection.onDidChangeWatchedFiles((_change) => {
+	// Monitored files have change in VSCode
+	connection.console.log('We recevied an file change event');
+});
+
+
+// This handler provides the initial list of the completion items.
+connection.onCompletion((_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+	// The pass parameter contains the position of the text document in
+	// which code complete got requested. For the example we ignore this
+	// info and always provide the same completion items.
+	return [
+		{
+			label: 'TypeScript',
+			kind: CompletionItemKind.Text,
+			data: 1
+		},
+		{
+			label: 'JavaScript',
+			kind: CompletionItemKind.Text,
+			data: 2
+		}
+	]
+});
+
+// This handler resolve additional information for the item selected in
+// the completion list.
+connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
+	if (item.data === 1) {
+		item.detail = 'TypeScript details',
+			item.documentation = 'TypeScript documentation'
+	} else if (item.data === 2) {
+		item.detail = 'JavaScript details',
+			item.documentation = 'JavaScript documentation'
+	}
+	return item;
+});
+
+
+// connection.onDidOpenTextDocument((params) => {
+// 	// A text document got opened in VSCode.
+// 	// params.uri uniquely identifies the document. For documents store on disk this is a file URI.
+// 	// params.text the initial full content of the document.
+// 	connection.console.log(`${params.textDocument.uri} opened.`);
+// });
+// connection.onDidChangeTextDocument((params) => {
+// 	// The content of a text document did change in VSCode.
+// 	// params.uri uniquely identifies the document.
+// 	// params.contentChanges describe the content changes to the document.
+// 	connection.console.log(`${params.textDocument.uri} changed: ${JSON.stringify(params.contentChanges)}`);
+// });
+// connection.onDidCloseTextDocument((params) => {
+// 	// A text document got closed in VSCode.
+// 	// params.uri uniquely identifies the document.
+// 	connection.console.log(`${params.textDocument.uri} closed.`);
+// });
+
+
+// Listen on the connection
+connection.listen();

--- a/languages/markdown/tsconfig.json
+++ b/languages/markdown/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": false,
+        "sourceMap": false
+    }
+}


### PR DESCRIPTION
This is a prototype to include a markdown language server, with some limited capabilities:

- Linting via the `write-good` library
- Spellchecking via `node-spellchecker`
- Go-to definition for following links

At the moment, it's basically just the sample language server, but will be expanded on (and could be extracted out to a separate project / npm package)