### PR TITLE
Use custom trigger characters when supplied.

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -86,6 +86,10 @@ const BaseConfiguration: IConfigurationValues = {
     "language.ocaml.languageServer.arguments": ["--stdio"],
     "language.ocaml.languageServer.configuration": ocamlAndReasonConfiguration,
 
+    "language.typescript.completionTriggerCharacters": [".", "/", "\\"],
+
+    "language.javascript.completionTriggerCharacters": [".", "/", "\\"],
+
     "menu.caseSensitive": "smart",
 
     "recorder.copyScreenshotToClipboard": false,

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -13,6 +13,7 @@ import { Event } from "./../../Event"
 import { IDisposable } from "./../../IDisposable"
 import * as Log from "./../../Log"
 
+import { configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
 
 import { ILanguageClient } from "./LanguageClient"
@@ -134,7 +135,13 @@ export class LanguageManager {
     }
 
     public getCompletionTriggerCharacters(language: string): string[] {
-        return ["."]
+        const languageSpecificTriggerChars = configuration.getValue(`language.${language}.completionTriggerCharacters`)
+
+        if (languageSpecificTriggerChars) {
+            return languageSpecificTriggerChars
+        } else {
+            return ["."]
+        }
     }
 
     public isLanguageServerAvailable(language: string): boolean {


### PR DESCRIPTION
When a custom trigger array is given, we should use that for the trigger characters of that language.

Currently, I've set the Typescript and Javascript ones to . / \ which are the ones I've seen used in other editors.

We could also extend the trigger character settings to be more complex.
I think in VSCode, they have . / \ ", with the last 3 all only working in certain cases.
Ie only allow / when on an import line, don't use " if its the end of an already open string.
This would also let us add " which I have excluded for now, as it messes with auto completion when closing import strings.

I can look at adding that as part of this PR, or add an issue and sort it separately, if its decided its needed/useful.