### PR TITLE
Build: Enable caching for node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ branches:
         - master
         - /^release.*/
 
+cache:
+    directories:
+        - node_modules
+
 matrix:
     include:
         - os: linux


### PR DESCRIPTION
- This should make it less frequent that `vscode-ripgrep` needs to be downloaded, so that we don't get the rate limit errors.