### PR TITLE
Rename bug fixes

### DIFF
--- a/browser/src/Services/Language/Rename.tsx
+++ b/browser/src/Services/Language/Rename.tsx
@@ -19,7 +19,9 @@ let _isRenameCommitted = false
 
 import { RenameView } from "./RenameView"
 
-export const isRenameActive = () => _isRenameActive
+export const isRenameActive = () => {
+    return _isRenameActive
+}
 
 export const startRename = async () => {
     if (_isRenameActive) {
@@ -39,24 +41,36 @@ export const startRename = async () => {
     UI.Actions.showToolTip(_renameToolTipName, <RenameView onComplete={onRenameClosed} tokenName={activeToken.tokenName} />, {
         position: null,
         openDirection: 2,
+        onDismiss: () => cancelRename(),
     })
 }
 
 export const commitRename = () => {
+    Log.verbose("[RENAME] Committing rename")
     _isRenameCommitted = true
-    UI.Actions.hideToolTip(_renameToolTipName)
+    _isRenameActive = false
+    closeToolTip()
 }
 
 export const cancelRename = () => {
+    Log.verbose("[RENAME] Cancelling")
     _isRenameCommitted = false
-    UI.Actions.hideToolTip(_renameToolTipName)
+    closeToolTip()
 }
 
 export const onRenameClosed = (newValue: string) => {
-    _isRenameActive = false
+    Log.verbose("[RENAME] onRenameClosed")
     if (_isRenameCommitted) {
+        _isRenameCommitted = false
         doRename(newValue)
     }
+    closeToolTip()
+}
+
+const closeToolTip = () => {
+    Log.verbose("[RENAME] closeToolTip")
+    _isRenameActive = false
+    UI.Actions.hideToolTip(_renameToolTipName)
 }
 
 export const doRename = async (newName: string): Promise<void> => {

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -142,7 +142,7 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
             right: this.state.isFullWidth ? "8px" : null,
         } : childStyle
 
-        return <div style={containerStyle}>
+        return <div style={containerStyle} key={this.props.key}>
             <div style={childStyleWithAdjustments}>
                 <div ref={(elem) => this._element = elem}>
                     {this.props.children}

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -27,21 +27,26 @@ export class TextInputView extends React.PureComponent<IToolTipsViewProps, {}> {
 
     public render(): JSX.Element {
 
+        const containerStyle: React.CSSProperties = {
+            padding: "4px",
+            border: "1px solid " + this.props.foregroundColor,
+        }
+
         const inputStyle: React.CSSProperties = {
             outline: "none",
             color: this.props.foregroundColor,
             backgroundColor: this.props.backgroundColor,
-            border: "1px solid " + this.props.foregroundColor,
+            border: "0px",
             transform: "translateY(0px)",
         }
 
         const defaultValue = this.props.defaultValue || ""
 
-        return <input type="text"
+        return <div style={containerStyle}><input type="text"
                     style={inputStyle}
                     placeholder={defaultValue}
                     onFocus={(evt) => evt.currentTarget.select()}
-                    ref={(elem) => this._element = elem} />
+                    ref={(elem) => this._element = elem} /></div>
     }
 
     public componentWillUnmount(): void {

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -18,7 +18,7 @@ export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
 
     public render(): JSX.Element {
 
-        const toolTipElements = this.props.toolTips.map((toolTip) => <ToolTipView {...toolTip} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor} />)
+        const toolTipElements = this.props.toolTips.map((toolTip) => <ToolTipView {...toolTip} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor} key={toolTip.id}/>)
 
         return <div className="tool-tips">
             {toolTipElements}
@@ -32,6 +32,27 @@ export interface IToolTipViewProps extends State.IToolTip {
 }
 
 export class ToolTipView extends React.PureComponent<IToolTipViewProps, {}> {
+
+    private _container: HTMLElement
+    private _unmount: () => void
+
+    constructor(props: IToolTipViewProps) {
+        super(props)
+    }
+
+    public componentDidMount(): void {
+        const func = (evt: MouseEvent) => this._checkIfClickIsOutside(evt)
+        document.addEventListener("mousedown", func)
+
+        this._unmount = () => document.removeEventListener("mousedown", func)
+    }
+
+    public componentWillUnmount(): void {
+        if (this._unmount) {
+            this._unmount()
+            this._unmount = null
+        }
+    }
 
     public render(): JSX.Element {
 
@@ -50,10 +71,23 @@ export class ToolTipView extends React.PureComponent<IToolTipViewProps, {}> {
         }
 
         return <CursorPositioner position={position} openDirection={openDirection} key={this.props.id}>
-            <div className="tool-tip-container" style={toolTipStyle}>
+            <div className="tool-tip-container enable-mouse" style={toolTipStyle} ref={(elem) => this._setContainer(elem)}>
                 {this.props.element}
             </div>
         </CursorPositioner>
+    }
+
+    private _setContainer(element: HTMLElement): void {
+        this._container = element
+    }
+
+    private _checkIfClickIsOutside(evt: MouseEvent): void {
+
+        if (this._container && !this._container.contains(evt.target as any)) {
+            if (this.props.options.onDismiss) {
+                this.props.options.onDismiss()
+            }
+        }
     }
 }
 

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -237,6 +237,7 @@ declare namespace Oni {
             position?: Coordinates.PixelSpacePoint
             openDirection: OpenDirection
             padding?: string
+            onDismiss?: () => void
         }
     }
 


### PR DESCRIPTION
- Fix bug with dismissal for `rename.cancel` gesture
- Set up tooltip to be dismissed when clicking away from the UI
- Don't re-render tooltip repeatedly (use the `key` value to help React understand the persistence)