### PR TITLE
LSP: Hover fixes / improvements

### DIFF
--- a/browser/src/Services/Language/LanguageClientTypes.ts
+++ b/browser/src/Services/Language/LanguageClientTypes.ts
@@ -1,5 +1,5 @@
 
-// import * as types from "vscode-languageserver-types"
+import * as types from "vscode-languageserver-types"
 
 import { IServerCapabilities } from "./ServerCapabilities"
 
@@ -8,6 +8,11 @@ export type NotificationFunctionWithPromise = (capabilities: IServerCapabilities
 export type NotificationValueOrThunk = NotificationFunction | NotificationFunctionWithPromise | any
 
 export type RequestHandler = (payload: any) => Promise<any>
+
+export interface IResultWithPosition<T> {
+    result: T
+    position: types.Position
+}
 
 export const unwrapThunkOrValue = (val: NotificationValueOrThunk, args: any): Promise<any> => {
     if (typeof val !== "function") {

--- a/browser/src/Services/Language/QuickInfo.ts
+++ b/browser/src/Services/Language/QuickInfo.ts
@@ -13,7 +13,9 @@ import { editorManager } from "./../EditorManager"
 
 import { languageManager } from "./LanguageManager"
 
-export const getQuickInfo = async (): Promise<types.Hover> => {
+import { IResultWithPosition } from "./LanguageClientTypes"
+
+export const getQuickInfo = async (): Promise<IResultWithPosition<types.Hover>> => {
     const buffer = editorManager.activeEditor.activeBuffer
     const { language, filePath } = buffer
     const { line, column } = buffer.cursor
@@ -34,9 +36,13 @@ export const getQuickInfo = async (): Promise<types.Hover> => {
                 },
         }
 
-        let result: types.Hover = null
+        let result: IResultWithPosition<types.Hover> = null
         try {
-            result = await languageManager.sendLanguageServerRequest(language, filePath, "textDocument/hover", args)
+            const hoverResult = await languageManager.sendLanguageServerRequest(language, filePath, "textDocument/hover", args)
+            result = {
+                position: types.Position.create(line, column),
+                result: hoverResult,
+            }
         } catch (ex) { Log.debug(ex) }
 
         return result

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -115,9 +115,13 @@ export const isInRange = (line: number, column: number, range: types.Range): boo
         && line <= range.end.line && column <= range.end.character)
 }
 
-export const ignoreWhilePendingPromise = <T, U>(observable$: Observable<T>, promiseFunction: (input: T) => Promise<U>): Observable<U> {
-
+/**
+ * Helper function to ignore incoming values while a promise is waiting to complete
+ * This is lossy, in that any input that comes in will be dropped while the promise
+ * is in-progress.
+ */
+export function ignoreWhilePendingPromise<T, U>(observable$: Observable<T>, promiseFunction: (input: T) => Promise<U>): Observable<U> {
     return observable$
-            .flatMap(
-
+            // .flatMap((input) => promiseFunction(input))
+            .flatMap((input) => Observable.defer(() => promiseFunction(input)))
 }

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -12,6 +12,8 @@ import * as find from "lodash/find"
 import * as isEqual from "lodash/isEqual"
 import * as reduce from "lodash/reduce"
 
+import { Observable } from "rxjs/Observable"
+
 import * as types from "vscode-languageserver-types"
 
 /**
@@ -111,4 +113,11 @@ export const getRootProjectFileFunc = (patternsToMatch: string[]) => {
 export const isInRange = (line: number, column: number, range: types.Range): boolean => {
     return (line >= range.start.line && column >= range.start.character
         && line <= range.end.line && column <= range.end.character)
+}
+
+export const ignoreWhilePendingPromise = <T, U>(observable$: Observable<T>, promiseFunction: (input: T) => Promise<U>): Observable<U> {
+
+    return observable$
+            .flatMap(
+
 }

--- a/browser/test/UtilityTests.ts
+++ b/browser/test/UtilityTests.ts
@@ -4,11 +4,11 @@ import * as rxjs from "rxjs"
 
 import * as Utility from "./../src/Utility"
 
-type PromiseInfo = { resolve: Function, reject: Function } 
-type PromiseCreationResult = { info: PromiseInfo[], inputs: any[], promiseCreator: (input: any) => Promise<any> }
+interface PromiseInfo { resolve: (val: any) => void, reject: (err: Error) => void }
+interface PromiseCreationResult { info: PromiseInfo[], inputs: any[], promiseCreator: (input: any) => Promise<any> }
 const createPromiseFunction = (): PromiseCreationResult => {
-    let info: any[] = []
-    let inputs: any[] = []
+    const info: any[] = []
+    const inputs: any[] = []
 
     const promiseCreator = (input: any) => {
         inputs.push(input)
@@ -26,8 +26,7 @@ const createPromiseFunction = (): PromiseCreationResult => {
 }
 
 describe("Utility", () => {
-
-    describe.only("ignoreWhilePendingPromise", () => {
+    describe("ignoreWhilePendingPromise", () => {
 
             let subject: rxjs.Subject<any>
 
@@ -40,7 +39,7 @@ describe("Utility", () => {
 
                 const outputObservable$ = Utility.ignoreWhilePendingPromise(subject, promiseFunction.promiseCreator)
 
-                let outputs: any[] = []
+                const outputs: any[] = []
                 outputObservable$.subscribe((val) => { outputs.push(val) })
 
                 // Resolve the promise that gets fired as a result of subject triggered
@@ -51,7 +50,7 @@ describe("Utility", () => {
                     .then(() => {
                         assert.deepEqual(promiseFunction.inputs, [5])
                         assert.deepEqual(outputs, ["a"])
-                    }, (err) => console.log("ERROR"))
+                    })
             })
 
             it("Does not dispatch promise function while previous is still pending", () => {
@@ -59,7 +58,7 @@ describe("Utility", () => {
 
                 const outputObservable$ = Utility.ignoreWhilePendingPromise(subject, promiseFunction.promiseCreator)
 
-                let outputs: any[] = []
+                const outputs: any[] = []
                 outputObservable$.subscribe((val) => { outputs.push(val) })
 
                 // Bring in multiple inputs
@@ -68,7 +67,6 @@ describe("Utility", () => {
                 subject.next(7)
                 subject.next(8)
                 promiseFunction.info[0].resolve("a")
-
 
                 return outputObservable$.take(1).toPromise()
                     .then(() => {

--- a/browser/test/UtilityTests.ts
+++ b/browser/test/UtilityTests.ts
@@ -1,0 +1,88 @@
+import * as assert from "assert"
+
+import * as rxjs from "rxjs"
+
+import * as Utility from "./../src/Utility"
+
+type PromiseInfo = { resolve: Function, reject: Function } 
+type PromiseCreationResult = { info: PromiseInfo[], inputs: any[], promiseCreator: (input: any) => Promise<any> }
+const createPromiseFunction = (): PromiseCreationResult => {
+    let info: any[] = []
+    let inputs: any[] = []
+
+    const promiseCreator = (input: any) => {
+        inputs.push(input)
+
+        console.log("called")
+
+        return new Promise((resolve, reject) => {
+            info.push({ resolve, reject })
+        })
+    }
+
+    return {
+        info,
+        inputs,
+        promiseCreator,
+    }
+}
+
+describe("Utility", () => {
+
+    describe("ignoreWhilePendingPromise", () => {
+
+            let subject: rxjs.Subject<any>
+
+            beforeEach(() => {
+                subject = new rxjs.Subject()
+            })
+
+            it.only("Executes promise function in response to observable input", () => {
+                const promiseFunction = createPromiseFunction()
+
+                const outputObservable$ = Utility.ignoreWhilePendingPromise(subject, promiseFunction.promiseCreator)
+
+                let outputs: any[] = []
+                outputObservable$.subscribe((val) => { outputs.push(val) })
+
+                // Resolve the promise that gets fired as a result of subject triggered
+                subject.next(5)
+                promiseFunction.info[0].resolve("a")
+
+                subject.complete()
+
+                return outputObservable$.delay(1).toPromise()
+                    .then(() => {
+                        assert.strictEqual(promiseFunction.inputs.length, 1)
+                        assert.deepEqual(outputs, ["a"])
+                    })
+            })
+
+            it.only("Does not dispatch promise function while previous is still pending", () => {
+                const promiseFunction = createPromiseFunction()
+
+                const outputObservable$ = Utility.ignoreWhilePendingPromise(subject, promiseFunction.promiseCreator)
+
+                let outputs: any[] = []
+                outputObservable$.subscribe((val) => { outputs.push(val) })
+
+                // Bring in multiple inputs
+                subject.next(5)
+                subject.next(6)
+                subject.next(7)
+                promiseFunction.info[0].resolve("a")
+
+                subject.complete()
+
+                return outputObservable$.delay(1).toPromise()
+                    .then(() => {
+                        // Only 5 should've been dispatched to the function,
+                        // because the observable should've been held
+                        // while the first promise was in flight.
+                        assert.deepEqual(promiseFunction.inputs, [5])
+                        assert.deepEqual(outputs, ["a"])
+                    })
+            })
+
+    })
+})


### PR DESCRIPTION
__Issue:__ There is a lot of flickering and distraction with the current hover UX.

__Defect:__ We are sometimes showing outdated hover info - for example, if we requested hover info at position `(x0,y0)`, but now the position is `(x1, y1)`, we'd still show the outdated hover. In addition, we'd continue making requests while a current request is pending, which would cause the hover UX to accumulate and then pop up quickly in multiple spots.

__Fix:__
- Throttle the hover request, such that we only have a single request queued up
- Don't show the hover response if it is out of date