### PR TITLE
Fix measurement issue with CursorPositioner

### DIFF
--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -84,6 +84,16 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
 
             this._resizeObserver = new window["ResizeObserver"]((entries: any) => { // tslint:disable-line
 
+                if (!entries || !entries.length) {
+                    return
+                }
+
+                const rect: ClientRect = entries[0].contentRect
+
+                if (rect.width <= this.state.lastMeasuredWidth && rect.height <= this.state.lastMeasuredHeight) {
+                    return
+                }
+
                 if (this._timeout) {
                     window.clearTimeout(this._timeout)
                 }

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -12,6 +12,8 @@ import * as find from "lodash/find"
 import * as isEqual from "lodash/isEqual"
 import * as reduce from "lodash/reduce"
 
+import { Observable } from "rxjs/Observable"
+
 import * as types from "vscode-languageserver-types"
 
 /**
@@ -111,4 +113,11 @@ export const getRootProjectFileFunc = (patternsToMatch: string[]) => {
 export const isInRange = (line: number, column: number, range: types.Range): boolean => {
     return (line >= range.start.line && column >= range.start.character
         && line <= range.end.line && column <= range.end.character)
+}
+
+export const ignoreWhilePendingPromise = <T, U>(observable$: Observable<T>, promiseFunction: (input: T) => Promise<U>): Observable<U> {
+
+    return observable$
+            .flatMap(
+
 }

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -12,8 +12,6 @@ import * as find from "lodash/find"
 import * as isEqual from "lodash/isEqual"
 import * as reduce from "lodash/reduce"
 
-import { Observable } from "rxjs/Observable"
-
 import * as types from "vscode-languageserver-types"
 
 /**
@@ -113,11 +111,4 @@ export const getRootProjectFileFunc = (patternsToMatch: string[]) => {
 export const isInRange = (line: number, column: number, range: types.Range): boolean => {
     return (line >= range.start.line && column >= range.start.character
         && line <= range.end.line && column <= range.end.character)
-}
-
-export const ignoreWhilePendingPromise = <T, U>(observable$: Observable<T>, promiseFunction: (input: T) => Promise<U>): Observable<U> {
-
-    return observable$
-            .flatMap(
-
 }


### PR DESCRIPTION
__Issue:__ In some cases, the `CursorPositioner` component gets caught in a loop - it will measure and re-position an item, and then think it needs to measure again, and update the position. This creates a 'dancing' effect and is very distracting.

__Fix:__ Implement a check when measuring bounds for the height and width, to prevent us from calling measure again.