### PR TITLE
Fix #860 - Add about entry and stub out auto-update

### DIFF
--- a/browser/src/Services/AutoUpdate.ts
+++ b/browser/src/Services/AutoUpdate.ts
@@ -39,11 +39,11 @@ export class AutoUpdater implements IAutoUpdater {
     public get onUpdateNotAvailable(): Observable<void> {
         return this._onUpdateNotAvailable
     }
-    public get onUpdateAvailable() : Observable<void> {
+    public get onUpdateAvailable(): Observable<void> {
         return this._onUpdateAvailable
     }
 
-    checkForUpdates(url: string): void {
+    public checkForUpdates(url: string): void {
         if (!configuration.getValue("autoUpdate.enabled")) {
             return
         }

--- a/browser/src/Services/AutoUpdate.ts
+++ b/browser/src/Services/AutoUpdate.ts
@@ -1,0 +1,63 @@
+/**
+ * AutoUpdate.ts
+ *
+ * Provides auto-update functionality
+ * - Check for update
+ * - Notifies when an update is available
+ */
+
+import * as os from "os"
+
+import { Observable } from "rxjs/Observable"
+import { Subject } from "rxjs/Subject"
+
+import { getMetadata } from "./Metadata"
+
+import { configuration } from "./Configuration"
+
+export interface IAutoUpdater {
+    onUpdateNotAvailable: Observable<void>
+    onUpdateAvailable: Observable<void>
+    checkForUpdates(url: string): void
+}
+
+export const constructFeedUrl = async (baseUrl: string) => {
+
+    const plat = os.platform()
+    const { version }  = await getMetadata()
+
+    const isDevelopment = process.env["NODE_ENV"] === "development" // tslint:disable-line no-string-literal
+    const channel = isDevelopment ? "development" : "release"
+
+    return baseUrl + `?platform=${plat}&version=${version}&channel=${channel}`
+}
+
+export class AutoUpdater implements IAutoUpdater {
+    private _onUpdateAvailable: Subject<void> = new Subject()
+    private _onUpdateNotAvailable: Subject<void> = new Subject()
+
+    public get onUpdateNotAvailable(): Observable<void> {
+        return this._onUpdateNotAvailable
+    }
+    public get onUpdateAvailable() : Observable<void> {
+        return this._onUpdateAvailable
+    }
+
+    checkForUpdates(url: string): void {
+        if (!configuration.getValue("autoUpdate.enabled")) {
+            return
+        }
+
+        fetch(url)
+            .then((response) => {
+
+                if (response.status === 204) {
+                    this._onUpdateNotAvailable.next()
+                } else {
+                    this._onUpdateAvailable.next()
+                }
+            })
+    }
+}
+
+export const autoUpdater = new AutoUpdater()

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -18,6 +18,7 @@ import { contextMenuManager } from "./../Services/ContextMenu"
 import { editorManager } from "./../Services/EditorManager"
 import { /*commitCompletion,*/ cancelRename, commitRename, expandCodeActions, findAllReferences, formatDocument, gotoDefinitionUnderCursor, isRenameActive, openDocumentSymbolsMenu, openWorkspaceSymbolsMenu, startRename } from "./../Services/Language"
 import { menuManager } from "./../Services/Menu"
+import { showAboutMessage } from "./../Services/Metadata"
 import { multiProcess } from "./../Services/MultiProcess"
 import { QuickOpen } from "./../Services/QuickOpen"
 import { tasks } from "./../Services/Tasks"
@@ -36,6 +37,8 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
     const commands = [
         new CallbackCommand("editor.clipboard.paste", "Clipboard: Paste", "Paste clipboard contents into active text", () => pasteContents(neovimInstance)),
         new CallbackCommand("editor.clipboard.yank", "Clipboard: Yank", "Yank contents to clipboard", () => neovimInstance.input("y")),
+
+        new CallbackCommand("oni.about", null, null, () => showAboutMessage()),
 
         new CallbackCommand("oni.quit", null, null, () => remote.app.quit()),
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -17,6 +17,8 @@ const BaseConfiguration: IConfigurationValues = {
     activate: noop,
     deactivate: noop,
 
+    "autoUpdate.enabled": true,
+
     "debug.fixedSize": null,
     "debug.neovimPath": null,
     "debug.persistOnNeovimExit": false,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -34,6 +34,8 @@ export interface IConfigurationValues {
     // See `:help bell` for instances where the bell sound would be used
     "oni.audio.bellUrl": string
 
+    "autoUpdate.enabled": boolean
+
     // Set this to `true` to enable additional syntax highlighting
     // from Oni & language integrations
     "oni.enhancedSyntaxHighlighting": boolean

--- a/browser/src/Services/Metadata.ts
+++ b/browser/src/Services/Metadata.ts
@@ -4,8 +4,9 @@
  * Provides information about Oni's pkg
  */
 
-import * as path from "path"
 import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 
 export interface IMetadata {
     name: string
@@ -37,5 +38,14 @@ export const getMetadata = async (): Promise<IMetadata> => {
 
 export const showAboutMessage = async () => {
     const metadata = await getMetadata()
-    alert(`${metadata.name} ${metadata.version}`)
+
+    const infoLines = [
+    `${metadata.name} version ${metadata.version}`,
+    "https://www.onivim.io",
+    "",
+    "Copyright 2017 Bryan Phelps",
+    "MIT License",
+    ]
+
+    alert(infoLines.join(os.EOL))
 }

--- a/browser/src/Services/Metadata.ts
+++ b/browser/src/Services/Metadata.ts
@@ -1,0 +1,34 @@
+/**
+ * Metadata.ts
+ *
+ * Provides information about Oni's pkg
+ */
+
+import * as path from "path"
+import * as fs from "fs"
+
+export interface IMetadata {
+    version: string
+}
+
+export const getMetadata = async (): Promise<IMetadata> => {
+    const packageMetadata = path.join(__dirname, "pkg.json")
+
+    return new Promise<IMetadata>((resolve, reject) => {
+        fs.readFile(packageMetadata, "utf8", (err: NodeJS.ErrnoException, data: string) => {
+
+            if (err) {
+                reject(err)
+                return
+            }
+
+            const pkg = JSON.parse(data)
+
+            const metadata = {
+                version: pkg.version,
+            }
+
+            resolve(metadata)
+        })
+    })
+}

--- a/browser/src/Services/Metadata.ts
+++ b/browser/src/Services/Metadata.ts
@@ -8,6 +8,7 @@ import * as path from "path"
 import * as fs from "fs"
 
 export interface IMetadata {
+    name: string
     version: string
 }
 
@@ -25,10 +26,16 @@ export const getMetadata = async (): Promise<IMetadata> => {
             const pkg = JSON.parse(data)
 
             const metadata = {
+                name: pkg.name,
                 version: pkg.version,
             }
 
             resolve(metadata)
         })
     })
+}
+
+export const showAboutMessage = async () => {
+    const metadata = await getMetadata()
+    alert(`${metadata.name} ${metadata.version}`)
 }

--- a/browser/src/Services/Metadata.ts
+++ b/browser/src/Services/Metadata.ts
@@ -13,7 +13,7 @@ export interface IMetadata {
 }
 
 export const getMetadata = async (): Promise<IMetadata> => {
-    const packageMetadata = path.join(__dirname, "pkg.json")
+    const packageMetadata = path.join(__dirname, "package.json")
 
     return new Promise<IMetadata>((resolve, reject) => {
         fs.readFile(packageMetadata, "utf8", (err: NodeJS.ErrnoException, data: string) => {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -11,6 +11,7 @@ import * as minimist from "minimist"
 import * as Log from "./Log"
 import { PluginManager } from "./Plugins/PluginManager"
 
+import { autoUpdater, constructFeedUrl } from "./Services/AutoUpdate"
 import { commandManager } from "./Services/CommandManager"
 import { configuration, IConfigurationValues } from "./Services/Configuration"
 
@@ -79,9 +80,16 @@ const start = (args: string[]) => {
     if (configuration.getValue("experimental.enableLanguageServerFromConfig")) {
         createLanguageClientsFromConfiguration(configuration.getValues())
     }
+
+    checkForUpdates()
 }
 
 ipcRenderer.on("init", (_evt: any, message: any) => {
     process.chdir(message.workingDirectory)
     start(message.args)
 })
+
+const checkForUpdates = async () => {
+    const feedUrl = await constructFeedUrl("https://api.onivim.io/v0/updates")
+    autoUpdater.checkForUpdates(feedUrl)
+}

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -90,6 +90,6 @@ ipcRenderer.on("init", (_evt: any, message: any) => {
 })
 
 const checkForUpdates = async () => {
-    const feedUrl = await constructFeedUrl("https://api.onivim.io/v0/updates")
+    const feedUrl = await constructFeedUrl("https://api.onivim.io/v1/update")
     autoUpdater.checkForUpdates(feedUrl)
 }

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -91,5 +91,9 @@ ipcRenderer.on("init", (_evt: any, message: any) => {
 
 const checkForUpdates = async () => {
     const feedUrl = await constructFeedUrl("https://api.onivim.io/v1/update")
+
+    autoUpdater.onUpdateAvailable.subscribe(() => Log.info("Update available."))
+    autoUpdater.onUpdateNotAvailable.subscribe(() => Log.info("Update not available."))
+
     autoUpdater.checkForUpdates(feedUrl)
 }

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -609,20 +609,36 @@ export const buildMenu = (mainWindow, loadInit) => {
             {
                 label: "Learn more",
                 click(item, focusedWindow) {
-                    shell.openExternal("https://github.com/extr0py/oni#introduction")
+                    shell.openExternal("https://github.com/onivim/oni#introduction")
                 },
             },
             {
                 label: "Issues",
                 click(item, focusedWindow) {
-                    shell.openExternal("https://github.com/extr0py/oni/issues")
+                    shell.openExternal("https://github.com/onivim/oni/issues")
                 },
             },
             {
                 label: "Github",
-                sublabel: "https://github.com/extr0py/oni",
+                sublabel: "https://github.com/onivim/oni",
                 click(item, focusedWindow) {
-                    shell.openExternal("https://github.com/extr0py/oni")
+                    shell.openExternal("https://github.com/onivim/oni")
+                },
+            },
+            {
+                label: "Website",
+                sublabel: "https://www.onivim.io",
+                click(item, focusedWindow) {
+                    shell.openExternal("https://www.onivim.io")
+                },
+            },
+            {
+                type: "separator",
+            },
+            {
+                label: "About Oni",
+                click(item, focusedWindow) {
+                    executeOniCommand("oni.about")
                 },
             },
             {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oni",
   "author": "",
   "email": "bryphe@outlook.com",
-  "homepage": "https://onivim.io",
+  "homepage": "https://www.onivim.io",
   "version": "0.2.15",
   "description": "NeoVim front-end with IDE-style extensibility",
   "keywords": [


### PR DESCRIPTION
__Issue:__ It's difficult to tell what version of Oni is being used, especially when hopping between multiple machines.

__Fix:__ Add a `Help -> About Oni` entry.

This also stubs out an auto-update API that I'm working on - right now, it is a no-op, but once I get the endpoint working, it'll prompt to update (and later just download and apply the update automatically). This can be disabled via the `autoUpdate.enabled` setting.