### PR TITLE
[NEXT] Add UI font for shell UI

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -106,6 +106,9 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.height": "2.5em",
     "tabs.maxWidth": "30em",
     "tabs.wrap": false,
+
+    "ui.fontFamily": "BlinkMacSystemFont, 'Lucide Grande', 'Segoe UI', Ubuntu, Cantarell, sans-seriff",
+    "ui.fontSize": "13px",
 }
 
 const MacConfigOverrides: Partial<IConfigurationValues> = {

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -156,6 +156,9 @@ export interface IConfigurationValues {
     // If `true`, will wrap the tabs.
     "tabs.wrap": boolean
 
+    "ui.fontFamily": string
+    "ui.fontSize": string
+
     // Handle other, non-predefined configuration keys
     [configurationKey: string]: any
 }

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -14,6 +14,7 @@ export interface StatusBarProps {
     items: StatusBarItemProps[]
     enabled: boolean
     fontSize: string
+    fontFamily: string
 }
 
 export interface StatusBarItemProps {
@@ -40,6 +41,7 @@ export class StatusBar extends React.PureComponent<StatusBarProps, {}> {
             .sort((a, b) => b.priority - a.priority)
 
         const statusBarStyle = {
+            "fontFamily": this.props.fontFamily,
             "fontSize": this.props.fontSize,
         }
 
@@ -94,7 +96,8 @@ const mapStateToProps = (state: IState): StatusBarProps => {
     const statusBarItems = getStatusBarItems(state)
 
     return {
-        fontSize: state.configuration["statusbar.fontSize"],
+        fontFamily: state.configuration["ui.fontFamily"],
+        fontSize: state.configuration["statusbar.fontSize"] || state.configuration["ui.fontSize"],
         items: statusBarItems,
         enabled: state.configuration["statusbar.enabled"],
     }

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -45,6 +45,9 @@ export interface ITabsProps {
     shouldWrap: boolean
     maxWidth: string
     height: string
+
+    fontFamily: string
+    fontSize: string
 }
 
 export class Tabs extends React.PureComponent<ITabsProps, {}> {
@@ -66,6 +69,8 @@ export class Tabs extends React.PureComponent<ITabsProps, {}> {
         const tabBorderStyle: React.CSSProperties = {
             ...overflowStyle,
             "borderBottom": `4px solid ${this.props.backgroundColor}`,
+            fontFamily: this.props.fontFamily,
+            fontSize: this.props.fontSize,
         }
 
         const tabs = this.props.tabs.map((t) => {
@@ -191,6 +196,8 @@ const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITa
     const closeFunc = shouldUseVimTabs ? ownProps.onTabClose : ownProps.onBufferClose
 
     return {
+        fontFamily: state.configuration["ui.fontFamily"],
+        fontSize: state.configuration["ui.fontSize"],
         backgroundColor: state.backgroundColor,
         foregroundColor: state.foregroundColor,
         onSelect: selectFunc,

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -45,8 +45,8 @@ const start = (args: string[]) => {
             UI.Actions.setConfigValue(prop, newConfigValues[prop])
         }
 
-        document.body.style.fontFamily = configuration.getValue("editor.fontFamily")
-        document.body.style.fontSize = configuration.getValue("editor.fontSize")
+        document.body.style.fontFamily = configuration.getValue("ui.fontFamily")
+        document.body.style.fontSize = configuration.getValue("ui.fontSize")
         document.body.style.fontVariant = configuration.getValue("editor.fontLigatures") ? "normal" : "none"
 
         const hideMenu: boolean = configuration.getValue("oni.hideMenu")


### PR DESCRIPTION
__Issue:__ Many of the newer text editors use separate fonts for their _shell_ interface vs the _edit_ experience. This helps improve the look and feel of the editor vs a single-font terminal UX.

__Fix:__ Enable specifying a separate font for shell items+