### PR TITLE
Fix exception when failing to resolve completion items

### DIFF
--- a/browser/src/Services/Language/Completion/Completion.ts
+++ b/browser/src/Services/Language/Completion/Completion.ts
@@ -208,6 +208,10 @@ export const resolveCompletionItem = async (language: string, filePath: string, 
     try {
         result = await languageManager.sendLanguageServerRequest(language, filePath, "completionItem/resolve", completionItem)
     } catch (ex) {
+        Log.verbose(ex)
+    }
+
+    if (!result) {
         return null
     }
 

--- a/browser/src/Services/Language/Completion/CompletionMenu.ts
+++ b/browser/src/Services/Language/Completion/CompletionMenu.ts
@@ -93,7 +93,10 @@ export const createCompletionMenu = (completionMeet$: Observable<ICompletionMeet
 
 export const updateCompletionItemDetails = async (menu: any, language: string, filePath: string, completionItem: types.CompletionItem)  => {
     const result = await resolveCompletionItem(language, filePath, completionItem)
-    menu.updateItem(result)
+
+    if (result) {
+        menu.updateItem(result)
+    }
 }
 
 export const commitCompletion = async (line: number, base: number, completion: string) => {


### PR DESCRIPTION
__Issue:__ If the completion item fails to resolve, and returns `null`, we hit an exception when trying to access its members while converting it to the menu item.

__Fix:__ Add a null check, and add logging when resolution fails