### PR TITLE
Several LSP fixes to generalize and support more language servers

### DIFF
--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -73,6 +73,15 @@ export const pathToTextDocumentIdentifierParms = (path: string) => ({
     },
 })
 
+export const pathToTextDocumentItemParams = (path: string, language: string, text: string, version: number) => ({
+    textDocument: {
+        uri: wrapPathInFileUri(path),
+        languageId: language,
+        text,
+        version,
+    },
+})
+
 export const eventContextToCodeActionParams = (filePath: string, range: types.Range) => {
     const emptyDiagnostics: types.Diagnostic[] = []
     return {

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -147,7 +147,36 @@ export class LanguageClientProcess {
             clientName: "oni",
             rootPath,
             rootUri: Helpers.wrapPathInFileUri(rootPath),
-            capabilities: {},
+            capabilities: {
+                workspace: {
+                    applyEdit: true,
+                    configuration: true,
+                    workspaceEdit: {
+                        documentChanges: false,
+                    },
+                    didChangeConfiguration: true,
+                    didChangeWatchedFiles: false,
+                    symbol: true,
+                    executeCommand: true,
+                },
+                textDocument: {
+                    synchronization: true,
+                    completion: true,
+                    hover: true,
+                    signatureHelp: true,
+                    references: true,
+                    documentHighlight: false,
+                    documentSymbol: true,
+                    formatting: true,
+                    rangeFormatting: true,
+                    onTypeFormatting: false,
+                    definition: true,
+                    codeAction: true,
+                    codeLens: true,
+                    documentLink: false,
+                    rename: true,
+                },
+            },
         }
 
         try {

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -52,9 +52,12 @@ export class LanguageManager {
                 this._statusBar.hide()
             }
 
-            return this.sendLanguageServerNotification(language, filePath, "textDocument/didOpen", () => {
+            return this.sendLanguageServerNotification(language, filePath, "textDocument/didOpen", async () => {
+                const lines = await editorManager.activeEditor.activeBuffer.getLines()
+                const text = lines.join(os.EOL)
+                const version = editorManager.activeEditor.activeBuffer.version
                 this._statusBar.setStatus(LanguageClientState.Active)
-                return Helpers.pathToTextDocumentIdentifierParms(filePath)
+                return Helpers.pathToTextDocumentItemParams(filePath, language, text, version)
             })
         })
 
@@ -108,6 +111,11 @@ export class LanguageManager {
 
         this.subscribeToLanguageServerNotification("telemetry/event", (args) => {
             logDebug(args)
+        })
+
+        this.handleLanguageServerRequest("workspace/configuration", async (req) => {
+            Log.warn("workspace/configuration not implemented: " + JSON.stringify(req.toString()))
+            return null
         })
 
         this.handleLanguageServerRequest("window/showMessageRequest", async (req) => {

--- a/package.json
+++ b/package.json
@@ -117,9 +117,9 @@
     "msgpack-lite": "0.1.26",
     "ocaml-language-server": "1.0.1",
     "typescript": "2.5.3",
-    "vscode-jsonrpc": "3.4.1",
-    "vscode-languageserver": "3.4.3",
-    "vscode-languageserver-types": "3.4.0",
+    "vscode-jsonrpc": "3.5.0",
+    "vscode-languageserver": "3.5.0",
+    "vscode-languageserver-types": "3.5.0",
     "vscode-ripgrep": "0.6.0-patch.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Implement `textDocument/didOpen` correctly by sending the latest version + textd
- Send the list of client capabilities
- Add stub for `workspace/configuration`