### PR TITLE
[NEXT] Streamline and break up some unnecessary dependency chains

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -142,7 +142,7 @@ export class NeovimEditor implements IEditor {
         const errorService = new Errors(this._neovimInstance)
         const windowTitle = new WindowTitle(this._neovimInstance)
 
-        registerBuiltInCommands(commandManager, this._pluginManager, this._neovimInstance)
+        registerBuiltInCommands(commandManager, this._neovimInstance)
 
         tasks.registerTaskProvider(commandManager)
         tasks.registerTaskProvider(errorService)

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -22,7 +22,7 @@ import { NeovimScreen } from "./../Screen"
 
 import { Event, IEvent } from "./../Event"
 
-import { PluginManager } from "./../Plugins/PluginManager"
+import { pluginManager } from "./../Plugins/PluginManager"
 
 import { commandManager } from "./../Services/CommandManager"
 import { registerBuiltInCommands } from "./../Services/Commands"
@@ -120,12 +120,11 @@ export class NeovimEditor implements IEditor {
     }
 
     constructor(
-        private _pluginManager: PluginManager,
         private _config = configuration,
     ) {
         const services: any[] = []
 
-        this._neovimInstance = new NeovimInstance(this._pluginManager, 100, 100)
+        this._neovimInstance = new NeovimInstance(100, 100)
         this._bufferManager = new BufferManager(this._neovimInstance)
         this._deltaRegionManager = new IncrementalDeltaRegionTracker()
         this._screen = new NeovimScreen(this._deltaRegionManager)
@@ -288,7 +287,7 @@ export class NeovimEditor implements IEditor {
     }
 
     public init(filesToOpen: string[]): void {
-        this._neovimInstance.start(filesToOpen)
+        this._neovimInstance.start(filesToOpen, { runtimePaths: pluginManager.getAllRuntimePaths() })
             .then(() => {
                 this._hasLoaded = true
                 VimConfigurationSynchronizer.synchronizeConfiguration(this._neovimInstance, this._config.getValues())
@@ -319,7 +318,6 @@ export class NeovimEditor implements IEditor {
 
         return <NeovimSurface renderer={this._renderer}
             neovimInstance={this._neovimInstance}
-            deltaRegionTracker={this._deltaRegionManager}
             screen={this._screen}
             onKeyDown={onKeyDown}
             onBufferClose={onBufferClose}

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -236,9 +236,6 @@ export class NeovimEditor implements IEditor {
         this._onConfigChanged(this._config.getValues())
         this._config.onConfigurationChanged.subscribe((newValues: Partial<IConfigurationValues>) => this._onConfigChanged(newValues))
 
-        window["__neovim"] = this._neovimInstance // tslint:disable-line no-string-literal
-        window["__screen"] = this._screen // tslint:disable-line no-string-literal
-
         ipcRenderer.on("menu-item-click", (_evt: any, message: string) => {
             if (message.startsWith(":")) {
                 this._neovimInstance.command("exec \"" + message + "\"")

--- a/browser/src/Editor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimSurface.tsx
@@ -6,7 +6,6 @@
 
 import * as React from "react"
 
-import { IncrementalDeltaRegionTracker } from "./../DeltaRegionTracker"
 import { NeovimInstance } from "./../neovim"
 import { INeovimRenderer } from "./../Renderer"
 import { NeovimScreen } from "./../Screen"
@@ -26,7 +25,6 @@ import { NeovimRenderer } from "./NeovimRenderer"
 
 export interface INeovimSurfaceProps {
     neovimInstance: NeovimInstance
-    deltaRegionTracker: IncrementalDeltaRegionTracker
     renderer: INeovimRenderer
     screen: NeovimScreen
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from "events"
 import * as fs from "fs"
 import * as path from "path"
-import { INeovimInstance } from "./../neovim"
 import { configuration } from "./../Services/Configuration"
 
 import { AnonymousPlugin } from "./AnonymousPlugin"
@@ -14,7 +13,6 @@ export class PluginManager extends EventEmitter {
     private _config = configuration
     private _rootPluginPaths: string[] = []
     private _plugins: Plugin[] = []
-    private _neovimInstance: INeovimInstance
     private _anonymousPlugin: AnonymousPlugin
 
     constructor() {
@@ -30,9 +28,7 @@ export class PluginManager extends EventEmitter {
         this._rootPluginPaths.push(path.join(this._config.getUserFolder(), "plugins"))
     }
 
-    public startPlugins(neovimInstance: INeovimInstance): Oni.Plugin.Api {
-        this._neovimInstance = neovimInstance
-
+    public startPlugins(): Oni.Plugin.Api {
         const allPlugins = this._getAllPluginPaths()
         this._plugins = allPlugins.map((pluginRootDirectory) => this._createPlugin(pluginRootDirectory))
 
@@ -61,6 +57,8 @@ export class PluginManager extends EventEmitter {
         return paths
     }
 }
+
+export const pluginManager = new PluginManager()
 
 function getDirectories(rootPath: string): string[] {
     if (!fs.existsSync(rootPath)) {

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -11,7 +11,6 @@ import * as path from "path"
 import { clipboard, remote } from "electron"
 
 import { INeovimInstance } from "./../neovim"
-import { PluginManager } from "./../Plugins/PluginManager"
 
 import { configuration } from "./../Services/Configuration"
 import { contextMenuManager } from "./../Services/ContextMenu"
@@ -31,7 +30,7 @@ import { CallbackCommand, CommandManager } from "./CommandManager"
 import * as Platform from "./../Platform"
 import { replaceAll } from "./../Utility"
 
-export const registerBuiltInCommands = (commandManager: CommandManager, pluginManager: PluginManager, neovimInstance: INeovimInstance) => {
+export const registerBuiltInCommands = (commandManager: CommandManager, neovimInstance: INeovimInstance) => {
     const quickOpen = new QuickOpen(neovimInstance)
 
     const commands = [

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -75,7 +75,7 @@ updateViewport()
 function render(_state: State.IState, pluginManager: PluginManager, args: any): void {
     const hostElement = document.getElementById("host")
 
-    const editor = new NeovimEditor(pluginManager)
+    const editor = new NeovimEditor()
     editor.init(args)
 
     editorManager.setActiveEditor(editor)

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -9,7 +9,7 @@
 import { ipcRenderer, remote } from "electron"
 import * as minimist from "minimist"
 import * as Log from "./Log"
-import { PluginManager } from "./Plugins/PluginManager"
+import { pluginManager } from "./Plugins/PluginManager"
 
 import { autoUpdater, constructFeedUrl } from "./Services/AutoUpdate"
 import { commandManager } from "./Services/CommandManager"
@@ -29,8 +29,6 @@ const start = (args: string[]) => {
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
     require("./overlay.less")
-
-    const pluginManager = new PluginManager()
 
     const initialConfigParsingError = configuration.getParsingError()
     if (initialConfigParsingError) {
@@ -80,6 +78,12 @@ const start = (args: string[]) => {
     if (configuration.getValue("experimental.enableLanguageServerFromConfig")) {
         createLanguageClientsFromConfiguration(configuration.getValues())
     }
+
+    performance.mark("NeovimInstance.Plugins.Start")
+    const api = pluginManager.startPlugins()
+    performance.mark("NeovimInstance.Plugins.End")
+
+    configuration.activate(api)
 
     checkForUpdates()
 }


### PR DESCRIPTION
- Break dependency between `NeovimInstance` and `PluginManager`, since we will be multiplexing `NeovimInstance`'s but `PluginManager` is a singleton.
- Break dependency between `Commands` and `PluginManager` since the commands no longer use the plugin channel to execute commands