### PR TITLE
Window API: Add `Pane` concept

### DIFF
--- a/browser/src/Services/WindowManager.ts
+++ b/browser/src/Services/WindowManager.ts
@@ -13,16 +13,16 @@ import { Event, IEvent } from "./../Event"
 import { applySplit, closeSplit, createSplitLeaf, createSplitRoot, ISplitInfo, ISplitLeaf, SplitDirection } from "./WindowSplit"
 
 export class WindowManager {
-    private _activeSplit: ISplitLeaf<Oni.Editor>
-    private _splitRoot: ISplitInfo<Oni.Editor>
+    private _activeSplit: ISplitLeaf<Oni.IWindowSplit>
+    private _splitRoot: ISplitInfo<Oni.IWindowSplit>
 
-    private _onSplitChanged = new Event<ISplitInfo<Oni.Editor>>()
+    private _onSplitChanged = new Event<ISplitInfo<Oni.IWindowSplit>>()
 
-    public get onSplitChanged(): IEvent<ISplitInfo<Oni.Editor>> {
+    public get onSplitChanged(): IEvent<ISplitInfo<Oni.IWindowSplit>> {
         return this._onSplitChanged
     }
 
-    public get splitRoot(): ISplitInfo<Oni.Editor> {
+    public get splitRoot(): ISplitInfo<Oni.IWindowSplit> {
         return this._splitRoot
     }
 
@@ -31,8 +31,8 @@ export class WindowManager {
         this._activeSplit = null
     }
 
-    public split(direction: SplitDirection, newEditor: Oni.Editor) {
-        const newLeaf = createSplitLeaf(newEditor)
+    public split(direction: SplitDirection, newSplit: Oni.IWindowSplit) {
+        const newLeaf = createSplitLeaf(newSplit)
         this._splitRoot = applySplit(this._splitRoot, direction, newLeaf)
 
         this._onSplitChanged.dispatch(this._splitRoot)
@@ -54,12 +54,12 @@ export class WindowManager {
         // TODO
     }
 
-    public showDock(direction: SplitDirection, newEditor: Oni.Editor) {
+    public showDock(direction: SplitDirection, split: Oni.IWindowSplit) {
         // TODO
     }
 
-    public close(editor: Oni.Editor) {
-        this._splitRoot = closeSplit(this._splitRoot, editor)
+    public close(split: Oni.IWindowSplit) {
+        this._splitRoot = closeSplit(this._splitRoot, split)
         this._onSplitChanged.dispatch(this._splitRoot)
     }
 }

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -7,8 +7,8 @@ import { MenuContainer } from "./../Services/Menu"
 import * as WindowManager from "./../Services/WindowManager"
 
 import { Background } from "./components/Background"
-import { WindowSplits } from "./components/WindowSplits"
 import StatusBar from "./components/StatusBar"
+import { WindowSplits } from "./components/WindowSplits"
 
 interface IRootComponentProps {
     windowManager: WindowManager.WindowManager

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -7,7 +7,7 @@ import { MenuContainer } from "./../Services/Menu"
 import * as WindowManager from "./../Services/WindowManager"
 
 import { Background } from "./components/Background"
-import { EditorWindows } from "./components/EditorWindows"
+import { WindowSplits } from "./components/WindowSplits"
 import StatusBar from "./components/StatusBar"
 
 interface IRootComponentProps {
@@ -24,7 +24,7 @@ export class RootComponent extends React.PureComponent<IRootComponentProps, {}> 
                 <div className="container vertical full">
                     <div className="container full">
                         <div className="stack">
-                            <EditorWindows windowManager={this.props.windowManager} />
+                            <WindowSplits windowManager={this.props.windowManager} />
                         </div>
                         <div className="stack layer">
                             <MenuContainer />

--- a/browser/src/UI/components/WindowSplitHost.tsx
+++ b/browser/src/UI/components/WindowSplitHost.tsx
@@ -1,5 +1,5 @@
 /**
- * EditorHost.tsx
+ * ISplitHost.tsx
  *
  * React component that hosts an IEditor implementation
  */
@@ -8,16 +8,19 @@ import * as React from "react"
 
 import { IEditor } from "./../../Editor/Editor"
 
-export interface IEditorHostProps {
-    editor: IEditor
+export interface IWindowSplitHostProps {
+    split: Oni.IWindowSplit
 }
 
-export class EditorHost extends React.PureComponent<IEditorHostProps, {}> {
+/**
+ * Component responsible for rendering an individual window split
+ */
+export class WindowSplitHost extends React.PureComponent<IWindowSplitHostProps, {}> {
 
     public render(): JSX.Element {
         return <div className="container vertical full">
                 <div className="editor">
-                    {this.props.editor.render()}
+                    {this.props.split.render()}
                 </div>
         </div>
     }

--- a/browser/src/UI/components/WindowSplitHost.tsx
+++ b/browser/src/UI/components/WindowSplitHost.tsx
@@ -6,8 +6,6 @@
 
 import * as React from "react"
 
-import { IEditor } from "./../../Editor/Editor"
-
 export interface IWindowSplitHostProps {
     split: Oni.IWindowSplit
 }

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -1,27 +1,27 @@
 /**
- * EditorWindows.tsx
+ * WindowSplits.tsx
  *
  * UI that hosts all the `Editor` instances
  */
 
 import * as React from "react"
 
-import { EditorHost } from "./EditorHost"
+import { WindowSplitHost } from "./WindowSplitHost"
 
 import { WindowManager } from "./../../Services/WindowManager"
 import { ISplitInfo } from "./../../Services/WindowSplit"
 
-export interface IEditorWindowsProps {
+export interface IWindowSplitsProps {
     windowManager: WindowManager
 }
 
-export interface IEditorWindowsState {
-    splitRoot: ISplitInfo<Oni.Editor>
+export interface IWindowSplitsState {
+    splitRoot: ISplitInfo<Oni.IWindowSplit>
 }
 
-export class EditorWindows extends React.PureComponent<IEditorWindowsProps, IEditorWindowsState> {
+export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindowSplitsState> {
 
-    constructor(props: IEditorWindowsProps) {
+    constructor(props: IWindowSplitsProps) {
         super(props)
 
         this.state = {
@@ -49,16 +49,16 @@ export class EditorWindows extends React.PureComponent<IEditorWindowsProps, IEdi
             "height": "100%",
         }
 
-        const editors = this.state.splitRoot.splits.map((split) => {
-            if (split.type === "Split") {
+        const editors = this.state.splitRoot.splits.map((splitNode) => {
+            if (splitNode.type === "Split") {
                 return null
             } else {
-                const anyEditor: any = split.contents
+                const split: Oni.IWindowSplit = splitNode.contents
 
-                if (!anyEditor) {
+                if (!split) {
                     return <div className="container vertical full">TODO: Implement an editor here...</div>
                 } else {
-                    return <EditorHost editor={anyEditor} />
+                    return <WindowSplitHost split={split} />
                 }
             }
         })

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -36,12 +36,19 @@ declare namespace Oni {
     }
 
     export interface IWindowManager {
-        split(direction: number, editor: Oni.Editor, sourceEditor?: Oni.Editor)
+        split(direction: number, split: IWindowSplit)
+        showDock(direction: number, split: IWindowSplit)
         moveLeft(): void
         moveRight(): void
         moveDown(): void
         moveUp(): void
         close(editor: Oni.Editor)
+    }
+
+    export interface IWindowSplit {
+        enter(): void
+        leave(): void
+        render(): JSX.Element
     }
 
     export interface EditorManager {

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -46,8 +46,6 @@ declare namespace Oni {
     }
 
     export interface IWindowSplit {
-        enter(): void
-        leave(): void
         render(): JSX.Element
     }
 


### PR DESCRIPTION
The `Oni.Editor` interface is getting pretty heavyweight - needing to have a `mode` along with all sorts of events in terms of buffer changing / entering / leaving. For scenarios like Markdown Preview, File Explorer, etc, this shouldn't really be needed.

This introduces the concept of an `Oni.IWindowSplit` which is really simple - it just has a `render` method and takes up space. 

Some enhancements for later:
- We'll need to track focus in and out of the split
- Need to figure out how this relates to the editors - does a window split host multiple editors? Or a single neovim instance?