### PR TITLE
Fix two typos in the default ui.fontFamily configuration

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -107,7 +107,7 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.maxWidth": "30em",
     "tabs.wrap": false,
 
-    "ui.fontFamily": "BlinkMacSystemFont, 'Lucide Grande', 'Segoe UI', Ubuntu, Cantarell, sans-seriff",
+    "ui.fontFamily": "BlinkMacSystemFont, 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",
     "ui.fontSize": "13px",
 }
 


### PR DESCRIPTION
Thanks @badosu for catching this - #876 introduced separate fonts for shell (non-editor) UI, but there were a couple typos that likely made it look pretty ugly on some platforms.