### PR TITLE
Fix break in automation due to regression in webdriverio

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "ts-loader": "2.3.2",
     "tslint": "5.7.0",
     "wcwidth": "1.0.1",
+    "webdriverio": "4.8.0",
     "webpack": "3.5.3",
     "webpack-dev-server": "2.7.1"
   },

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -29,8 +29,10 @@ export class Oni {
     }
 
     public async start(args: string[] = []): Promise<void> {
+        const executablePath = getExecutablePath()
+        log("Using executable path: " + executablePath)
         this._app = new Application({
-            path: getExecutablePath(),
+            path: executablePath,
             args,
         })
 


### PR DESCRIPTION
- Clamp webdriverio version to `4.8.0` to try and prevent it from changing underneath us again
- Add additional logging to process start