### PR TITLE
API: Remove unused API methods

### DIFF
--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -271,12 +271,6 @@ declare namespace Oni {
             }
         }
 
-        export interface FormattingEditsResponse {
-            filePath: string
-            version: number
-            edits: any[]
-        }
-
         export interface Api extends EventEmitter {
             automation: Automation.Api
             configuration: Configuration
@@ -290,10 +284,6 @@ declare namespace Oni {
             process: Process
             statusBar: StatusBar
             workspace: Workspace
-        }
-
-        export interface LanguageService {
-            getFormattingEdits?(position: EventContext): Promise<FormattingEditsResponse>
         }
     }
 }


### PR DESCRIPTION
Some cleanup to remove some API methods. This is in preparation for moving `Oni.d.ts` to a separate node module (`oni-api`).