### PR TITLE
Fix flickering of completion details by caching last result request

### DIFF
--- a/browser/src/Services/Language/Completion/CompletionMenu.ts
+++ b/browser/src/Services/Language/Completion/CompletionMenu.ts
@@ -91,8 +91,21 @@ export const createCompletionMenu = (completionMeet$: Observable<ICompletionMeet
         })
 }
 
+let lastDetailsRequestInfo: { label: string, result: types.CompletionItem } = { label: null, result: null }
+
 export const updateCompletionItemDetails = async (menu: any, language: string, filePath: string, completionItem: types.CompletionItem)  => {
+
+    if (lastDetailsRequestInfo.label === completionItem.label && lastDetailsRequestInfo.result) {
+        menu.updateItem(lastDetailsRequestInfo.result)
+        return
+    }
+
     const result = await resolveCompletionItem(language, filePath, completionItem)
+
+    lastDetailsRequestInfo = {
+        label: completionItem.label,
+        result,
+    }
 
     if (result) {
         menu.updateItem(result)


### PR DESCRIPTION
__Issue:__ As you type, if there is completion + detail item, there is noticeable flickering.

__Defect:__ We keep re-requesting details for the same item

__Fix:__ Cache the last details request we made and use that 