### PR TITLE
Add escape to leave terminal mode by default

### DIFF
--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -34,4 +34,6 @@ inoremap <expr> <C-a> pumvisible() ? "<Esc>A" : "<C-o>A"
 inoremap <expr> <C-b> pumvisible() ? "<Esc>bi" : "<C-o>b"
 inoremap <expr> <C-l> pumvisible() ? "<Esc>la" : "<C-o>a"
 
+tnoremap <Esc> <C-\><C-n>
+
 colorscheme onedark


### PR DESCRIPTION
Fix #915  - add default `Esc` binding for leaving terminal mode.

Good info here: https://neovim.io/doc/user/nvim_terminal_emulator.html