### PR TITLE
Fix #916 - Remove 'experimental' flag for language server config

### DIFF
--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -75,9 +75,7 @@ const start = (args: string[]) => {
         commandManager.executeCommand(command, null)
     })
 
-    if (configuration.getValue("experimental.enableLanguageServerFromConfig")) {
-        createLanguageClientsFromConfiguration(configuration.getValues())
-    }
+    createLanguageClientsFromConfiguration(configuration.getValues())
 
     performance.mark("NeovimInstance.Plugins.Start")
     const api = pluginManager.startPlugins()


### PR DESCRIPTION
A feature flag `experimental.enableLanguageServerFromConfig` was in place while the language server configuration work was stabilized. It should be removed now, as this is the primary way to enable language server integration as documented in the [wiki](https://github.com/onivim/oni/wiki/Language-Support)

Thanks for catching this, @saibing!