### PR TITLE
Add a check for the symbol search keybind.

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -23,7 +23,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<m-p>", "quickOpen.show")
         input.bind("<m-s-p>", "commands.show")
         input.bind("<m-enter>", "language.codeAction.expand")
-        input.bind("<m-t>", "language.symbols.workspace")
+        input.bind("<m-t>", "language.symbols.workspace", () => !menu.isMenuOpen())
         input.bind("<s-m-t>", "language.symbols.document")
 
         if (config.getValue("editor.clipboard.enabled")) {
@@ -35,7 +35,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<c-p>", "quickOpen.show", () => isNormalMode() && !isMenuOpen())
         input.bind("<s-c-p>", "commands.show", isNormalMode)
         input.bind("<a-enter>", "language.codeAction.expand")
-        input.bind("<c-t>", "language.symbols.workspace")
+        input.bind("<c-t>", "language.symbols.workspace", () => !menu.isMenuOpen())
         input.bind("<s-c-t>", "language.symbols.document")
 
         if (config.getValue("editor.clipboard.enabled")) {


### PR DESCRIPTION
Currently, the LSP symbol search is set to <Ctrl+t> which overlaps with the Quick open, open in new tab keybind.

This should fix that by checking the menu isn't open first, assuming this wasn't by design?
If it was, I can update the PR to remap the open in new tab option, since currently its not usable.\

I'm putting a very early table of the keybinds in the wiki as well, so please fill out around it to add a bit more context! (I also wasn't 100% on the LSP Expand keybind, so I put in a placeholder for now).

Two other quick questions I had:

1. There looks to be a number of keybinds with both a C and M version, such as this PR.
Others just seem to have a Ctrl version only (ie Ctrl+/ for search current buffer), is that by design?
Or more likely, I'm just misunderstanding the keybind system / Mac keybinds in general and somehow it applies to both?
2. I'm having some issues with ripgrep since the move to our own repo, it was very flaky getting it installed so I'd appreciate you testing this PR to check its working as intended. Am I missing something I need to do to get it installed? The neovim download worked perfectly, but ripgrep seemed to not return any results, so I'm assuming it wasn't downloaded properly.