### PR TITLE
Fix #923: Not loading `after` folder

### DIFF
--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -48,7 +48,7 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
     }
 
     const argsToPass = initVimArg
-        .concat(["--cmd", `let &rtp.='${joinedRuntimePaths}'`, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
+        .concat(["--cmd", `let &rtp.=',${joinedRuntimePaths}'`, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
         .concat(args)
 
     const nvimProc = spawnProcess(nvimProcessPath, argsToPass, {})


### PR DESCRIPTION
__Issue:__ We were not properly concatenating Oni's plugin runtime paths with Neovim's runtime paths. This could cause unpredictable issues with other plugins / Oni's built in plug-ins, depending on the ordering.

![image](https://user-images.githubusercontent.com/13532591/32754907-b363cb52-c887-11e7-9c68-efb421c6106a.png)


__Fix:__ Add a comma explicitly when setting the runtime paths. This SO post had good info too: https://superuser.com/questions/806595/why-the-runtimepath-in-vim-cannot-be-set-as-a-variable

