### PR TITLE
Fix #911 - Handle case when 'nvim' is not available on path

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -5,7 +5,6 @@
  */
 
 import * as React from "react"
-import * as ReactDOM from "react-dom"
 
 import "rxjs/add/observable/defer"
 import "rxjs/add/observable/merge"
@@ -35,8 +34,6 @@ import * as UI from "./../UI/index"
 
 import { IEditor } from "./Editor"
 
-import { InstallHelp } from "./../UI/components/InstallHelp"
-
 import { BufferManager } from "./BufferManager"
 import { listenForBufferUpdates } from "./BufferUpdates"
 import { NeovimPopupMenu } from "./NeovimPopupMenu"
@@ -56,7 +53,6 @@ export class NeovimEditor implements IEditor {
     private _popupMenu: NeovimPopupMenu
 
     private _pendingAnimationFrame: boolean = false
-    private _element: HTMLElement
 
     private _currentMode: string
     private _onBufferEnterEvent = new Event<Oni.EditorBufferEventArgs>()
@@ -169,7 +165,7 @@ export class NeovimEditor implements IEditor {
         this._neovimInstance.on("event", (eventName: string, evt: any) => this._onVimEvent(eventName, evt))
 
         this._neovimInstance.onError.subscribe((err) => {
-            ReactDOM.render(<InstallHelp />, this._element.parentElement)
+            UI.Actions.setNeovimError(true)
         })
 
         this._neovimInstance.onDirectoryChanged.subscribe((newDirectory) => {

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -73,8 +73,6 @@ export class NeovimEditor implements IEditor {
 
     private _windowManager: NeovimWindowManager
 
-    private _errorStartingNeovim: boolean = false
-
     private _isFirstRender: boolean = true
 
     private _lastBufferId: string = null
@@ -157,14 +155,20 @@ export class NeovimEditor implements IEditor {
             }
         })
 
+        this._neovimInstance.onLeave.subscribe(() => {
+            // TODO: Only leave if all editors are closed...
+            if (!configuration.getValue("debug.persistOnNeovimExit")) {
+                remote.getCurrentWindow().close()
+            }
+        })
+
         this._neovimInstance.onOniCommand.subscribe((command) => {
             commandManager.executeCommand(command)
         })
 
         this._neovimInstance.on("event", (eventName: string, evt: any) => this._onVimEvent(eventName, evt))
 
-        this._neovimInstance.on("error", (_err: string) => {
-            this._errorStartingNeovim = true
+        this._neovimInstance.onError.subscribe((err) => {
             ReactDOM.render(<InstallHelp />, this._element.parentElement)
         })
 

--- a/browser/src/Editor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimSurface.tsx
@@ -24,8 +24,6 @@ import { ErrorsContainer } from "./../UI/containers/ErrorsContainer"
 import { NeovimInput } from "./NeovimInput"
 import { NeovimRenderer } from "./NeovimRenderer"
 
-
-
 export interface INeovimSurfaceProps {
     neovimInstance: NeovimInstance
     renderer: INeovimRenderer

--- a/browser/src/Editor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimSurface.tsx
@@ -13,6 +13,7 @@ import { NeovimScreen } from "./../Screen"
 import { ActiveWindowContainer } from "./../UI/components/ActiveWindow"
 import { Cursor } from "./../UI/components/Cursor"
 import { CursorLine } from "./../UI/components/CursorLine"
+import { InstallHelp } from "./../UI/components/InstallHelp"
 import { TabsContainer } from "./../UI/components/Tabs"
 import { ToolTips } from "./../UI/components/ToolTip"
 
@@ -22,6 +23,8 @@ import { ErrorsContainer } from "./../UI/containers/ErrorsContainer"
 
 import { NeovimInput } from "./NeovimInput"
 import { NeovimRenderer } from "./NeovimRenderer"
+
+
 
 export interface INeovimSurfaceProps {
     neovimInstance: NeovimInstance
@@ -68,6 +71,7 @@ export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> 
                 <div className="stack layer">
                     <ToolTips />
                 </div>
+                <InstallHelp />
             </div>
         </div>
     }

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -28,6 +28,13 @@ import { IConfigurationValues } from "./../Services/Configuration"
 export type DispatchFunction = (action: any) => void
 export type GetStateFunction = () => State.IState
 
+export const setNeovimError = (neovimError: boolean) => ({
+    type: "SET_NEOVIM_ERROR",
+    payload: {
+        neovimError: neovimError,
+    }
+})
+
 export const setViewport = (width: number, height: number) => ({
     type: "SET_VIEWPORT",
     payload: {

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -31,8 +31,8 @@ export type GetStateFunction = () => State.IState
 export const setNeovimError = (neovimError: boolean) => ({
     type: "SET_NEOVIM_ERROR",
     payload: {
-        neovimError: neovimError,
-    }
+        neovimError,
+    },
 })
 
 export const setViewport = (width: number, height: number) => ({

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -23,6 +23,13 @@ export interface ISetViewportAction {
     }
 }
 
+export interface ISetNeovimErrorAction {
+    type: "SET_NEOVIM_ERROR",
+    payload: {
+        neovimError: boolean,
+    }
+}
+
 export interface ISetCursorScaleAction {
     type: "SET_CURSOR_SCALE",
     payload: {
@@ -239,6 +246,7 @@ export type SimpleAction =
     IStatusBarShowAction |
     ISetErrorsAction |
     ISetCurrentBuffersAction |
+    ISetNeovimErrorAction |
     ISetTabs |
     ISetViewportAction |
     ISetWindowCursor |

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -23,7 +23,7 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
     switch (a.type) {
         case "SET_NEOVIM_ERROR":
             return { ...s,
-                    neovimError: a.payload.neovimError }
+                     neovimError: a.payload.neovimError }
         case "SET_VIEWPORT":
             return { ...s,
                      viewport: viewportReducer(s.viewport, a) }

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -21,6 +21,9 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
     }
 
     switch (a.type) {
+        case "SET_NEOVIM_ERROR":
+            return { ...s,
+                    neovimError: a.payload.neovimError }
         case "SET_VIEWPORT":
             return { ...s,
                      viewport: viewportReducer(s.viewport, a) }

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -48,6 +48,8 @@ export interface IState {
     imeActive: boolean
     viewport: IViewport
 
+    neovimError: boolean
+
     statusBar: { [id: string]: IStatusBarItem }
     toolTips: { [id: string]: IToolTip }
 
@@ -186,6 +188,7 @@ export const createDefaultState = (): IState => ({
     cursorLineOpacity: 0,
     cursorColumnOpacity: 0,
     backgroundColor: "#000000",
+    neovimError: false,
 
     configuration: configuration.getValues(),
 

--- a/browser/src/UI/components/InstallHelp.less
+++ b/browser/src/UI/components/InstallHelp.less
@@ -7,7 +7,7 @@
     right: 0px;
     bottom: 0px;
 
-    background-color: @background-color;
+    background-color: rgb(40, 44, 52);
     color: @text-color;
 
     display: flex;
@@ -17,6 +17,10 @@
 
     .title {
         text-align: center;
+
+        p {
+            font-weight: bold;
+        }
     }
 
     .instructions {
@@ -26,8 +30,9 @@
             margin: 8px;
         }
 
-        a {
-            color: @text-color-highlight;
-        }
+    }
+
+    a {
+        color: @text-color-highlight;
     }
 }

--- a/browser/src/UI/components/InstallHelp.tsx
+++ b/browser/src/UI/components/InstallHelp.tsx
@@ -1,40 +1,61 @@
 import * as React from "react"
 
+import { connect } from "react-redux"
+
 import { remote } from "electron"
 
 import { Icon, IconSize } from "./../Icon"
 
+import * as State from "./../State"
+
 require("./InstallHelp.less") // tslint:disable-line no-var-requires
 
-export const InstallHelp = () => {
-    const _onClick = (evt: any) => {
-        remote.shell.openExternal("https://github.com/neovim/neovim/wiki/Installing-Neovim")
-        evt.preventDefault()
-    }
-
-    const _onClickIssue = (evt: any) => {
-        remote.shell.openExternal("https://github.com/onivim/oni/issues")
-        evt.preventDefault()
-    }
-
-    return <div className="install-help enable-mouse">
-        <div className="title">
-            <Icon name="warning" size={IconSize.FiveX} />
-            <h1>Uh oh! Unable to launch Neovim...</h1>
-            <p>Neovim v0.2.1 is required to run Oni.</p>
-        </div>
-        <div className="instructions">
-            <ul>
-                <li>
-                    <span>Install neovim from here: </span>
-                    <a href="#" onClick={(evt) => _onClick(evt)}>Installing Neovim</a>
-                </li>
-                <li>Run `nvim --version` from your command prompt to verify you're good to go!</li>
-                <li>Close and re-open Oni</li>
-            </ul>
-        </div>
-        <div>
-            If this issue persists, help us by logging an <a href="#" onClick={(evt) => _onClickIssue}>issue!</a>
-        </div>
-    </div>
+export interface InstallHelpViewProps {
+    visible: boolean
 }
+
+export class InstallHelpView extends React.PureComponent<InstallHelpViewProps, {}> {
+
+    public render(): JSX.Element {
+        if (!this.props.visible) {
+            return null
+        }
+
+        const _onClick = (evt: any) => {
+            remote.shell.openExternal("https://github.com/neovim/neovim/wiki/Installing-Neovim")
+            evt.preventDefault()
+        }
+
+        const _onClickIssue = (evt: any) => {
+            remote.shell.openExternal("https://github.com/onivim/oni/issues")
+            evt.preventDefault()
+        }
+
+        return <div className="install-help enable-mouse">
+            <div className="title">
+                <Icon name="warning" size={IconSize.FiveX} />
+                <h1>Uh oh! Unable to launch Neovim...</h1>
+                <p>Neovim v0.2.1 is required to run Oni.</p>
+            </div>
+            <div className="instructions">
+                <ul>
+                    <li>
+                        <span>Install neovim from here: </span>
+                        <a href="#" onClick={(evt) => _onClick(evt)}>Installing Neovim</a>
+                    </li>
+                    <li>Run `nvim --version` from your command prompt to verify you're good to go!</li>
+                    <li>Close and re-open Oni</li>
+                </ul>
+            </div>
+            <div>
+                If this issue persists, help us by logging an <a href="#" onClick={(evt) => _onClickIssue}>issue!</a>
+            </div>
+        </div>
+    }
+}
+
+const mapStateFromProps = (state: State.IState): InstallHelpViewProps => ({
+    visible: state.neovimError,
+})
+
+export const InstallHelp = connect(mapStateFromProps)(InstallHelpView)

--- a/browser/src/UI/components/InstallHelp.tsx
+++ b/browser/src/UI/components/InstallHelp.tsx
@@ -12,19 +12,29 @@ export const InstallHelp = () => {
         evt.preventDefault()
     }
 
-    return <div className="install-help">
+    const _onClickIssue = (evt: any) => {
+        remote.shell.openExternal("https://github.com/onivim/oni/issues")
+        evt.preventDefault()
+    }
+
+    return <div className="install-help enable-mouse">
         <div className="title">
             <Icon name="warning" size={IconSize.FiveX} />
-            <h1>Unable to launch NeoVim</h1>
+            <h1>Uh oh! Unable to launch Neovim...</h1>
+            <p>Neovim v0.2.1 is required to run Oni.</p>
         </div>
         <div className="instructions">
             <ul>
                 <li>
-                    <span>Install NeoVim from here:</span>
+                    <span>Install neovim from here: </span>
                     <a href="#" onClick={(evt) => _onClick(evt)}>Installing Neovim</a>
                 </li>
+                <li>Run `nvim --version` from your command prompt to verify you're good to go!</li>
                 <li>Close and re-open Oni</li>
             </ul>
+        </div>
+        <div>
+            If this issue persists, help us by logging an <a href="#" onClick={(evt) => _onClickIssue}>issue!</a>
         </div>
     </div>
 }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -1,4 +1,3 @@
-import { remote } from "electron"
 import { EventEmitter } from "events"
 import * as path from "path"
 
@@ -140,6 +139,7 @@ export interface INeovimStartOptions {
 export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _neovim: Session
     private _initPromise: Promise<void>
+    private _isLeaving: boolean
 
     private _config = configuration
     private _autoCommands: NeovimAutoCommands
@@ -158,6 +158,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _quickFix: QuickFixList
 
     private _onDirectoryChanged = new Event<string>()
+    private _onErrorEvent = new Event<Error | string>()
     private _onYank = new Event<INeovimYankInfo>()
     private _onOniCommand = new Event<string>()
     private _onRedrawComplete = new Event<void>()
@@ -168,6 +169,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _onHidePopupMenu = new Event<void>()
     private _onShowPopupMenu = new Event<INeovimCompletionInfo>()
     private _onSelectPopupMenu = new Event<number>()
+    private _onLeave = new Event<void>()
 
     private _pendingScrollTimeout: number | null = null
 
@@ -185,6 +187,14 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     public get onDirectoryChanged(): IEvent<string> {
         return this._onDirectoryChanged
+    }
+
+    public get onError(): IEvent<Error | string> {
+        return this._onErrorEvent
+    }
+
+    public get onLeave(): IEvent<void> {
+        return this._onLeave
     }
 
     public get onModeChanged(): IEvent<Oni.Vim.Mode> {
@@ -225,7 +235,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     constructor(widthInPixels: number, heightInPixels: number) {
         super()
-
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
 
@@ -263,7 +272,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 this._neovim = nv
 
                 this._neovim.on("error", (err: Error) => {
-                    Log.error(err)
+                    this._onError(err)
                 })
 
                 this._neovim.on("notification", (method: any, args: any) => {
@@ -292,6 +301,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
                             if (eventName === "DirChanged") {
                                 this._updateProcessDirectory()
+                            } else if (eventName === "VimLeave") {
+                                this._isLeaving = true
+                                this._onLeave.dispatch()
                             }
 
                             this._autoCommands.notifyAutocommand(eventName, eventContext)
@@ -321,9 +333,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 })
 
                 this._neovim.on("disconnect", () => {
-
-                    if (!configuration.getValue("debug.persistOnNeovimExit")) {
-                        remote.getCurrentWindow().close()
+                    if (!this._isLeaving) {
+                        this._onError("Neovim disconnected. This likely means that the Neovim process crashed.")
                     }
                 })
 
@@ -346,7 +357,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                         await this.callFunction("OniConnect", [])
                     },
                     (err: any) => {
-                        this.emit("error", err)
+                        this._onError(err)
                     })
             })
 
@@ -612,6 +623,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             context,
             bufferLines,
         })
+    }
+
+    private _onError(error: Error | string): void {
+        Log.error(error)
+        this._onErrorEvent.dispatch(error)
     }
 
     private async _updateProcessDirectory(): Promise<void> {

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert"
+import * as fs from "fs"
 import * as path from "path"
 
 import { Oni } from "./common"
@@ -9,44 +10,88 @@ const CiTests = [
     "AutoCompletionTest",
     "BasicEditingTest",
     "QuickOpenTest",
+    "NoInstalledNeovim",
 ]
+
+import * as Platform from "./../browser/src/Platform"
+
+export interface ITestCase {
+    name: string
+    testPath: string
+    configPath: string
+}
+
+const normalizePath = (p) => p.split("\\").join("/")
+
+const loadTest = (testName: string): ITestCase => {
+    const ciPath = path.join(__dirname, "ci")
+    const testPath = path.join(ciPath, testName + ".js")
+
+    const testMeta = require(testPath)
+    const testDescription = testMeta.settings || {}
+
+    const normalizedMeta: ITestCase = {
+        name: testDescription.name || testName,
+        testPath: normalizePath(testPath),
+        configPath: testDescription.configPath ? normalizePath(path.join(ciPath, testDescription.configPath)) : "",
+    }
+
+    return normalizedMeta
+}
 
 describe("ci tests", function() { // tslint:disable-line only-arrow-functions
     // Retry up to two times
     this.retries(2)
 
-    let oni: Oni
-
-    beforeEach(async () => {
-        oni = new Oni()
-        return oni.start()
-    })
-
-    afterEach(async () => {
-        return oni.close()
-    })
-
     CiTests.forEach((test) => {
 
-        const testPath = path.join(__dirname, "ci", test + ".js")
-        const normalizedTestPath = testPath.split("\\").join("/")
+        describe(test, () => {
 
-        it("ci test: " + test, async () => {
-            await oni.client.waitForExist(".editor", LongTimeout)
-            const text = await oni.client.getText(".editor")
-            assert(text && text.length > 0, "Validate editor element is present")
+            const testCase = loadTest(test)
 
-            console.log("Test path: " + normalizedTestPath) // tslint:disable-line
+            let oni: Oni
 
-            oni.client.execute("Oni.automation.runTest('" + normalizedTestPath + "')")
+            beforeEach(async () => {
 
-            console.log("Waiting for result...") // tslint:disable-line
-            await oni.client.waitForExist(".automated-test-result", 30000)
-            const resultText = await oni.client.getText(".automated-test-result")
-            console.log("Got result: " + resultText) // tslint:disable-line
+                const configPath = path.join(Platform.getUserHome(), ".oni", "config.js")
 
-            const result = JSON.parse(resultText)
-            assert.ok(result.passed)
+                if (fs.existsSync(configPath)) {
+                    // console.log("--Removing existing config..")
+                    // fs.unlinkSync(configPath)
+                }
+
+                if (testCase.configPath) {
+                    console.log("Writing config from: " + testCase.configPath)
+                    const configContents = fs.readFileSync(testCase.configPath)
+                    console.log("Writing config to: " + configPath)
+                    fs.writeFileSync(configPath, configContents)
+                }
+
+                oni = new Oni()
+                return oni.start()
+            })
+
+            afterEach(async () => {
+                return oni.close()
+            })
+
+            it("ci test: " + test, async () => {
+                await oni.client.waitForExist(".editor", LongTimeout)
+                const text = await oni.client.getText(".editor")
+                assert(text && text.length > 0, "Validate editor element is present")
+
+                console.log("Test path: " + testCase.testPath) // tslint:disable-line
+
+                oni.client.execute("Oni.automation.runTest('" + testCase.testPath + "')")
+
+                console.log("Waiting for result...") // tslint:disable-line
+                await oni.client.waitForExist(".automated-test-result", 30000)
+                const resultText = await oni.client.getText(".automated-test-result")
+                console.log("Got result: " + resultText) // tslint:disable-line
+
+                const result = JSON.parse(resultText)
+                assert.ok(result.passed)
+            })
         })
     })
 })

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -13,6 +13,8 @@ const CiTests = [
     "NoInstalledNeovim",
 ]
 
+// tslint:disable:no-console
+
 import * as Platform from "./../browser/src/Platform"
 
 export interface ITestCase {

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -55,7 +55,7 @@ describe("ci tests", function() { // tslint:disable-line only-arrow-functions
 
     before(() => {
 
-        if (!fs.existsSync(configFolder) {
+        if (!fs.existsSync(configFolder)) {
             console.log("Config folder doesn't exist - creating.")
             mkdirp.sync(configFolder)
             console.log("Config folder created successfully.")

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -3,6 +3,8 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 
+import { mkdirp } from "mkdirp"
+
 import { Oni } from "./common"
 
 const LongTimeout = 5000
@@ -46,11 +48,19 @@ describe("ci tests", function() { // tslint:disable-line only-arrow-functions
     // Retry up to two times
     this.retries(2)
 
+    const configFolder = path.join(Platform.getUserHome(), ".oni")
     const configPath = path.join(Platform.getUserHome(), ".oni", "config.js")
 
     const temporaryConfigPath = path.join(os.tmpdir(), "config.js")
 
     before(() => {
+
+        if (!fs.existsSync(configFolder) {
+            console.log("Config folder doesn't exist - creating.")
+            mkdirp.sync(configFolder)
+            console.log("Config folder created successfully.")
+        }
+
         if (fs.existsSync(configPath)) {
             console.log("Backing up config to: " + temporaryConfigPath)
             const configContents = fs.readFileSync(configPath, "utf8")

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -3,7 +3,7 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 
-import { mkdirp } from "mkdirp"
+import * as mkdirp from "mkdirp"
 
 import { Oni } from "./common"
 

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -56,8 +56,8 @@ describe("ci tests", function() { // tslint:disable-line only-arrow-functions
                 const configPath = path.join(Platform.getUserHome(), ".oni", "config.js")
 
                 if (fs.existsSync(configPath)) {
-                    // console.log("--Removing existing config..")
-                    // fs.unlinkSync(configPath)
+                    console.log("--Removing existing config..")
+                    fs.unlinkSync(configPath)
                 }
 
                 if (testCase.configPath) {

--- a/test/ci/NoInstalledNeovim.config.js
+++ b/test/ci/NoInstalledNeovim.config.js
@@ -1,0 +1,7 @@
+// For more information on customizing Oni,
+// check out our wiki page:
+// https://github.com/extr0py/oni/wiki/Configuration
+
+module.exports = {
+    "debug.neovimPath": "/derp/not-a-valid-neovim-binary",
+}

--- a/test/ci/NoInstalledNeovim.config.js
+++ b/test/ci/NoInstalledNeovim.config.js
@@ -4,4 +4,4 @@
 
 module.exports = {
     "debug.neovimPath": "/derp/not-a-valid-neovim-binary",
-}
+};

--- a/test/ci/NoInstalledNeovim.ts
+++ b/test/ci/NoInstalledNeovim.ts
@@ -27,5 +27,5 @@ export const test = async (oni: any) => {
 }
 
 export const settings = {
-    configPath: "NoInstalledNeovim.config.js"
+    configPath: "NoInstalledNeovim.config.js",
 }

--- a/test/ci/NoInstalledNeovim.ts
+++ b/test/ci/NoInstalledNeovim.ts
@@ -1,0 +1,31 @@
+/**
+ * Test script to verify the scenario where no neovim is installed
+ *
+ * We should be showing a descriptive error message...
+ */
+
+import * as assert from "assert"
+import * as os from "os"
+import * as path from "path"
+
+const getCompletionElement = () => {
+
+    const elements = document.body.getElementsByClassName("install-help")
+
+    if (!elements || !elements.length) {
+        return null
+    } else {
+        return elements[0]
+    }
+}
+
+export const test = async (oni: any) => {
+    // Wait for install help UX to show
+    await oni.automation.waitFor(() => getCompletionElement() !== null)
+
+    assert.ok(true, "Found install help content as expected.")
+}
+
+export const settings = {
+    configPath: "NoInstalledNeovim.config.js"
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,7 +5,8 @@
         "target": "es2015",
         "noImplicitAny": false,
         "sourceMap": false,
-        "outDir": "../lib_test/test",
+        "allowJs": true,
+        "outDir": "../lib_test",
         "lib": [
             "dom",
             "es2017"
@@ -16,7 +17,8 @@
         "./../definitions/Oni.d.ts"
     ],
     "include": [
-        "**/*.ts"
+        "**/*.ts",
+        "**/*.js"
     ],
     "exclude": [
         "node_modules"

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -75,6 +75,7 @@ augroup OniEventListeners
     autocmd! InsertEnter * :call OniNotifyEvent("InsertEnter")
     autocmd! DirChanged * :call OniNotifyEvent("DirChanged")
     autocmd! VimResized * :call OniNotifyEvent("VimResized")
+    autocmd! VimLeave * :call OniNotifyEvent("VimLeave")
 augroup END
 
 augroup OniNotifyBufferUpdates


### PR DESCRIPTION
Currently, the behavior is very poor when `nvim` is not available on the path. This occurs in Linux, as on OS X and Windows we package the binaries.

Right now, if `nvim` is not available (which is common in Linux), Oni crashes and burns in a bad way - like in #900 (just shows a white screen and exits).

This change adds a UI to guide users to install Neovim:
![image](https://user-images.githubusercontent.com/13532591/32760147-bd28a166-c8a1-11e7-93f1-ab5d5f508238.png)

It's not perfect or ideal, but better than a flashing white screen and exiting instantly...