### PR TITLE
Fix #903 - Move Windows Config and Create Config folder if needed.

### DIFF
--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -10,7 +10,7 @@ export const isMac = () => os.platform() === "darwin"
 export const isLinux = () => os.platform() === "linux"
 
 export const getUserHome = () =>
-    isWindows() ? process.env["USERPROFILE"] : process.env["HOME"] // tslint:disable-line no-string-literal
+    isWindows() ? process.env["APPDATA"] : process.env["HOME"] // tslint:disable-line no-string-literal
 
 export const getLinkPath = () => isMac() ? "/usr/local/bin/oni" : "" // TODO: windows + linux
 export const isAddedToPath = () => {

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -69,7 +69,8 @@ export class Configuration implements Oni.Configuration {
     }
 
     public getUserFolder(): string {
-        return path.join(Platform.getUserHome(), ".oni")
+        return Platform.isWindows() ? path.join(Platform.getUserHome(), "oni") :
+                                      path.join(Platform.getUserHome(), ".oni")
     }
 
     // Emitting event is not enough, at startup nobody's listening yet

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -2,6 +2,7 @@ import * as fs from "fs"
 import * as cloneDeep from "lodash/cloneDeep"
 import * as isError from "lodash/isError"
 import * as path from "path"
+import * as mkdirp from "mkdirp"
 
 import { Event, IEvent } from "./../../Event"
 import { applyDefaultKeyBindings } from "./../../Input/KeyBindings"
@@ -47,6 +48,8 @@ export class Configuration implements Oni.Configuration {
                     this.applyConfig()
                 }
             })
+        } else {
+            mkdirp.sync(this.getUserFolder())
         }
 
         Performance.mark("Config.load.end")

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs"
 import * as cloneDeep from "lodash/cloneDeep"
 import * as isError from "lodash/isError"
-import * as path from "path"
 import * as mkdirp from "mkdirp"
+import * as path from "path"
 
 import { Event, IEvent } from "./../../Event"
 import { applyDefaultKeyBindings } from "./../../Input/KeyBindings"

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -48,8 +48,9 @@ describe("ci tests", function() { // tslint:disable-line only-arrow-functions
     // Retry up to two times
     this.retries(2)
 
-    const configFolder = path.join(Platform.getUserHome(), ".oni")
-    const configPath = path.join(Platform.getUserHome(), ".oni", "config.js")
+    const configFolder = Platform.isWindows() ? path.join(Platform.getUserHome(), "oni") :
+                                                path.join(Platform.getUserHome(), ".oni")
+    const configPath = path.join(configFolder, "config.js")
 
     const temporaryConfigPath = path.join(os.tmpdir(), "config.js")
 


### PR DESCRIPTION
This PR moves the Windows config file from from `C:\Users\XXX\.oni\config.js` to `%APPDATA%\oni\config.js`. It will also make the relevant folder if needed on any platform.

Currently, I'm using `mkdirp.sync()` since the package was already there, but should I instead be using an Async version, and if so any suggestions what?

Since this PR is a breaking change, it may need doing alongside some of the ideas in #938.