### PR TITLE
Add option to use named pipes as the transport for the msgpack-rpc API

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -15,7 +15,7 @@ import { Observable } from "rxjs/Observable"
 
 import { clipboard, ipcRenderer, remote } from "electron"
 
-import { NeovimInstance, NeovimWindowManager } from "./../neovim"
+import { INeovimStartOptions, NeovimInstance, NeovimWindowManager } from "./../neovim"
 import { CanvasRenderer, INeovimRenderer } from "./../Renderer"
 import { NeovimScreen } from "./../Screen"
 
@@ -281,7 +281,13 @@ export class NeovimEditor implements IEditor {
     }
 
     public init(filesToOpen: string[]): void {
-        this._neovimInstance.start(filesToOpen, { runtimePaths: pluginManager.getAllRuntimePaths() })
+        const startOptions: INeovimStartOptions = {
+            args: filesToOpen,
+            runtimePaths: pluginManager.getAllRuntimePaths(),
+            transport: configuration.getValue("experimental.neovim.transport"),
+        }
+
+        this._neovimInstance.start(startOptions)
             .then(() => {
                 this._hasLoaded = true
                 VimConfigurationSynchronizer.synchronizeConfiguration(this._neovimInstance, this._config.getValues())

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -37,6 +37,10 @@ const BaseConfiguration: IConfigurationValues = {
         { "open": "(", "close": ")" },
     ],
 
+    "experimental.neovim.transport": "stdio",
+    // TODO: Enable pipe transport for Windows
+    // "experimental.neovim.transport": Platform.isWindows() ? "pipe" : "stdio",
+
     "oni.audio.bellUrl": null,
 
     "oni.useDefaultConfig": true,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -30,6 +30,11 @@ export interface IConfigurationValues {
     "experimental.autoClosingPairs.enabled": boolean
     "experimental.autoClosingPairs.default": any
 
+
+    // The transport to use for Neovim
+    // Valid values are "stdio" and "pipe"
+    "experimental.neovim.transport": string
+
     // Production settings
 
     // Bell sound effect to use

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -30,7 +30,6 @@ export interface IConfigurationValues {
     "experimental.autoClosingPairs.enabled": boolean
     "experimental.autoClosingPairs.default": any
 
-
     // The transport to use for Neovim
     // Valid values are "stdio" and "pipe"
     "experimental.neovim.transport": string

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -15,7 +15,7 @@ import { configuration } from "./../Services/Configuration"
 
 import { NeovimBufferReference } from "./MsgPack"
 import { INeovimAutoCommands, NeovimAutoCommands } from "./NeovimAutoCommands"
-import { startNeovim, INeovimStartOptions } from "./NeovimProcessSpawner"
+import { INeovimStartOptions, startNeovim } from "./NeovimProcessSpawner"
 import { IQuickFixList, QuickFixList } from "./QuickFix"
 import { Session } from "./Session"
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -15,7 +15,7 @@ import { configuration } from "./../Services/Configuration"
 
 import { NeovimBufferReference } from "./MsgPack"
 import { INeovimAutoCommands, NeovimAutoCommands } from "./NeovimAutoCommands"
-import { startNeovim } from "./NeovimProcessSpawner"
+import { startNeovim, INeovimStartOptions } from "./NeovimProcessSpawner"
 import { IQuickFixList, QuickFixList } from "./QuickFix"
 import { Session } from "./Session"
 
@@ -130,10 +130,6 @@ export interface INeovimInstance {
     openInitVim(): Promise<void>
 }
 
-export interface INeovimStartOptions {
-    runtimePaths?: string[]
-}
-
 /**
  * Integration with NeoVim API
  */
@@ -246,13 +242,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         return this.callFunction("OniGetContext", [])
     }
 
-    public start(filesToOpen?: string[], startOptions?: INeovimStartOptions): Promise<void> {
-        filesToOpen = filesToOpen || []
-
-        startOptions = startOptions || { }
-        const runtimePaths = startOptions.runtimePaths || []
-
-        this._initPromise = startNeovim(runtimePaths, filesToOpen)
+    public start(startOptions?: INeovimStartOptions): Promise<void> {
+        this._initPromise = startNeovim(startOptions)
             .then((nv) => {
                 Log.info("NeovimInstance: Neovim started")
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -252,7 +252,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         startOptions = startOptions || { }
         const runtimePaths = startOptions.runtimePaths || []
 
-        this._initPromise = Promise.resolve(startNeovim(runtimePaths, filesToOpen))
+        this._initPromise = startNeovim(runtimePaths, filesToOpen)
             .then((nv) => {
                 Log.info("NeovimInstance: Neovim started")
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -1,3 +1,4 @@
+import * as net from "net"
 import * as path from "path"
 
 import * as Platform from "./../Platform"
@@ -13,7 +14,7 @@ const remapPathToUnpackedAsar = (originalPath: string) => {
     return originalPath.split("app.asar").join("app.asar.unpacked")
 }
 
-export const startNeovim = (runtimePaths: string[], args: string[]): Session => {
+export const startNeovim = async (runtimePaths: string[], args: string[]): Promise<Session> => {
 
     const noopInitVimPath = remapPathToUnpackedAsar(path.join(__dirname, "vim", "noop.vim"))
 
@@ -55,5 +56,18 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
 
     console.log(`Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
 
-    return new Session(nvimProc.stdin, nvimProc.stdout)
+    const session1 = new Session(nvimProc.stdin, nvimProc.stdout)
+
+    return session1.request("nvim_eval", ["v:servername"]).then((result: string) => {
+        const pipe = result
+
+
+        const client = net.createConnection(pipe, () => {
+            console.log("connected")
+
+        })
+
+        return new Session(client, client)
+
+    })
 }

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -31,7 +31,7 @@ const DefaultStartOptions: INeovimStartOptions = {
     transport: "stdio",
 }
 
-const getSessionFromProcess = async (neovimProcess: ChildProcess, transport: MsgPackTransport = "stdio") : Promise<Session> => {
+const getSessionFromProcess = async (neovimProcess: ChildProcess, transport: MsgPackTransport = "stdio"): Promise<Session> => {
 
     Log.info("Initializing neovim process using transport: " + transport)
 
@@ -98,4 +98,3 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
     return getSessionFromProcess(nvimProc, options.transport)
 
 }
-

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -14,7 +14,21 @@ const remapPathToUnpackedAsar = (originalPath: string) => {
     return originalPath.split("app.asar").join("app.asar.unpacked")
 }
 
-export const startNeovim = async (runtimePaths: string[], args: string[]): Promise<Session> => {
+export type MsgPackTransport = "stdio" | "pipe"
+
+export interface INeovimStartOptions {
+    args: string[]
+    runtimePaths?: string[]
+    transport?: MsgPackTransport
+}
+
+const DefaultStartOptions: INeovimStartOptions = {
+    args: []
+    runtimePaths: [],
+    transport: "stdio",
+}
+
+export const startNeovim = async (options: INeovimStartOptions): Promise<Session> => {
 
     const noopInitVimPath = remapPathToUnpackedAsar(path.join(__dirname, "vim", "noop.vim"))
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -1,3 +1,4 @@
+import { ChildProcess } from "child_process"
 import * as net from "net"
 import * as path from "path"
 
@@ -6,6 +7,8 @@ import { spawnProcess } from "./../Plugins/Api/Process"
 import { configuration } from "./../Services/Configuration"
 
 import { Session } from "./Session"
+
+import * as Log from "./../Log"
 
 // Most of the paths coming in the packaged binary reference the `app.asar`,
 // but the binaries (Neovim) as well as the .vim files are unpacked,
@@ -23,12 +26,34 @@ export interface INeovimStartOptions {
 }
 
 const DefaultStartOptions: INeovimStartOptions = {
-    args: []
+    args: [],
     runtimePaths: [],
     transport: "stdio",
 }
 
-export const startNeovim = async (options: INeovimStartOptions): Promise<Session> => {
+const getSessionFromProcess = async (neovimProcess: ChildProcess, transport: MsgPackTransport = "stdio") : Promise<Session> => {
+
+    Log.info("Initializing neovim process using transport: " + transport)
+
+    const stdioSession = new Session(neovimProcess.stdin, neovimProcess.stdout)
+
+    if (transport === "stdio") {
+        return stdioSession
+    }
+
+    const namedPipe = await stdioSession.request<string>("nvim_eval", ["v:servername"])
+
+    const client = net.createConnection(namedPipe, () => {
+        Log.info("NeovimProcess - connected via named pipe: " + namedPipe)
+    })
+
+    return new Session(client, client)
+}
+
+export const startNeovim = async (options: INeovimStartOptions = DefaultStartOptions): Promise<Session> => {
+
+    const runtimePaths = options.runtimePaths || []
+    const args = options.args || []
 
     const noopInitVimPath = remapPathToUnpackedAsar(path.join(__dirname, "vim", "noop.vim"))
 
@@ -70,18 +95,7 @@ export const startNeovim = async (options: INeovimStartOptions): Promise<Session
 
     console.log(`Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
 
-    const session1 = new Session(nvimProc.stdin, nvimProc.stdout)
+    return getSessionFromProcess(nvimProc, options.transport)
 
-    return session1.request("nvim_eval", ["v:servername"]).then((result: string) => {
-        const pipe = result
-
-
-        const client = net.createConnection(pipe, () => {
-            console.log("connected")
-
-        })
-
-        return new Session(client, client)
-
-    })
 }
+


### PR DESCRIPTION
__Issue:__ On OSX/Linux, `stdio` is pretty fast and low-latency. On Windows, though, there are different characteristics between using `stdio` vs `named-pipes` or local sockets.

__Fix:__ This is an experimental option to enable using socket transport for Neovim, to evaluate performance on Windows using named pipes vs `stdio`.

This option needs to be opted-in by setting the `experimental.neovim.transport` setting to `pipe`.