### PR TITLE
Fix feature gate for auto-closing pairs

### DIFF
--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -68,6 +68,13 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
             return
         }
 
+
+        if (subscriptions && subscriptions.length) {
+            subscriptions.forEach((df) => df())
+        }
+
+        subscriptions = []
+
         const autoClosingPairs = getAutoClosingPairs(configuration, newBuffer.language)
 
         autoClosingPairs.forEach((pair) => {
@@ -75,18 +82,6 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
             subscriptions.push(inputManager.bind(pair.close, handleCloseCharacter(pair, editorManager.activeEditor), insertModeFilter))
         })
 
-    })
-
-    editorManager.activeEditor.onBufferLeave.subscribe((newBuffer) => {
-        if (!configuration.getValue("experimental.autoClosingPairs.enabled")) {
-            Log.verbose("[Auto Closing Pairs] Not enabled.")
-            return
-        }
-
-        if (subscriptions && subscriptions.length) {
-            subscriptions.forEach((df) => df())
-            subscriptions = []
-        }
     })
 }
 

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -65,6 +65,7 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
 
         if (!configuration.getValue("experimental.autoClosingPairs.enabled")) {
             Log.verbose("[Auto Closing Pairs] Not enabled.")
+            return
         }
 
         const autoClosingPairs = getAutoClosingPairs(configuration, newBuffer.language)
@@ -77,8 +78,15 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
     })
 
     editorManager.activeEditor.onBufferLeave.subscribe((newBuffer) => {
-        subscriptions.forEach((df) => df())
-        subscriptions = []
+        if (!configuration.getValue("experimental.autoClosingPairs.enabled")) {
+            Log.verbose("[Auto Closing Pairs] Not enabled.")
+            return
+        }
+
+        if (subscriptions && subscriptions.length) {
+            subscriptions.forEach((df) => df())
+            subscriptions = []
+        }
     })
 }
 

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -68,7 +68,6 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
             return
         }
 
-
         if (subscriptions && subscriptions.length) {
             subscriptions.forEach((df) => df())
         }


### PR DESCRIPTION
The auto-closing pairs feature still needs some testing, so it's behind the `experimental.autoClosingPairs.enabled` gate. However, it just falls through and runs anyway even if it is `false`. This fixes the check to properly gate the feature.
