### PR TITLE
[WIP] Fix #355 - Improve startup experience

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,4 @@
+- Animate startup
+- Add loading spinner
+- Add transition-out for loading screen
+- Add transition-in for tabs + statusbar

--- a/browser/src/Lifecycle/Startup.ts
+++ b/browser/src/Lifecycle/Startup.ts
@@ -1,0 +1,35 @@
+/**
+ * Startup.ts
+ *
+ * Entry point for the app
+ */
+
+export type Task = () => Promise<void>
+
+import * as Log from "./../Log"
+
+export class Startup {
+
+    private _tasks: Task[] = []
+
+    public enqueueTask(name: string, task: Task): void {
+
+        this._tasks.push(async () => {
+            Log.verbose(`[Startup] BEGIN ${name}`)
+            const startTime = new Date().getTime()
+
+            await task()
+            const endTime = new Date().getTime()
+
+            const totalTime = endTime - startTime
+
+            Log.verbose(`[Startup] END ${name}: ${totalTime}ms`)
+        })
+
+    }
+
+    public start(): Promise<any> {
+        const promises = this._tasks.map((t) => t())
+        return Promise.all(promises)
+    }
+}

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -28,6 +28,10 @@ import { IConfigurationValues } from "./../Services/Configuration"
 export type DispatchFunction = (action: any) => void
 export type GetStateFunction = () => State.IState
 
+export const setLoadingComplete = () => ({
+    type: "SET_LOADING_COMPLETE",
+})
+
 export const setViewport = (width: number, height: number) => ({
     type: "SET_VIEWPORT",
     payload: {

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -23,6 +23,10 @@ export interface ISetViewportAction {
     }
 }
 
+export interface ISetLoadingCompletionAction {
+    type: "SET_LOADING_COMPLETE",
+}
+
 export interface ISetCursorScaleAction {
     type: "SET_CURSOR_SCALE",
     payload: {
@@ -232,6 +236,7 @@ export type SimpleAction =
     IHideMessageDialog |
     IHideDefinitionAction |
     IShowDefinitionAction |
+    ISetLoadingCompletionAction |
     ISetModeAction |
     ISetCursorScaleAction |
     ISetColorsAction |

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -21,6 +21,9 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
     }
 
     switch (a.type) {
+        case "SET_LOADING_COMPLETE":
+            return { ...s, 
+                      isLoading: false, }
         case "SET_VIEWPORT":
             return { ...s,
                      viewport: viewportReducer(s.viewport, a) }

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -14,6 +14,38 @@ interface IRootComponentProps {
     windowManager: WindowManager.WindowManager
 }
 
+import * as State from "./State"
+import { connect } from "react-redux"
+
+export interface IOniLoadingViewProps {
+    visible: boolean
+}
+
+export class OniLoadingView extends React.PureComponent<IOniLoadingViewProps, {}> {
+    public render(): JSX.Element {
+        if (!this.props.visible) {
+            return null
+        }
+
+        const style: React.CSSProperties = {
+            position: "absolute",
+            top: "0px",
+            left: "0px",
+            right: "0px",
+            bottom: "0px",
+            backgroundColor: "black",
+        }
+
+        return <div style={style}>LOADING</div>
+    }
+}
+
+const mapStateToProps = (state: State.IState): IOniLoadingViewProps => ({
+    visible: state.isLoading
+})
+
+export const OniLoading = connect(mapStateToProps)(OniLoadingView)
+
 export class RootComponent extends React.PureComponent<IRootComponentProps, {}> {
     public render() {
         return <div className="stack disable-mouse" onKeyDownCapture={(evt) => this._onRootKeyDown(evt)}>
@@ -35,6 +67,7 @@ export class RootComponent extends React.PureComponent<IRootComponentProps, {}> 
                     </div>
                 </div>
             </div>
+            <OniLoading />
         </div>
     }
 

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -41,6 +41,7 @@ export interface IState {
     mode: string
     backgroundColor: string
     foregroundColor: string
+    isLoading: boolean
     definition: null | IDefinition
     cursorLineOpacity: number
     cursorColumnOpacity: number
@@ -183,6 +184,7 @@ export const createDefaultState = (): IState => ({
         width: 0,
         height: 0,
     },
+    isLoading: true,
     cursorLineOpacity: 0,
     cursorColumnOpacity: 0,
     backgroundColor: "#000000",


### PR DESCRIPTION
This change formalizes the startup tasks we require on load, and ideally will improve on the UX.

This opens the door for us to move away from some of the synchronous loading, specifically:
- We should refactor config loading to be asychronous
- We should refactor plugin discovery to be asynchronous

In addition, I'd like to have a transition-in effect for the Oni UI