### PR TITLE
Fix #951: Sass support

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -101,8 +101,8 @@ const BaseConfiguration: IConfigurationValues = {
     "language.less.languageServer.command": cssLanguageServerPath,
     "language.less.languageServer.arguments": ["--stdio"],
 
-    "language.sass.languageServer.command": cssLanguageServerPath,
-    "language.sass.languageServer.arguments": ["--stdio"],
+    "language.scss.languageServer.command": cssLanguageServerPath,
+    "language.scss.languageServer.arguments": ["--stdio"],
 
     "language.reason.languageServer.command": ocamlLanguageServerPath,
     "language.reason.languageServer.arguments": ["--stdio"],


### PR DESCRIPTION
__Issue:__ Sass files (`.scss`) weren't being picked up by the bundled `css-language-server`.

__Defect:__ The filetype is `scss` instead of `sass`

__Fix:__ Use correct filetype in default configuration