### PR TITLE
Fix #957 - Remove results-caching logic in MenuReducer

### DIFF
--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -96,10 +96,8 @@ export function createReducer<T, FilteredT extends T>(filterFunc: MenuFilterFunc
                 if (!s) {
                     return s
                 }
-                // If we already had search results, and this search is a superset of the previous,
-                // just filter the already-pruned subset
-                const optionsToSearch = a.payload.filter.indexOf(s.filter) === 0 ? s.filteredOptions : s.options
-                const filteredOptionsSorted = filterFunc(optionsToSearch, a.payload.filter)
+
+                const filteredOptionsSorted = filterFunc(s.options, a.payload.filter)
 
                 return {...s,
                         filter: a.payload.filter,


### PR DESCRIPTION
__Issue:__ When typing quickly in the Menu, not all expected results are available.

__Defect:__ We had some code that uses the 'cached' results for the menu when searching. This logic worked fine in the case where we acquired all results at once, but in the 'streaming' case, we'll lose any results that come in after the first filter.

__Fix:__ Remove the caching logic, and always filter against the set of items.

The only concern I have with this fix is it might cause a degradation in performance in large directories. But we should be accurate in the results - it's hard to have confidence in a fuzzy finder that doesn't find everything... We can find an alternative fix to performance if necessary.
