### PR TITLE
Fix #882 - Handle 'javascript.jsx' filetype

### DIFF
--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -254,7 +254,15 @@ export class LanguageManager {
     }
 
     private _getLanguageClient(language: string): ILanguageClient {
-        return this._languageServerInfo[language]
+        if (!language) {
+            return null
+        }
+
+        // Fix for #882 - handle cases like `javascript.jsx` where there is
+        // some scoping to the filetype / language name
+        const normalizedLanguage = language.split(".")[0]
+
+        return this._languageServerInfo[normalizedLanguage]
     }
 
     private _setStatus(protocolMessage: string, status: LanguageClientState): void {


### PR DESCRIPTION
__Issue:__ With `vim-polyglot`, which is a popular plugin, JSX files show up as `javascript.jsx`, and no completion is available.

__Defect:__ Our built-in javascript/typescript integration expect a filetype of `typescript` or `javascript`.

__Fix:__ Disregard any `.` in the language name and grab the first part when looking for an available language server. If it turns out there are more generalized mappings that are interesting, we could add a configuration value to map filetype -> language server.