### PR TITLE
Fix issue with 'Rename' dialog disappearing

### DIFF
--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -52,7 +52,7 @@ export class BufferScrollBar extends React.PureComponent<IBufferScrollBarProps, 
                 width: "100%",
             }
 
-            return <div style={markerStyle} />
+            return <div style={markerStyle} key={m.line.toString() + m.color}/>
         })
 
         return <div className="scroll-bar-container">

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -48,12 +48,12 @@ export class StatusBar extends React.PureComponent<StatusBarProps, {}> {
         return <div className="status-bar enable-mouse" style={statusBarStyle}>
             <div className="status-bar-inner">
                 <div className="status-bar-container left">
-                    {leftItems.map((item) => <StatusBarItem {...item} />)}
+                    {leftItems.map((item) => <StatusBarItem {...item} key={item.id}/>)}
                 </div>
                 <div className="status-bar-container center">
                 </div>
                 <div className="status-bar-container right">
-                    {rightItems.map((item) => <StatusBarItem {...item} />)}
+                    {rightItems.map((item) => <StatusBarItem {...item} key={item.id}/>)}
                     <div className="status-bar-item" onClick={() => this._openGithub()}>
                         <span><i className="fa fa-github" /></span>
                     </div>

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -21,7 +21,6 @@ export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
     public render(): JSX.Element {
 
         const toolTipElements = this.props.toolTips.map((toolTip) => {
-            console.log("Rendering tooltip: " + toolTip.id)
             return <CSSTransition
                 timeout={250}
                 classNames="fade"

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -21,13 +21,15 @@ export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
     public render(): JSX.Element {
 
         const toolTipElements = this.props.toolTips.map((toolTip) => {
+            console.log("Rendering tooltip: " + toolTip.id)
             return <CSSTransition
                 timeout={250}
                 classNames="fade"
                 unmountOnExit={true}
                 exit={false}
+                key={toolTip.id}
             >
-            <ToolTipView {...toolTip} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor} key={toolTip.id}/>
+            <ToolTipView {...toolTip} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor}/>
             </CSSTransition>
         })
 
@@ -83,7 +85,7 @@ export class ToolTipView extends React.PureComponent<IToolTipViewProps, {}> {
             padding,
         }
 
-        return <CursorPositioner position={position} openDirection={openDirection} key={this.props.id}>
+        return <CursorPositioner position={position} openDirection={openDirection}>
                 <div className="tool-tip-container enable-mouse" style={toolTipStyle} ref={(elem) => this._setContainer(elem)}>
                     {this.props.element}
                 </div>

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -42,9 +42,9 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
             return null
         }
 
-        const containerStyle = {
+        const containerStyle: React.CSSProperties = {
             "display": "flex",
-            "flex-direction": "row",
+            "flexDirection": "row",
             "width": "100%",
             "height": "100%",
         }
@@ -58,7 +58,7 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
                 if (!split) {
                     return <div className="container vertical full">TODO: Implement an editor here...</div>
                 } else {
-                    return <WindowSplitHost split={split}/>
+                    return <WindowSplitHost split={split} />
                 }
             }
         })

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -58,7 +58,7 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
                 if (!split) {
                     return <div className="container vertical full">TODO: Implement an editor here...</div>
                 } else {
-                    return <WindowSplitHost split={split} />
+                    return <WindowSplitHost split={split}/>
                 }
             }
         })

--- a/vim/core/oni-core-statusbar/index.js
+++ b/vim/core/oni-core-statusbar/index.js
@@ -35,10 +35,10 @@ const activate = (Oni) => {
             width: "100%",
             height: "100%",
             display: "flex",
-            "align-items": "center",
-            "padding-left": "8px",
-            "padding-right": "8px",
-            "text-transform": "uppercase",
+            "alignItems": "center",
+            "paddingLeft": "8px",
+            "paddingRight": "8px",
+            "textTransform": "uppercase",
             color: rgb(220, 220, 220),
             backgroundColor: getColorForMode(mode)
         }


### PR DESCRIPTION
__Issue:__ The `Rename` dialog (F2, if in a file that has a language server that supports rename) disappears if the quickinfo/hover UI shows up.

__Defect:__ When a second tooltip comes up, all of the tooltips are re-rendered. The `componentWillUnmount` lifecycle event is triggered, and rename thinks it should hide. This is because the `key` property is missing, so React re-renders the whole array.

__Fix:__ Use the `key` property on the `CSSTransition` element (root of group).

Also opportunistically fixed a few other React warnings and missed keys.