### PR TITLE
Fix "Edit NeoVim config" command.

### DIFF
--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -380,7 +380,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             return this.open(loadInitVim)
         } else {
             // Use path from: https://github.com/neovim/neovim/wiki/FAQ
-            const rootFolder = Platform.isWindows() ? path.join(Platform.getUserHome(), "AppData", "Local", "nvim") : path.join(Platform.getUserHome(), ".config", "nvim")
+            const rootFolder = Platform.isWindows() ? path.join(process.env["LOCALAPPDATA"], "nvim") : path.join(Platform.getUserHome(), ".config", "nvim")
 
             mkdirp.sync(rootFolder)
             const initVimPath = path.join(rootFolder, "init.vim")

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -380,7 +380,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             return this.open(loadInitVim)
         } else {
             // Use path from: https://github.com/neovim/neovim/wiki/FAQ
-            const rootFolder = Platform.isWindows() ? path.join(process.env["LOCALAPPDATA"], "nvim") : path.join(Platform.getUserHome(), ".config", "nvim")
+            const rootFolder = Platform.isWindows() ? path.join(process.env["LOCALAPPDATA"], "nvim") : // tslint:disable-line no-string-literal
+                                                      path.join(Platform.getUserHome(), ".config", "nvim")
 
             mkdirp.sync(rootFolder)
             const initVimPath = path.join(rootFolder, "init.vim")


### PR DESCRIPTION
Looks like I broke the init.vim edit command when I updated the `getUserHome()` command for Windows.
I've updated it to use the environment variable instead now.