### PR TITLE
Build: Bring back node_modules caching in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ branches:
 
 cache:
     yarn: true
+    directories:
+        - node_modules
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 
 install:
     - npm install -g yarn
-    - yarn install --verbose
+    - yarn install
 
 script:
     - ./build/script/travis-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 
 install:
     - npm install -g yarn
-    - yarn install
+    - yarn install --verbose
 
 script:
     - ./build/script/travis-build.sh

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
     "ocaml-language-server": "1.0.12",
-    "oni-neovim-binaries": "^0.0.7",
+    "oni-neovim-binaries": "0.0.8",
     "oni-ripgrep": "0.0.3",
     "typescript": "2.5.3",
     "vscode-jsonrpc": "3.5.0",


### PR DESCRIPTION
Hopefully, this can help alleviate the failures we see on TravisCI machines - where we fail to download the `oni-neovim-binaries`.