### PR TITLE
[WIP] #956 - Fix autocompletion oddities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ $RECYCLE.BIN/
 
 # OCaml / Reason
 .merlin
+
+yarn.lock

--- a/browser/src/Services/ContextMenu/ContextMenu.less
+++ b/browser/src/Services/ContextMenu/ContextMenu.less
@@ -11,7 +11,8 @@
 
     .entry {
         &.selected {
-            .box-shadow;
+            transform: translateY(0.1px);
+            box-shadow: 0 1px 8px 1px rgba(0, 0, 0, 0.2), 0 1px 20px 0 rgba(0, 0, 0, 0.19);
 
             .main {
                 opacity: 1;

--- a/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
@@ -51,7 +51,7 @@ export class ContextMenuView extends React.PureComponent<IContextMenuProps, {}> 
         const entries = firstTenEntries.map((s, i) => {
             const isSelected = i === this.props.selectedIndex
 
-            return <ContextMenuItem {...s} isSelected={isSelected} base={this.props.base} highlightColor={highlightColor}/>
+            return <ContextMenuItem {...s} isSelected={isSelected} base={this.props.base} highlightColor={highlightColor} key={s.label}/>
         })
 
         const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)

--- a/browser/src/Services/Language/Completion/Completion.ts
+++ b/browser/src/Services/Language/Completion/Completion.ts
@@ -35,6 +35,8 @@ export interface ICompletionResults {
     meetPosition: number
 }
 
+import { createStore } from "./CompletionStore"
+
 export const initCompletionUI = (latestCursorAndBufferInfo$: Observable<ILatestCursorAndBufferInfo>, modeChanged$: Observable<Oni.Vim.Mode>) => {
 
     // Observable that gets full completion context (cursor positon + meet info)

--- a/browser/src/Services/Language/Completion/CompletionMenu.ts
+++ b/browser/src/Services/Language/Completion/CompletionMenu.ts
@@ -25,6 +25,13 @@ export const createContextMenu = (store: Store<ICompletionState>) => {
         render(store.getState())
     })
 
+    completionContextMenu2.onSelectedItemChanged.subscribe((completionItem: types.Command) => {
+        store.dispatch({
+            type: "SELECT_ITEM",
+            completionItem,
+        })
+    })
+
     completionContextMenu2.onItemSelected.subscribe((completionItem: types.CompletionItem) => {
 
         const state = store.getState()
@@ -45,7 +52,11 @@ export const render = (state: ICompletionState): void => {
     const filteredCompletions = getFilteredCompletions(state)
 
     if (filteredCompletions && filteredCompletions.length) {
-        completionContextMenu2.show(filteredCompletions, state.meetInfo.meetBase)
+        if (completionContextMenu2.isOpen()) {
+            completionContextMenu2.setItems(filteredCompletions)
+        } else {
+            completionContextMenu2.show(filteredCompletions, state.meetInfo.meetBase)
+        }
     } else {
         completionContextMenu2.hide()
     }

--- a/browser/src/Services/Language/Completion/CompletionMenu.ts
+++ b/browser/src/Services/Language/Completion/CompletionMenu.ts
@@ -2,25 +2,43 @@
  * Completion.ts
  */
 
-import "rxjs/add/observable/combineLatest"
-import "rxjs/add/operator/withLatestFrom"
-import { Observable } from "rxjs/Observable"
-
 import * as types from "vscode-languageserver-types"
 
 import { contextMenuManager } from "./../../ContextMenu"
-import { editorManager } from "./../../EditorManager"
 
-import * as CompletionUtility from "./CompletionUtility"
-
-import { ICompletionMeetInfo, IResolvedCompletions, resolveCompletionItem } from "./Completion"
+import { resolveCompletionItem } from "./Completion"
 
 import { ICompletionState } from "./CompletionStore"
+
+import { Store } from "redux"
 
 // TODO: Factor into closure
 const completionContextMenu2 = contextMenuManager.create()
 
 import { getFilteredCompletions } from "./CompletionSelectors"
+
+import * as CompletionUtility from "./CompletionUtility"
+
+export const createContextMenu = (store: Store<ICompletionState>) => {
+
+    store.subscribe(() => {
+        render(store.getState())
+    })
+
+    completionContextMenu2.onItemSelected.subscribe((completionItem: types.CompletionItem) => {
+
+        const state = store.getState()
+
+        store.dispatch({
+            type: "COMMIT_COMPLETION",
+            meetLine: state.meetInfo.meetLine,
+            meetPosition: state.meetInfo.meetPosition,
+            completionText: CompletionUtility.getInsertText(completionItem)
+        })
+
+    })
+
+}
 
 export const render = (state: ICompletionState): void => {
 
@@ -34,81 +52,81 @@ export const render = (state: ICompletionState): void => {
 
 }
 
-export const createCompletionMenu = (completionMeet$: Observable<ICompletionMeetInfo>, completion$: Observable<IResolvedCompletions>, modeChanged$: Observable<Oni.Vim.Mode>): void => {
+//export const createCompletionMenu = (completionMeet$: Observable<ICompletionMeetInfo>, completion$: Observable<IResolvedCompletions>, modeChanged$: Observable<Oni.Vim.Mode>): void => {
 
-    const completionContextMenu = contextMenuManager.create()
+//    const completionContextMenu = contextMenuManager.create()
 
-    let lastCompletedMeet: ICompletionMeetInfo = null
-    let lastSelection: string = null
+//    let lastCompletedMeet: ICompletionMeetInfo = null
+//    let lastSelection: string = null
 
-    // Handle menu completion
-    const completionMenuItemSelected$ = completionContextMenu.onItemSelected.asObservable()
-    completionMenuItemSelected$
-        .withLatestFrom(completionMeet$)
-        .subscribe((args: [any, ICompletionMeetInfo]) => {
-            const [completionItem, lastMeet] = args
+//    // Handle menu completion
+//    const completionMenuItemSelected$ = completionContextMenu.onItemSelected.asObservable()
+//    completionMenuItemSelected$
+//        .withLatestFrom(completionMeet$)
+//        .subscribe((args: [any, ICompletionMeetInfo]) => {
+//            const [completionItem, lastMeet] = args
 
-            if (lastMeet) {
-                const insertText = CompletionUtility.getInsertText(completionItem)
-                commitCompletion(lastMeet.meetLine, lastMeet.meetPosition, insertText)
+//            if (lastMeet) {
+//                const insertText = CompletionUtility.getInsertText(completionItem)
+//                commitCompletion(lastMeet.meetLine, lastMeet.meetPosition, insertText)
 
-                lastCompletedMeet = lastMeet
-                lastSelection = insertText
-                completionContextMenu.hide()
-            }
-        })
+//                lastCompletedMeet = lastMeet
+//                lastSelection = insertText
+//                completionContextMenu.hide()
+//            }
+//        })
 
-    // Handle menu selection
-    const completionMenuSelectedItemChanged$ = completionContextMenu.onSelectedItemChanged.asObservable()
-    completionMenuSelectedItemChanged$
-        .withLatestFrom(completionMeet$)
-        .subscribe(async (args: [any, ICompletionMeetInfo]) => {
-            const [newItem, lastMeet] = args
+//    // Handle menu selection
+//    const completionMenuSelectedItemChanged$ = completionContextMenu.onSelectedItemChanged.asObservable()
+//    completionMenuSelectedItemChanged$
+//        .withLatestFrom(completionMeet$)
+//        .subscribe(async (args: [any, ICompletionMeetInfo]) => {
+//            const [newItem, lastMeet] = args
 
-            await updateCompletionItemDetails(completionContextMenu, lastMeet.language, lastMeet.filePath, newItem.rawCompletion)
-        })
+//            await updateCompletionItemDetails(completionContextMenu, lastMeet.language, lastMeet.filePath, newItem.rawCompletion)
+//        })
 
-    completion$
-        .combineLatest(modeChanged$)
-        .subscribe((result: [IResolvedCompletions, Oni.Vim.Mode]) => {
+//    completion$
+//        .combineLatest(modeChanged$)
+//        .subscribe((result: [IResolvedCompletions, Oni.Vim.Mode]) => {
 
-                const [completions, mode] = result
+//                const [completions, mode] = result
 
-                if (!completions || !completions.completions || !completions.completions.length) {
-                    completionContextMenu.hide()
-                    return
-                }
+//                if (!completions || !completions.completions || !completions.completions.length) {
+//                    completionContextMenu.hide()
+//                    return
+//                }
 
-                // If we're switching from insert mode,
-                // clear out completion state and hide menu
-                if (mode !== "insert") {
-                    lastCompletedMeet = null
-                    lastSelection = null
-                    completionContextMenu.hide()
-                    return
-                }
+//                // If we're switching from insert mode,
+//                // clear out completion state and hide menu
+//                if (mode !== "insert") {
+//                    lastCompletedMeet = null
+//                    lastSelection = null
+//                    completionContextMenu.hide()
+//                    return
+//                }
 
-                const meetInfo = completions.meetInfo
+//                const meetInfo = completions.meetInfo
 
-                // If we're trying to complete the same item
-                // we completed before, from the same spot,
-                // hide the menu.
-                //
-                // This helps the case where we accepted a shorter completion,
-                // but there are potential longer completions. Without this logic,
-                // we'd still keep the completion menu pu
-                if (lastCompletedMeet !== null
-                    && lastCompletedMeet.meetLine === meetInfo.meetLine
-                    && lastCompletedMeet.meetPosition === meetInfo.meetPosition
-                    && lastSelection === meetInfo.meetBase) {
-                        completionContextMenu.hide()
-                        return
-                    }
+//                // If we're trying to complete the same item
+//                // we completed before, from the same spot,
+//                // hide the menu.
+//                //
+//                // This helps the case where we accepted a shorter completion,
+//                // but there are potential longer completions. Without this logic,
+//                // we'd still keep the completion menu pu
+//                if (lastCompletedMeet !== null
+//                    && lastCompletedMeet.meetLine === meetInfo.meetLine
+//                    && lastCompletedMeet.meetPosition === meetInfo.meetPosition
+//                    && lastSelection === meetInfo.meetBase) {
+//                        completionContextMenu.hide()
+//                        return
+//                    }
 
-                completionContextMenu.show(completions.completions,  meetInfo.meetBase)
-                updateCompletionItemDetails(completionContextMenu, meetInfo.language, meetInfo.filePath, completions.completions[0])
-        })
-}
+//                completionContextMenu.show(completions.completions,  meetInfo.meetBase)
+//                updateCompletionItemDetails(completionContextMenu, meetInfo.language, meetInfo.filePath, completions.completions[0])
+//        })
+//}
 
 let lastDetailsRequestInfo: { label: string, result: types.CompletionItem } = { label: null, result: null }
 
@@ -129,22 +147,4 @@ export const updateCompletionItemDetails = async (menu: any, language: string, f
     if (result) {
         menu.updateItem(result)
     }
-}
-
-export const commitCompletion = async (line: number, base: number, completion: string) => {
-    const buffer = editorManager.activeEditor.activeBuffer
-    const currentLines = await buffer.getLines(line, line + 1)
-
-    const column = buffer.cursor.column
-
-    if (!currentLines || !currentLines.length) {
-        return
-    }
-
-    const originalLine = currentLines[0]
-
-    const newLine = CompletionUtility.replacePrefixWithCompletion(originalLine, base, column, completion)
-    await buffer.setLines(line, line + 1, [newLine])
-    const cursorOffset = newLine.length - originalLine.length
-    await buffer.setCursorPosition(line, column + cursorOffset)
 }

--- a/browser/src/Services/Language/Completion/CompletionMenu.ts
+++ b/browser/src/Services/Language/Completion/CompletionMenu.ts
@@ -15,6 +15,25 @@ import * as CompletionUtility from "./CompletionUtility"
 
 import { ICompletionMeetInfo, IResolvedCompletions, resolveCompletionItem } from "./Completion"
 
+import { ICompletionState } from "./CompletionStore"
+
+// TODO: Factor into closure
+const completionContextMenu2 = contextMenuManager.create()
+
+import { getFilteredCompletions } from "./CompletionSelectors"
+
+export const render = (state: ICompletionState): void => {
+
+    const filteredCompletions = getFilteredCompletions(state)
+
+    if (filteredCompletions && filteredCompletions.length) {
+        completionContextMenu2.show(filteredCompletions, state.meetInfo.meetBase)
+    } else {
+        completionContextMenu2.hide()
+    }
+
+}
+
 export const createCompletionMenu = (completionMeet$: Observable<ICompletionMeetInfo>, completion$: Observable<IResolvedCompletions>, modeChanged$: Observable<Oni.Vim.Mode>): void => {
 
     const completionContextMenu = contextMenuManager.create()

--- a/browser/src/Services/Language/Completion/CompletionSelectors.ts
+++ b/browser/src/Services/Language/Completion/CompletionSelectors.ts
@@ -1,0 +1,58 @@
+/**
+ * CompletionSelectors.ts
+ *
+ * Selectors are functions that take a state and derive a value from it.
+ */
+
+import { ICompletionState } from "./CompletionStore"
+
+import * as types from "vscode-languageserver-types"
+
+export const getFilteredCompletions = (state: ICompletionState): types.CompletionItem[] => {
+
+    if (!state.completionResults.completions || !state.completionResults.completions.length) {
+        return []
+    }
+
+    if (!state.meetInfo.shouldExpand) {
+        return []
+    }
+
+    if (state.meetInfo.meetLine !== state.completionResults.meetLine
+        || state.meetInfo.meetPosition !== state.completionResults.meetPosition) {
+            return []
+        }
+
+    const completions = state.completionResults.completions
+
+    const filteredCompletions = filterCompletionOptions(completions, state.meetInfo.meetBase)
+    return filteredCompletions
+}
+
+export const filterCompletionOptions = (items: types.CompletionItem[], searchText: string): types.CompletionItem[] => {
+    if (!searchText) {
+        return items
+    }
+
+    if (!items || !items.length) {
+        return null
+    }
+
+    const filterRegEx = new RegExp("^" + searchText.split("").join(".*") + ".*")
+
+    const filteredOptions = items.filter((f) => {
+        const textToFilterOn = f.filterText || f.label
+        return textToFilterOn.match(filterRegEx)
+    })
+
+    return filteredOptions.sort((itemA, itemB) => {
+
+        const itemAFilterText = itemA.filterText || itemA.label
+        const itemBFilterText = itemB.filterText || itemB.label
+
+        const indexOfA = itemAFilterText.indexOf((searchText))
+        const indexOfB = itemBFilterText.indexOf((searchText))
+
+        return indexOfB - indexOfA
+    })
+}

--- a/browser/src/Services/Language/Completion/CompletionStore.ts
+++ b/browser/src/Services/Language/Completion/CompletionStore.ts
@@ -1,0 +1,106 @@
+/**
+ * CompletionStore.ts
+ */
+
+import * as types from "vscode-languageserver-types"
+
+import { combineReducers, createStore as reduxCreateStore, Reducer, Store } from "redux"
+
+export interface ICompletionMeetInfo {
+    meetLine: number
+    meetPosition: number
+    queryPosition: number
+    meetBase: string
+    shouldExpand: boolean
+}
+
+const DefaultMeetInfo: ICompletionMeetInfo = {
+    meetLine: -1,
+    meetPosition: -1,
+    queryPosition: -1,
+    meetBase: "",
+    shouldExpand: false,
+}
+
+export interface ICompletionBufferInfo {
+    language: string
+    filePath: string
+}
+
+export interface ICompletionResults {
+    completions: types.CompletionItem[]
+    meetLine: number
+    meetPosition: number
+}
+
+const DefaultCompletionResults: ICompletionResults = {
+    completions: [],
+    meetLine: -1
+    meetPosition: -1,
+}
+
+export interface ICompletionState {
+    bufferInfo: ICompletionBufferInfo
+    meetInfo: ICompletionMeetInfo
+    completionResults: ICompletionResults
+}
+
+export type CompletionAction = {
+    type: "MODE_CHANGED",
+    mode: string
+} | {
+    type: "BUFFER_CHANGED",
+    language: string
+    filePath: string,
+} | {
+    type: "CURRENT_MEET_CHANGED",
+    currentMeet: ICompletionMeetInfo
+} | {
+    type: "GET_COMPLETIONS_START"
+} | {
+    type: "GET_COMPLETIONS_FINISH"
+    meetLine: number
+    meetPosition: number
+    completions: types.CompletionItem[]
+} | {
+    type: "SELECT_ITEM",
+    completionItem: types.CompletionItem
+} | {
+    type: "GET_COMPLETION_ITEM_DETAILS_START"
+    completionItem: types.CompletionItem
+} | {
+    type: "GET_COMPLETION_ITEM_DETAILS_FINISH"
+    completionItemWithDetails: types.CompletionItem
+}
+
+const bufferInfoReducer: Reducer<ICompletionBufferInfo> = (
+    state: ICompletionBufferInfo = {
+        language: null,
+        filePath: null
+    }, action: CompletionAction
+) => {
+    return state
+}
+
+const meetInfoReducer: Reducer<ICompletionMeetInfo> = (
+    state: ICompletionMeetInfo = DefaultMeetInfo,
+    action: CompletionAction
+) => {
+    return state
+}
+
+export const completionResultsReducer: Reducer<ICompletionResults> = (
+    state: ICompletionResults = DefaultCompletionResults,
+    action: CompletionAction
+) => {
+    return state
+}
+
+export const createStore = (): Store<ICompletionState> => {
+    return reduxCreateStore(
+        combineReducers<ICompletionState>({
+            bufferInfo: bufferInfoReducer,
+            meetInfo: meetInfoReducer,
+            completionResults: completionResultsReducer,
+        }))
+}

--- a/browser/src/Services/Language/Completion/CompletionStore.ts
+++ b/browser/src/Services/Language/Completion/CompletionStore.ts
@@ -161,6 +161,17 @@ export const completionResultsReducer: Reducer<ICompletionResults> = (
                 meetPosition: action.meetPosition,
                 completions: action.completions,
             }
+        case "GET_COMPLETION_ITEM_DETAILS_RESULT":
+            return {
+                ...state,
+                completions: state.completions.map((completion) => {
+                    if (completion.label === action.completionItemWithDetails.label) {
+                        return action.completionItemWithDetails
+                    } else {
+                        return completion
+                    }
+                }),
+        }
         default:
             return state
     }

--- a/browser/src/Services/Language/Completion/CompletionStore.ts
+++ b/browser/src/Services/Language/Completion/CompletionStore.ts
@@ -4,7 +4,16 @@
 
 import * as types from "vscode-languageserver-types"
 
-import { combineReducers, createStore as reduxCreateStore, Reducer, Store } from "redux"
+import { Observable } from "rxjs/Observable"
+import "rxjs/add/operator/mergeMap"
+
+import { applyMiddleware, combineReducers, createStore as reduxCreateStore, Reducer, Store } from "redux"
+import { combineEpics, createEpicMiddleware, Epic } from "redux-observable"
+
+import * as CompletionUtility from "./CompletionUtility"
+import { languageManager } from "./../LanguageManager"
+
+import { getCompletions } from "./Completion"
 
 export interface ICompletionMeetInfo {
     meetLine: number
@@ -35,30 +44,49 @@ export interface ICompletionResults {
 
 const DefaultCompletionResults: ICompletionResults = {
     completions: [],
-    meetLine: -1
+    meetLine: -1,
     meetPosition: -1,
 }
 
+export interface ICursorInfo {
+    line: number
+    column: number
+    lineContents: string
+}
+
+const DefaultCursorInfo: ICursorInfo = {
+    line: -1,
+    column: -1,
+    lineContents: "",
+}
+
 export interface ICompletionState {
+    enabled: boolean
+    cursorInfo: ICursorInfo
     bufferInfo: ICompletionBufferInfo
     meetInfo: ICompletionMeetInfo
     completionResults: ICompletionResults
 }
 
 export type CompletionAction = {
+    type: "CURSOR_MOVED",
+    line: number,
+    column: number
+    lineContents: string
+} | {
     type: "MODE_CHANGED",
     mode: string
 } | {
-    type: "BUFFER_CHANGED",
+    type: "BUFFER_ENTER",
     language: string
     filePath: string,
 } | {
-    type: "CURRENT_MEET_CHANGED",
+    type: "COMMIT_COMPLETION"
+} | {
+    type: "MEET_CHANGED",
     currentMeet: ICompletionMeetInfo
 } | {
-    type: "GET_COMPLETIONS_START"
-} | {
-    type: "GET_COMPLETIONS_FINISH"
+    type: "GET_COMPLETIONS_RESULT"
     meetLine: number
     meetPosition: number
     completions: types.CompletionItem[]
@@ -66,10 +94,7 @@ export type CompletionAction = {
     type: "SELECT_ITEM",
     completionItem: types.CompletionItem
 } | {
-    type: "GET_COMPLETION_ITEM_DETAILS_START"
-    completionItem: types.CompletionItem
-} | {
-    type: "GET_COMPLETION_ITEM_DETAILS_FINISH"
+    type: "GET_COMPLETION_ITEM_DETAILS_RESULT"
     completionItemWithDetails: types.CompletionItem
 }
 
@@ -79,28 +104,172 @@ const bufferInfoReducer: Reducer<ICompletionBufferInfo> = (
         filePath: null
     }, action: CompletionAction
 ) => {
-    return state
+    switch (action.type) {
+        case "BUFFER_ENTER":
+            return {
+                language: action.language,
+                filePath: action.filePath,
+            }
+        default:
+            return state
+    }
 }
 
 const meetInfoReducer: Reducer<ICompletionMeetInfo> = (
     state: ICompletionMeetInfo = DefaultMeetInfo,
     action: CompletionAction
 ) => {
-    return state
+    switch (action.type) {
+        case "MEET_CHANGED":
+            return {
+                ...action.currentMeet,
+            }
+        default:
+            return state
+    }
 }
 
 export const completionResultsReducer: Reducer<ICompletionResults> = (
     state: ICompletionResults = DefaultCompletionResults,
     action: CompletionAction
 ) => {
+    switch (action.type) {
+        case "MODE_CHANGED":
+        case "BUFFER_ENTER":
+            return DefaultCompletionResults
+        case "GET_COMPLETIONS_RESULT":
+            return {
+                meetLine: action.meetLine,
+                meetPosition: action.meetPosition,
+                completions: action.completions,
+            }
+        default:
+            return state
+    }
+}
+
+export const cursorInfoReducer: Reducer<ICursorInfo> = (
+    state: ICursorInfo = DefaultCursorInfo,
+    action: CompletionAction
+) => {
     return state
 }
+
+export const enabledReducer: Reducer<boolean> = (
+    state: boolean = false,
+    action: CompletionAction
+) => {
+    switch(action.type) {
+        case "MODE_CHANGED":
+            return action.mode === "insert"
+        default:
+            return state
+    }
+}
+
+const nullAction = { type: null } as CompletionAction
+
+const getCompletionMeetEpic: Epic<CompletionAction, ICompletionState> = (action$, store) =>
+    action$.ofType("CURSOR_MOVED")
+        .map((action: CompletionAction) => {
+            const currentState: ICompletionState = store.getState()
+
+            if (action.type !== "CURSOR_MOVED") {
+                return nullAction
+            }
+
+            if (!currentState.enabled) {
+                return nullAction
+            }
+
+            if (!currentState.bufferInfo || !currentState.bufferInfo.language) {
+                return nullAction
+            }
+
+            const {bufferInfo }= currentState
+
+            const token = languageManager.getTokenRegex(bufferInfo.language)
+            const completionCharacters = languageManager.getCompletionTriggerCharacters(bufferInfo.language)
+
+            const meet = CompletionUtility.getCompletionMeet(action.lineContents, action.column, token, completionCharacters)
+
+            const meetForAction: ICompletionMeetInfo = {
+                meetPosition: meet.position,
+                meetLine: action.line,
+                queryPosition: meet.positionToQuery,
+                meetBase: meet.base,
+                shouldExpand: meet.shouldExpandCompletions
+            }
+
+            console.log("DISPATCHING MEET_CHANGED")
+
+            return {
+                type: "MEET_CHANGED",
+                currentMeet: meetForAction
+            } as CompletionAction
+        })
+
+const getCompletionsEpic: Epic<CompletionAction, ICompletionState> = (action$, store) => 
+    action$.ofType("MEET_CHANGED")
+        .filter(() => store.getState().enabled)
+        .filter((action) => {
+            const state = store.getState()
+
+            if (action.type !== "MEET_CHANGED") {
+                return false
+            }
+
+            if (!action.currentMeet.shouldExpand) {
+                return false
+            }
+
+            if (action.currentMeet.meetLine === state.completionResults.meetLine
+                && action.currentMeet.meetPosition === state.completionResults.meetPosition) {
+                    return false
+            }
+
+            return true
+        })
+        .mergeMap((action: CompletionAction): Observable<CompletionAction> => {
+
+            const state = store.getState()
+
+            // Helper to let TypeScript know that we can assume this is 'MEET_CHANGED'...
+            if (action.type !== "MEET_CHANGED") {
+                return Observable.of(nullAction)
+            }
+
+            // Check if the meet is different from the last meet we queried
+            const requestResult: Observable<types.CompletionItem[]> = Observable.defer(async () => {
+                const results = await getCompletions(state.bufferInfo.language, state.bufferInfo.filePath, action.currentMeet.meetLine, action.currentMeet.queryPosition)
+                const completions = results || []
+                return completions
+
+            })
+
+            const ret = requestResult.map((completions) => {
+                console.log("Got completions: " + completions.length)
+                return {
+                    type: "GET_COMPLETIONS_RESULT",
+                    meetLine: action.currentMeet.meetLine,
+                    meetPosition: action.currentMeet.meetPosition,
+                    completions,
+                } as CompletionAction
+            })
+
+            return ret
+        })
 
 export const createStore = (): Store<ICompletionState> => {
     return reduxCreateStore(
         combineReducers<ICompletionState>({
+            enabled: enabledReducer,
             bufferInfo: bufferInfoReducer,
             meetInfo: meetInfoReducer,
             completionResults: completionResultsReducer,
-        }))
+        }),
+        applyMiddleware(createEpicMiddleware(combineEpics(
+            getCompletionMeetEpic,
+            getCompletionsEpic,
+        ))))
 }

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "react-redux": "5.0.6",
     "react-transition-group": "2.2.1",
     "redux": "3.7.2",
+    "redux-observable": "0.17.0",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
     "rimraf": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4926,6 +4926,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-observable@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.17.0.tgz#23e29e3f3c39204b7ed6a14b67a29e317c03106b"
+
 redux-thunk@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"


### PR DESCRIPTION
This a refactoring of the completion code, to use `redux-observable` and split out the _synchronous_ state changes (via redux reducers) from the _asynchronous_ operations in the form of `Epics`.

This will hopefully be easier to maintain, as it was hard to reason about how all the observable streams coalesced in the previous round... In this case, at least every operation is defined as a `CompletionAction`, and would be visible through the redux-devtools - and the state of the completion popup is completely dependent on the `ICompletionState`, so at least there is a more concrete data flow.

This is a WIP to opportunistically refactor that code, as well as address the 2 issues brought up in #956 . 

Completion needs to be fast and solid for users to trust it and leverage it in their day-to-day workflow.