### PR TITLE
Add native tab option

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -130,7 +130,7 @@ const BaseConfiguration: IConfigurationValues = {
     "statusbar.fontSize": "0.9em",
 
     "tabs.enabled": true,
-    "tabs.showVimTabs": false,
+    "tabs.mode": "buffers",
     "tabs.height": "2.5em",
     "tabs.maxWidth": "30em",
     "tabs.wrap": false,

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -129,7 +129,6 @@ const BaseConfiguration: IConfigurationValues = {
     "statusbar.enabled": true,
     "statusbar.fontSize": "0.9em",
 
-    "tabs.enabled": true,
     "tabs.mode": "buffers",
     "tabs.height": "2.5em",
     "tabs.maxWidth": "30em",

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -151,7 +151,6 @@ export interface IConfigurationValues {
     "statusbar.enabled": boolean
     "statusbar.fontSize": string
 
-    "tabs.enabled": boolean
     "tabs.mode": string
 
     // Height of individual tabs in the tab strip

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -152,7 +152,7 @@ export interface IConfigurationValues {
     "statusbar.fontSize": string
 
     "tabs.enabled": boolean
-    "tabs.showVimTabs": boolean
+    "tabs.showVimTabs": boolean | string
 
     // Height of individual tabs in the tab strip
     "tabs.height": string

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -152,7 +152,7 @@ export interface IConfigurationValues {
     "statusbar.fontSize": string
 
     "tabs.enabled": boolean
-    "tabs.showVimTabs": boolean | string
+    "tabs.mode": string
 
     // Height of individual tabs in the tab strip
     "tabs.height": string

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -186,7 +186,7 @@ const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITa
     const shouldUseVimTabs = state.configuration["tabs.showVimTabs"]
     const tabs = shouldUseVimTabs ? getTabsFromVimTabs(state) : getTabsFromBuffers(state)
 
-    const visible = state.configuration["tabs.enabled"]
+    const visible = state.configuration["tabs.enabled"] && shouldUseVimTabs !== "native"
 
     const height = state.configuration["tabs.height"]
     const maxWidth = state.configuration["tabs.maxWidth"]

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -184,12 +184,11 @@ const getTabsFromVimTabs = createSelector(
 const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITabsProps => {
 
     const oniTabMode = state.configuration["tabs.mode"]
-    const oniTabsEnabled = state.configuration["tabs.enabled"]
-
     const shouldUseVimTabs = oniTabMode === "tabs"
+
     const tabs = shouldUseVimTabs ? getTabsFromVimTabs(state) : getTabsFromBuffers(state)
 
-    const visible = oniTabsEnabled && oniTabMode !== "native"
+    const visible = oniTabMode !== "native" && oniTabMode !== "hidden"
 
     const height = state.configuration["tabs.height"]
     const maxWidth = state.configuration["tabs.maxWidth"]

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -183,10 +183,13 @@ const getTabsFromVimTabs = createSelector(
 
 const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITabsProps => {
 
-    const shouldUseVimTabs = state.configuration["tabs.showVimTabs"]
+    const oniTabMode = state.configuration["tabs.mode"]
+    const oniTabsEnabled = state.configuration["tabs.enabled"]
+
+    const shouldUseVimTabs = oniTabMode === "tabs"
     const tabs = shouldUseVimTabs ? getTabsFromVimTabs(state) : getTabsFromBuffers(state)
 
-    const visible = state.configuration["tabs.enabled"] && shouldUseVimTabs !== "native"
+    const visible = oniTabsEnabled && oniTabMode !== "native"
 
     const height = state.configuration["tabs.height"]
     const maxWidth = state.configuration["tabs.maxWidth"]

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -628,19 +628,24 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private async _attachUI(columns: number, rows: number): Promise<void> {
         const version = await this.getApiVersion()
+        const externaliseTabline = configuration.getValue("tabs.showVimTabs") !== "native" ||
+                                   configuration.getValue("tabs.enabled") === false
         console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console
 
-        const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor, version.patch)
+        const startupOptions = this._getStartupOptionsForVersion(version.major,
+                                                                 version.minor,
+                                                                 version.patch,
+                                                                 externaliseTabline)
 
         await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])
     }
 
-    private _getStartupOptionsForVersion(major: number, minor: number, patch: number) {
+    private _getStartupOptionsForVersion(major: number, minor: number, patch: number, shouldExtTabs: boolean) {
         if (major >= 0 && minor >= 2 && patch >= 1) {
             return {
                 rgb: true,
                 popupmenu_external: true,
-                ext_tabline: true,
+                ext_tabline: shouldExtTabs,
             }
         } else if (major === 0 && minor === 2) {
             // 0.1 and below does not support external tabline

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -628,8 +628,12 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private async _attachUI(columns: number, rows: number): Promise<void> {
         const version = await this.getApiVersion()
-        const externaliseTabline = configuration.getValue("tabs.showVimTabs") !== "native" ||
-                                   configuration.getValue("tabs.enabled") === false
+
+        const useNativeTabs = configuration.getValue("tabs.showVimTabs") === "native"
+        const oniTabsEnabled = configuration.getValue("tabs.enabled")
+
+        const externaliseTabline = oniTabsEnabled && !useNativeTabs
+
         console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console
 
         const startupOptions = this._getStartupOptionsForVersion(version.major,

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -629,7 +629,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private async _attachUI(columns: number, rows: number): Promise<void> {
         const version = await this.getApiVersion()
 
-        const useNativeTabs = configuration.getValue("tabs.showVimTabs") === "native"
+        const useNativeTabs = configuration.getValue("tabs.mode") === "native"
         const oniTabsEnabled = configuration.getValue("tabs.enabled")
 
         const externaliseTabline = oniTabsEnabled && !useNativeTabs

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -630,9 +630,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         const version = await this.getApiVersion()
 
         const useNativeTabs = configuration.getValue("tabs.mode") === "native"
-        const oniTabsEnabled = configuration.getValue("tabs.enabled")
 
-        const externaliseTabline = oniTabsEnabled && !useNativeTabs
+        const externaliseTabline = !useNativeTabs
 
         console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console
 


### PR DESCRIPTION
Adds a native tab option, to render vim tabs instead of Oni tabs, as well as fixing the `tabs.enabled` option. 
A partial fix for #977. Next Oni needs to be able to check the modification status of all buffers in a tab and show a dirty state if any are modified.

Whilst this works, if the user changes to "native" they will lose their tabs, and need to reload Oni to see the native tabs, which is because we pass the command when we start communicating with neovim. This means the user must restart for this to take place, and they are left in an awkward state until then. I'm not sure what the best way to deal with that is though...