### PR TITLE
Fix #990 - Two <ESC> key presses required to go to normal mode w/ completion menu up

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -14,6 +14,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
 
     const isVisualMode = () => editors.activeEditor.mode === "visual"
     const isNormalMode = () => editors.activeEditor.mode === "normal"
+    const isNotInsertMode = () => editors.activeEditor.mode !== "insert"
     const isInsertOrCommandMode = () => editors.activeEditor.mode === "insert" || editors.activeEditor.mode === "cmdline_normal"
 
     const isMenuOpen = () => menu.isMenuOpen()
@@ -67,7 +68,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     input.bind(["<enter>", "<tab>"], "contextMenu.select")
     input.bind(["<down>", "<C-n>"], "contextMenu.next")
     input.bind(["<up>", "<C-p>"], "contextMenu.previous")
-    input.bind(["<esc>"], "contextMenu.close")
+    input.bind(["<esc>"], "contextMenu.close", isNotInsertMode /* In insert mode, the mode change will close the popupmenu anyway */)
 
     // Menu
     input.bind(["<down>", "<C-n>"], "menu.next")


### PR DESCRIPTION
__Issue:__ When the completion menu is open, it takes two `<esc>` key presses to dismiss it and go to normal mode. This is problematic because you need to know to use a different set of key presses to get back to normal mode, depending on whether the menu is up - it can be especially disorienting if you press `<esc>` just as it is opening.

__Fix:__ In insert mode, we don't need an explicit mapping - switching mode will close the completion menu.

> Note: There are still some separate issues tracked by #956 (#972)