### PR TITLE
Fix a few language server regressions after upgrading to TypeScript 2.6

### DIFF
--- a/vim/core/oni-plugin-typescript/src/Definition.ts
+++ b/vim/core/oni-plugin-typescript/src/Definition.ts
@@ -25,6 +25,10 @@ export const getDefinition = (oni: Oni.Plugin.Api, host: TypeScriptServerHost) =
 
     const resultPos = val[0]
 
+    if (!resultPos) {
+        return null
+    }
+
     const range = types.Range.create(resultPos.start.line - 1, resultPos.start.offset - 1, resultPos.end.line - 1, resultPos.end.offset - 1)
 
     return {

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -20,6 +20,8 @@ export class TypeScriptServerHost extends events.EventEmitter {
     private _seqToPromises = {}
     private _rl: any
 
+    private _openedFiles: string[] = []
+
     public get pid(): number {
         return this._tssProcess.pid
     }
@@ -71,9 +73,17 @@ export class TypeScriptServerHost extends events.EventEmitter {
         })
     }
 
-    public openFile(file: string): Promise<any> {
+    public async openFile(file: string, text?: string): Promise<any> {
+
+        if (this._openedFiles.indexOf(file) >= 0 ){
+            return
+        }
+
+        this._openedFiles.push(file)
+
         return this._makeTssRequest("open", {
             file,
+            fileContent: text,
         })
     }
 
@@ -141,10 +151,15 @@ export class TypeScriptServerHost extends events.EventEmitter {
                                         endOffset})
     }
 
-    public updateFile(file: string, fileContent: string): Promise<void> {
-        return this._makeTssRequest<void>("open", {
+    public  updateFile(file: string, fileContent: string): Promise<void> {
+        const totalLines = fileContent.split(os.EOL)
+        return this._makeTssRequest<void>("change", {
             file,
-            fileContent,
+            line: 1,
+            offset: 1,
+            endLine: totalLines.length + 1,
+            endOffset: 1,
+            insertString: fileContent,
         })
     }
 

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -75,7 +75,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
 
     public async openFile(file: string, text?: string): Promise<any> {
 
-        if (this._openedFiles.indexOf(file) >= 0 ){
+        if (this._openedFiles.indexOf(file) >= 0) {
             return
         }
 

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -51,7 +51,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
         })
 
         this._tssProcess.stderr.on("data", (data, err) => {
-            console.error("Error from tss: " + data) // tslint:disable-line no-console
+            console.warn("Error from tss: " + data) // tslint:disable-line no-console
         })
 
         this._tssProcess.on("error", (data) => {

--- a/vim/core/oni-plugin-typescript/src/index.ts
+++ b/vim/core/oni-plugin-typescript/src/index.ts
@@ -66,9 +66,10 @@ export const activate = (oni: Oni.Plugin.Api) => {
     })
 
     const protocolOpenFile = (message: string, payload: any) => {
-        const textDocument: types.TextDocumentIdentifier = payload.textDocument
+        const textDocument: any = payload.textDocument
         const filePath = oni.language.unwrapFileUriPath(textDocument.uri)
-        host.openFile(filePath)
+
+        host.openFile(filePath, textDocument.text)
     }
 
     const isSingleLineChange = (range: types.Range): boolean => {


### PR DESCRIPTION
__Issue:__ Would get a periodic `assert failure` after upgrading to TypeScript 2.6. It looks like this is a change in behavior - the server only expects you to send `open` _once_, whereas previously we were using to submit updates.

__Fix:__ 
- Don't submit multiple 'open' requests
- Switch to using `change` for the update gesture