### PR TITLE
Performance: Batch redux notifications

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,2 @@
+- How does this work with typing predictions? Seems like there may be artifacts that weren't present before
+- Any regressions?

--- a/browser/src/Services/TypingPredictionManager.ts
+++ b/browser/src/Services/TypingPredictionManager.ts
@@ -13,16 +13,21 @@ export interface IPredictedCharacter {
     id: number
 }
 
+export interface ITypingPrediction {
+    predictedCharacters: IPredictedCharacter[]
+    predictedCursorColumn: number
+}
+
 export class TypingPredictionManager {
 
-    private _predictionsChanged: Event<IPredictedCharacter[]> = new Event<IPredictedCharacter[]>()
+    private _predictionsChanged: Event<ITypingPrediction> = new Event<ITypingPrediction>()
     private _predictions: IPredictedCharacter[] = []
     private _enabled: boolean = false
 
     private _line: number = null
     private _column: number = null
 
-    public get onPredictionsChanged(): IEvent<IPredictedCharacter[]> {
+    public get onPredictionsChanged(): IEvent<ITypingPrediction> {
         return this._predictionsChanged
     }
 
@@ -88,6 +93,9 @@ export class TypingPredictionManager {
     }
 
     private _notifyPredictionsChanged(): void {
-        this._predictionsChanged.dispatch(this._predictions)
+        this._predictionsChanged.dispatch({
+            predictedCharacters: this._predictions,
+            predictedCursorColumn: this._column + this._predictions.length,
+        })
     }
 }

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -60,7 +60,7 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
         const width = isInsertCursor ? 0 : this.props.width
         const characterToShow = isInsertCursor ? "" : this.props.character
 
-        const position = this.props.mode === "insert" && this.state.predictedCursorColumn >= 0 ? 
+        const position = this.props.mode === "insert" && this.state.predictedCursorColumn >= 0 ?
                             this.state.predictedCursorColumn * this.props.fontPixelWidth :
                             this.props.x
 

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -29,7 +29,7 @@ export interface ICursorRendererProps {
 require("./Cursor.less") // tslint:disable-line no-var-requires
 
 export interface ICursorRendererState {
-    predictedCharacters: number
+    predictedCursorColumn: number
 }
 
 class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRendererState> {
@@ -38,14 +38,14 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
         super(props)
 
         this.state = {
-            predictedCharacters: 0,
+            predictedCursorColumn: -1,
         }
     }
 
     public componentDidMount(): void {
         this.props.typingPrediction.onPredictionsChanged.subscribe((predictions) => {
             this.setState({
-                predictedCharacters: predictions.length,
+                predictedCursorColumn: predictions.predictedCursorColumn,
             })
         })
     }
@@ -60,10 +60,14 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
         const width = isInsertCursor ? 0 : this.props.width
         const characterToShow = isInsertCursor ? "" : this.props.character
 
+        const position = this.props.mode === "insert" && this.state.predictedCursorColumn >= 0 ? 
+                            this.state.predictedCursorColumn * this.props.fontPixelWidth :
+                            this.props.x
+
         const containerStyle: React.CSSProperties = {
             visibility: this.props.visible ? "visible" : "hidden",
             position: "absolute",
-            left: (this.props.x + this.state.predictedCharacters * this.props.fontPixelWidth).toString() + "px",
+            left: position.toString() + "px",
             top: this.props.y.toString() + "px",
             width: width.toString() + "px",
             height,

--- a/browser/src/UI/components/TypingPredictions.tsx
+++ b/browser/src/UI/components/TypingPredictions.tsx
@@ -12,7 +12,7 @@ import { connect } from "react-redux"
 
 import * as State from "./../State"
 
-import { IPredictedCharacter, TypingPredictionManager } from "./../../Services/TypingPredictionManager"
+import { ITypingPrediction, TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 
 export interface ITypingPredictionProps {
     typingPrediction: TypingPredictionManager
@@ -32,13 +32,9 @@ export interface ITypingPredictionViewProps {
     highlightPredictions: boolean
 }
 
-export interface ITypingPredictionViewState {
-    predictions: IPredictedCharacter[]
-}
-
 const noop = (val?: any): void => { } // tslint:disable-line
 
-class TypingPredictionView extends React.PureComponent<ITypingPredictionViewProps, ITypingPredictionViewState> {
+class TypingPredictionView extends React.PureComponent<ITypingPredictionViewProps, {}> {
 
     private _containerElement: HTMLElement
     private _subscription: IDisposable
@@ -46,7 +42,7 @@ class TypingPredictionView extends React.PureComponent<ITypingPredictionViewProp
     private _predictedElements: { [id: number]: HTMLElement } = {}
 
     public componentDidMount(): void {
-        this._subscription = this.props.typingPrediction.onPredictionsChanged.subscribe((updatedPredictions: IPredictedCharacter[]) => {
+        this._subscription = this.props.typingPrediction.onPredictionsChanged.subscribe((prediction: ITypingPrediction) => {
 
             if (!this._containerElement) {
                 return
@@ -54,13 +50,16 @@ class TypingPredictionView extends React.PureComponent<ITypingPredictionViewProp
 
             this._containerElement.innerHTML = ""
 
+            const updatedPredictions = prediction.predictedCharacters
+            const startX = (prediction.predictedCursorColumn - prediction.predictedCharacters.length) * this.props.width
+
             // Add new predictions
             updatedPredictions.forEach((up, idx) => {
                 const elem = document.createElement("div")
                 elem.className = "predicted-text"
                 elem.style.position = "absolute"
                 elem.style.top = this.props.y.toString() + "px"
-                elem.style.left = (this.props.startX + idx * this.props.width).toString() + "px"
+                elem.style.left = (startX + idx * this.props.width).toString() + "px"
                 elem.style.width = (this.props.width.toString()) + "px"
                 elem.style.height = (this.props.height.toString()) + "px"
                 elem.style.lineHeight = this.props.height.toString() + "px"

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -31,6 +31,21 @@ import { PluginManager } from "./../Plugins/PluginManager"
 
 import { NeovimEditor } from "./../Editor/NeovimEditor"
 
+import { batchedSubscribe } from "redux-batched-subscribe"
+
+let rafId: any = null
+
+const rafUpdateBatcher = (notify: any) => {
+    if (rafId) {
+        return
+    }
+
+    rafId = window.requestAnimationFrame(() => {
+        rafId = null
+        notify()
+    })
+}
+
 const defaultState = State.createDefaultState()
 
 require("./components/common.less") // tslint:disable-line no-var-requires
@@ -38,6 +53,7 @@ require("./components/common.less") // tslint:disable-line no-var-requires
 const composeEnhancers = window["__REDUX_DEVTOOLS_EXTENSION__COMPOSE__"] || compose // tslint:disable-line no-string-literal
 const enhancer = composeEnhancers(
     applyMiddleware(thunk),
+    batchedSubscribe(rafUpdateBatcher)
 )
 
 export const store = createStore(reducer, defaultState, enhancer)

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -53,7 +53,7 @@ require("./components/common.less") // tslint:disable-line no-var-requires
 const composeEnhancers = window["__REDUX_DEVTOOLS_EXTENSION__COMPOSE__"] || compose // tslint:disable-line no-string-literal
 const enhancer = composeEnhancers(
     applyMiddleware(thunk),
-    batchedSubscribe(rafUpdateBatcher)
+    batchedSubscribe(rafUpdateBatcher),
 )
 
 export const store = createStore(reducer, defaultState, enhancer)

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/redux-batched-subscribe": "^0.1.2",
     "css-language-server": "0.0.2",
     "find-up": "2.1.0",
     "keyboard-layout": "2.0.13",
@@ -123,6 +124,7 @@
     "oni-neovim-binaries": "0.1.0",
     "oni-ripgrep": "0.0.3",
     "oni-types": "0.0.4",
+    "redux-batched-subscribe": "^0.1.6",
     "typescript": "2.6.1",
     "vscode-jsonrpc": "3.5.0",
     "vscode-languageserver": "3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,12 @@
   version "16.0.25"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.25.tgz#bf696b83fe480c5e0eff4335ee39ebc95884a1ed"
 
+"@types/redux-batched-subscribe@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/redux-batched-subscribe/-/redux-batched-subscribe-0.1.2.tgz#a5f0e510b07b6e8f10fe781bd830fae4f9bcf648"
+  dependencies:
+    redux ">=1.0.0"
+
 "@types/sinon@1.16.32":
   version "1.16.32"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.32.tgz#b3246844902d7cb33f376b369b176a65a144af7e"
@@ -4935,11 +4941,15 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-batched-subscribe@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/redux-batched-subscribe/-/redux-batched-subscribe-0.1.6.tgz#de928602708df7198b4d0c98c7119df993780d59"
+
 redux-thunk@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
-redux@3.7.2, redux@^3.6.0:
+redux@3.7.2, redux@>=1.0.0, redux@^3.6.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:


### PR DESCRIPTION
We're particularly noisy (abusive) of our redux store - in particular, a single user gesture can dispatch multiple actions (some coming from auto command notifications, key presses, etc). _Each action_ causes the redux store to dispatch an update, which then triggers a re-render.

In order to improve performance, we should batch these up - ideally under a `requestAnimationFrame`. This will give us more predictable performance.

For items that truly require an instant rendering - like the typing predictions - we should still be able to push those instantly. But those should be less frequent.