### PR TITLE
Bugfix/mouse selection buffer bar

### DIFF
--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -54,6 +54,7 @@
 
     overflow: hidden;
     text-overflow: ellipsis;
+    user-select: none;
 
     .name {
         flex: 1 1 auto;

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -51,16 +51,16 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
             "height": "100%",
         }
 
-        const editors = this.state.splitRoot.splits.map((splitNode) => {
+        const editors = this.state.splitRoot.splits.map((splitNode, i) => {
             if (splitNode.type === "Split") {
                 return null
             } else {
                 const split: Oni.IWindowSplit = splitNode.contents
 
                 if (!split) {
-                    return <div className="container vertical full">TODO: Implement an editor here...</div>
+                    return <div className="container vertical full" key={i}>TODO: Implement an editor here...</div>
                 } else {
-                    return <WindowSplitHost split={split} />
+                    return <WindowSplitHost key={i} split={split} />
                 }
             }
         })


### PR DESCRIPTION
* Added `user-select: none` to tabs.less to stop users highlighting buffer bar text.
* Added keys to WindowSplits - :worried: I couldn't find any id like data to use as keys hopefully the index here will be fine if not ill take them out, was just desperate to make the error go away
* Fixes #1010 (hopefully)

