### PR TITLE
Fix scroll bar focus/unfocus positioning bug

### DIFF
--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -29,6 +29,7 @@
     width: 100%;
     color: #c8c8c8;
     background-color: rgba(0, 0, 0, 0.2);
+    overflow-x: hidden;
 
     &:hover {
         overflow-x: overlay;


### PR DESCRIPTION
@bryphe, whilst testing things out I noticed that following my PR for the tab bar scroll bar, If you scroll into the overflow area and then move the cursor it would lose the position of the barwhich was quite "jerky" from a UX standpoint, I managed to resolve this by specifying overflow-x: hidden on the tab bar element, which was an oversight on my part in the original PR, apologies for missing that earlier.
![buffer-bar](https://user-images.githubusercontent.com/22454918/33231782-fe90b67a-d1f2-11e7-91f1-01a349f2ef5a.gif)

The PR should fix this (i've tested this locally), with this change the bar now keeps the correct position but on hover the scrollbar appears and you can move back and forth without the position changing