### PR TITLE
Fix regression in status bar loading

### DIFF
--- a/browser/src/Plugins/Plugin.ts
+++ b/browser/src/Plugins/Plugin.ts
@@ -33,17 +33,19 @@ export class Plugin {
                 Log.error(`[PLUGIN] Aborting plugin load, invalid package.json: ${packageJsonPath}`)
             } else {
                 if (this._oniPluginMetadata.main) {
-
-                    this._oni = new Oni()
-                    this._onActivate()
-
                     this._commands = PackageMetadataParser.getAllCommandsFromMetadata(this._oniPluginMetadata)
                 }
             }
         }
     }
 
-    private _onActivate(): void {
+    public activate(): void {
+
+        if (!this._oniPluginMetadata || !this._oniPluginMetadata.main) {
+            return
+        }
+
+        this._oni = new Oni()
         const vm = require("vm")
         Log.info(`[PLUGIN] Activating: ${this._oniPluginMetadata.name}`)
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -22,7 +22,7 @@ export class PluginManager extends EventEmitter {
         return this._plugins
     }
 
-    public startPlugins(): void {
+    public discoverPlugins(): void {
 
         this._rootPluginPaths.push(corePluginsRoot)
 
@@ -40,6 +40,11 @@ export class PluginManager extends EventEmitter {
     }
 
     public startApi(): Oni.Plugin.Api {
+
+        this._plugins.forEach((plugin) => {
+            plugin.activate()
+        })
+
         return this._anonymousPlugin.oni
     }
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -22,7 +22,7 @@ export class PluginManager extends EventEmitter {
         return this._plugins
     }
 
-    public startPlugins(): Oni.Plugin.Api {
+    public startPlugins(): void {
 
         this._rootPluginPaths.push(corePluginsRoot)
 
@@ -37,7 +37,9 @@ export class PluginManager extends EventEmitter {
         this._plugins = allPluginPaths.map((pluginRootDirectory) => this._createPlugin(pluginRootDirectory))
 
         this._anonymousPlugin = new AnonymousPlugin()
+    }
 
+    public startApi(): Oni.Plugin.Api {
         return this._anonymousPlugin.oni
     }
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -73,12 +73,12 @@ const start = (args: string[]) => {
     configuration.onConfigurationChanged.subscribe(configChange)
 
     performance.mark("NeovimInstance.Plugins.Start")
-    const api = pluginManager.startPlugins()
+    pluginManager.startPlugins()
     performance.mark("NeovimInstance.Plugins.End")
-
-    configuration.activate(api)
-
     UI.init(pluginManager, parsedArgs._)
+
+    const api = pluginManager.startApi()
+    configuration.activate(api)
 
     ipcRenderer.on("execute-command", (_evt: any, command: string) => {
         commandManager.executeCommand(command, null)

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -72,9 +72,9 @@ const start = (args: string[]) => {
     configChange(configuration.getValues()) // initialize values
     configuration.onConfigurationChanged.subscribe(configChange)
 
-    performance.mark("NeovimInstance.Plugins.Start")
-    pluginManager.startPlugins()
-    performance.mark("NeovimInstance.Plugins.End")
+    performance.mark("NeovimInstance.Plugins.Discover.Start")
+    pluginManager.discoverPlugins()
+    performance.mark("NeovimInstance.Plugins.Discover.End")
     UI.init(pluginManager, parsedArgs._)
 
     const api = pluginManager.startApi()

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -14,6 +14,7 @@ const CiTests = [
     "AutoCompletionTest-CSS",
     "AutoCompletionTest-TypeScript",
     "QuickOpenTest",
+    "StatusBar-Mode",
     "NoInstalledNeovim",
 ]
 

--- a/test/ci/Common.ts
+++ b/test/ci/Common.ts
@@ -3,14 +3,7 @@
  */
 
 export const getCompletionElement = () => {
-
-    const elements = document.body.getElementsByClassName("autocompletion")
-
-    if (!elements || !elements.length) {
-        return null
-    } else {
-        return elements[0]
-    }
+    return getElementByClassName("autocompletion")
 }
 
 export const getElementByClassName = (className: string) => {

--- a/test/ci/Common.ts
+++ b/test/ci/Common.ts
@@ -12,3 +12,14 @@ export const getCompletionElement = () => {
         return elements[0]
     }
 }
+
+export const getElementByClassName = (className: string) => {
+
+    const elements = document.body.getElementsByClassName(className)
+
+    if (!elements || !elements.length) {
+        return null
+    } else {
+        return elements[0]
+    }
+}

--- a/test/ci/StatusBar-Mode.ts
+++ b/test/ci/StatusBar-Mode.ts
@@ -1,0 +1,24 @@
+/**
+ * Test scripts for StatusBar
+ *
+ * Validating the 'mode' UX element showsu p
+ */
+
+import * as assert from "assert"
+import * as os from "os"
+import * as path from "path"
+
+import { getCompletionElement } from "./Common"
+
+export const test = async (oni: any) => {
+    const dir = os.tmpdir()
+
+    // Wait for completion popup to show
+    await oni.automation.waitFor(() => getElementByClassName("mode") !== null)
+
+    // Check for 'alert' as an available completion
+    const statusBarModeElement = getElementByClassName("mode")
+    const textContent = statusBarModeElement.textContent
+
+    assert.ok(textContent.indexOf("normal") >= 0, "Verify 'normal' was present in the statusbar mode item")
+}

--- a/test/ci/StatusBar-Mode.ts
+++ b/test/ci/StatusBar-Mode.ts
@@ -5,14 +5,11 @@
  */
 
 import * as assert from "assert"
-import * as os from "os"
 import * as path from "path"
 
-import { getCompletionElement } from "./Common"
+import { getElementByClassName } from "./Common"
 
 export const test = async (oni: any) => {
-    const dir = os.tmpdir()
-
     // Wait for completion popup to show
     await oni.automation.waitFor(() => getElementByClassName("mode") !== null)
 

--- a/vim/core/oni-core-statusbar/index.js
+++ b/vim/core/oni-core-statusbar/index.js
@@ -43,7 +43,7 @@ const activate = (Oni) => {
             backgroundColor: getColorForMode(mode)
         }
 
-        const modeElement  = React.createElement("div", { style }, parseMode(mode))
+        const modeElement  = React.createElement("div", { style, className: "mode" }, parseMode(mode))
         modeItem.setContents(modeElement)
     }
 


### PR DESCRIPTION
A change in the load timing caused `Oni.editors.activeEditor` to not be available at plugin initialization; this caused the status bar to fail to load.

This change fixes the issue and adds a regression test (to check for the status bar rendering).
