### PR TITLE
Fix filter exception with auto-closing pairs

### DIFF
--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -38,7 +38,11 @@ export class InputManager implements Oni.InputManager {
         this._boundKeys[normalizedKeyChord] = [...currentBinding, newBinding]
 
         return () => {
-            this._boundKeys[normalizedKeyChord] = this._boundKeys[normalizedKeyChord].filter((f) => f !== newBinding)
+            const existingBindings = this._boundKeys[normalizedKeyChord]
+
+            if (existingBindings) {
+                this._boundKeys[normalizedKeyChord] = existingBindings.filter((f) => f !== newBinding)
+            }
         }
     }
 

--- a/browser/test/Input/InputManagerTests.ts
+++ b/browser/test/Input/InputManagerTests.ts
@@ -30,5 +30,20 @@ describe("InputManager", () => {
             assert.strictEqual(count, 0, "Handler should not have been called")
             assert.strictEqual(handled, false)
         })
+
+        it("dispose key handler is robust if unbindAll was called first", () => {
+            const im = new InputManager()
+
+            let count = 0
+            const dispose = im.bind("{", () => { count++; return true })
+
+            im.unbindAll()
+
+            dispose()
+
+            const handled = im.handleKey("{")
+            assert.strictEqual(count, 0, "Handler should not have been called.")
+            assert.strictEqual(handled, false)
+        })
     })
 })


### PR DESCRIPTION
When the `experimental.autoClosingPairs.enabled` flag is `true`, and you edit your config, there is a javascript crash that causes future keypresses to fail.

In this case, first `unbindAll` is called because the config was reloaded, but when we try to change buffer, we update the auto closing pairs bindings... and the dispose fails because there is nothing to dispose.