### PR TITLE
#956 - Fix completion case that was still broken

### DIFF
--- a/browser/src/Redux/LoggingMiddleware.ts
+++ b/browser/src/Redux/LoggingMiddleware.ts
@@ -9,7 +9,7 @@ import { Store } from "redux"
 import * as Log from "./../Log"
 
 export const createLoggingMiddleware = (storeName: string) => (store: Store<any>) => (next: any) => (action: any): any => {
-    Log.verbose("[REDUX - " + storeName + "] Applying action - " + action.type + ":")
+    Log.verbose("[REDUX - " + storeName + "][ACTION] " + action.type)
 
     if (Log.isDebugLoggingEnabled()) {
         console.dir(action) // tslint:disable-line

--- a/browser/src/Services/Completion/Completion.ts
+++ b/browser/src/Services/Completion/Completion.ts
@@ -103,7 +103,7 @@ export class Completion implements IDisposable {
     }
 
     private async _onModeChanged(newMode: string): Promise<void> {
-        if (newMode === "insert" && this._lastCursorPosition) {
+       if (newMode === "insert" && this._lastCursorPosition) {
 
             const [latestLine] = await this._editor.activeBuffer.getLines(this._lastCursorPosition.line, this._lastCursorPosition.line + 1)
             this._throttledCursorUpdates.next({
@@ -114,7 +114,7 @@ export class Completion implements IDisposable {
             })
         }
 
-        this._store.dispatch({
+       this._store.dispatch({
             type: "MODE_CHANGED",
             mode: newMode,
         })

--- a/browser/src/Services/Completion/CompletionStore.ts
+++ b/browser/src/Services/Completion/CompletionStore.ts
@@ -236,7 +236,7 @@ const getCompletionsEpic: Epic<CompletionAction, ICompletionState> = (action$, s
 
             return true
         })
-        .mergeMap((action: CompletionAction): Observable<CompletionAction> => {
+        .switchMap((action: CompletionAction): Observable<CompletionAction> => {
 
             const state = store.getState()
 
@@ -271,7 +271,7 @@ const getCompletionsEpic: Epic<CompletionAction, ICompletionState> = (action$, s
 
 const getCompletionDetailsEpic: Epic<CompletionAction, ICompletionState> = (action$, store) =>
     action$.ofType("SELECT_ITEM")
-        .mergeMap((action) => {
+        .switchMap((action) => {
 
             if (action.type !== "SELECT_ITEM") {
                 return Observable.of(nullAction)

--- a/browser/src/Services/Completion/CompletionStore.ts
+++ b/browser/src/Services/Completion/CompletionStore.ts
@@ -168,7 +168,7 @@ export const lastCompletionInfoReducer: Reducer<ILastCompletionInfo> = (
 const nullAction: CompletionAction = { type: null } as CompletionAction
 
 const getCompletionMeetEpic: Epic<CompletionAction, ICompletionState> = (action$, store) =>
-    action$.ofType("CURSOR_MOVED", "MODE_CHANGED")
+    action$.ofType("CURSOR_MOVED")
         .map((action: CompletionAction) => {
             const currentState: ICompletionState = store.getState()
 


### PR DESCRIPTION
__Issue:__ On `MODE_CHANGED` being dispatched, we'd still be holding onto the old completions / meets.

__Fix:__ Don't re-evaluate the meet on `MODE_CHANGED`