### PR TITLE
Fix #1012 - Add 'ui.fontSmoothing' configuration

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -178,6 +178,7 @@ const BaseConfiguration: IConfigurationValues = {
     "ui.animations.enabled": true,
     "ui.fontFamily": "BlinkMacSystemFont, 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",
     "ui.fontSize": "13px",
+    "ui.fontSmoothing": "auto",
 }
 
 const MacConfigOverrides: Partial<IConfigurationValues> = {

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -15,6 +15,8 @@ export interface ITokenColorsSetting {
     settings: IHighlight | string
 }
 
+export type FontSmoothingOptions = "auto" | "antialiased" | "subpixel-antialiased" | "none"
+
 export interface IConfigurationValues {
 
     "activate": (oni: Oni.Plugin.Api) => void
@@ -185,6 +187,7 @@ export interface IConfigurationValues {
     "ui.animations.enabled": boolean
     "ui.fontFamily": string
     "ui.fontSize": string
+    "ui.fontSmoothing": FontSmoothingOptions
 
     // Handle other, non-predefined configuration keys
     [configurationKey: string]: any

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -49,6 +49,12 @@ const start = (args: string[]) => {
         document.body.style.fontSize = configuration.getValue("ui.fontSize")
         document.body.style.fontVariant = configuration.getValue("editor.fontLigatures") ? "normal" : "none"
 
+        const fontSmoothing = configuration.getValue("ui.fontSmoothing")
+
+        if (fontSmoothing) {
+            document.body.style["-webkit-font-smoothing"] = fontSmoothing
+        }
+
         const hideMenu: boolean = configuration.getValue("oni.hideMenu")
         browserWindow.setAutoHideMenuBar(hideMenu)
         browserWindow.setMenuBarVisibility(!hideMenu)

--- a/configuration/config.default.js
+++ b/configuration/config.default.js
@@ -30,4 +30,8 @@ module.exports = {
    //"oni.loadInitVim": false,
    //"editor.fontSize": "14px",
    //"editor.fontFamily": "Monaco"
+
+   // UI customizations
+    "ui.animations.enabled": true,
+    "ui.fontSmoothing": "auto",
 }


### PR DESCRIPTION
Adds a `ui.fontSmoothing` configuration value, which directly sets the `-webkit-font-smoothing` property on the body.

Valid values are:
- `auto` (default)
- `none`
- `antialiased`
- `subpixel-antialiased`

More documentation about the values is available here: https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth