### PR TITLE
Fix #981 - Use 'editor.fontFamily' for completion / tooltips

### DIFF
--- a/browser/src/Services/Language/RenameView.tsx
+++ b/browser/src/Services/Language/RenameView.tsx
@@ -17,14 +17,7 @@ export class RenameView extends React.PureComponent<IRenameViewProps, {}> {
 
     public render(): JSX.Element {
 
-        const titleStyle = {
-            marginBottom: "8px",
-        }
-
-        const renameText = "Rename '" + this.props.tokenName + "' to:"
-
         return <div className="rename">
-                    <div style={titleStyle}>{renameText}</div>
                     <TextInput {...this.props} defaultValue={this.props.tokenName} />
                 </div>
     }

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -33,12 +33,10 @@ export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
             </CSSTransition>
         })
 
-
         const style: React.CSSProperties = {
             fontFamily: this.props.fontFamily,
             fontSize: this.props.fontSize,
         }
-
 
         return <div className="tool-tips" key={"tool-tip-container"} style={style}>
         <TransitionGroup>

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -14,12 +14,13 @@ export interface IToolTipsViewProps {
     backgroundColor: string
     foregroundColor: string
     borderColor: string
+    fontFamily: string
+    fontSize: string
 }
 
 export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
 
     public render(): JSX.Element {
-
         const toolTipElements = this.props.toolTips.map((toolTip) => {
             return <CSSTransition
                 timeout={250}
@@ -32,7 +33,14 @@ export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
             </CSSTransition>
         })
 
-        return <div className="tool-tips" key={"tool-tip-container"}>
+
+        const style: React.CSSProperties = {
+            fontFamily: this.props.fontFamily,
+            fontSize: this.props.fontSize,
+        }
+
+
+        return <div className="tool-tips" key={"tool-tip-container"} style={style}>
         <TransitionGroup>
             {toolTipElements}
         </TransitionGroup>
@@ -122,6 +130,8 @@ const mapStateToProps = (state: State.IState): IToolTipsViewProps => {
         borderColor: state.colors["toolTip.border"],
         backgroundColor: state.colors["toolTip.background"],
         foregroundColor: state.colors["toolTip.foreground"],
+        fontFamily: state.fontFamily,
+        fontSize: state.fontSize,
         toolTips,
     }
 }


### PR DESCRIPTION
Fixes #981  - instead of using the shell font for completion / tooltips, we use the `editor.fontFamily` setting.