### PR TITLE
Fix tsx jsx grammar loading

### DIFF
--- a/browser/src/Services/SyntaxHighlighting/GrammarLoader.ts
+++ b/browser/src/Services/SyntaxHighlighting/GrammarLoader.ts
@@ -11,7 +11,8 @@ export interface IGrammarLoader {
 export interface ExtensionToGrammarMap { [extension: string]: string }
 
 export const getPathForLanguage = (language: string, extension: string): string => {
-    const grammar: string | ExtensionToGrammarMap = configuration.getValue("language." + language + ".textMateGrammar")
+    const verifiedLanguage = language.includes(".") ? language.split(".")[0] : language
+    const grammar: string | ExtensionToGrammarMap = configuration.getValue("language." + verifiedLanguage + ".textMateGrammar")
 
     if (!grammar) {
         Log.warn("No grammar found for language: " + language)


### PR DESCRIPTION
@bryphe, excellent work on the new Syntax highlighting (I know its still a [WIP] but looks great so far). I noticed while trying it though that it wasn't picking up `javascript.jsx` and `typescript.tsx` as `tsx` and `jsx` filetypes (which is what I believe most `viml tsx` and `jsx` plugins use or rather what they coerce the filetype to). The default config appears to be trying to account for these filetypes I think, but I noticed I wasn't getting the grammar loaded.

I Tweaked the grammar loader to check if a filetype contains a dot like `javascript.jsx` in which case I split the value and return the first half so the loader can accurately use the `js` or `ts` textmate objects.

I wasn't entirely sure if you'd want this sort of thing to be user configured(so this is a question/PR), although it took a tiny bit of digging to find out what was going on, If you rather this were user configured I could make an entry in the docs instead.

*Sidenote*: I've seen/used a plugin (not very popular) that set the `ft` to `typescript.jsx` which wouldn't be accounted.