### PR TITLE
Fix small bugs around configuring colors

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -355,13 +355,11 @@ export class NeovimEditor extends Editor implements IEditor {
 
             if (newTheme.baseVimTheme && newTheme.baseVimTheme !== this._currentColorScheme) {
                 this._neovimInstance.command(":color " + newTheme.baseVimTheme)
-                UI.Actions.setColors(this._themeManager.getColors())
             }
         })
 
         if (this._themeManager.activeTheme && this._themeManager.activeTheme.baseVimTheme) {
             await this._neovimInstance.command(":color " + this._themeManager.activeTheme.baseVimTheme)
-            UI.Actions.setColors(this._themeManager.getColors())
         }
 
         this._hasLoaded = true

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -17,7 +17,7 @@ import { Services } from "./Services"
 import { Ui } from "./Ui"
 
 import { automation } from "./../../Services/Automation"
-import { Colors } from "./../../Services/Colors"
+import { Colors, getInstance as getColors } from "./../../Services/Colors"
 import { commandManager } from "./../../Services/CommandManager"
 import { configuration } from "./../../Services/Configuration"
 import { contextMenuManager } from "./../../Services/ContextMenu"
@@ -27,7 +27,6 @@ import { languageManager } from "./../../Services/Language"
 import { menuManager } from "./../../Services/Menu"
 import { recorder } from "./../../Services/Recorder"
 import { statusBar } from "./../../Services/StatusBar"
-import { getThemeManagerInstance } from "./../../Services/Themes"
 import { windowManager, WindowManager } from "./../../Services/WindowManager"
 import { workspace } from "./../../Services/Workspace"
 
@@ -140,7 +139,7 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
 
     constructor() {
         super()
-        this._colors = new Colors(getThemeManagerInstance(), configuration)
+        this._colors = getColors()
 
         this._diagnostics = new Diagnostics()
         this._dependencies = new Dependencies()

--- a/browser/src/Services/Colors.ts
+++ b/browser/src/Services/Colors.ts
@@ -13,6 +13,16 @@ import { getThemeManagerInstance, ThemeManager } from "./Themes"
 
 export interface ColorsDictionary { [colorName: string]: string}
 
+let _colors: Colors = null
+export const getInstance = (): Colors => {
+
+    if (_colors === null) {
+        _colors = new Colors()
+    }
+
+    return _colors
+}
+
 export class Colors implements IDisposable {
 
     private _subscriptions: IDisposable[] = []

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -109,6 +109,12 @@ export class Configuration implements Oni.Configuration {
         const previousConfig = this._config
 
         const userRuntimeConfigOrError = this.getUserRuntimeConfig()
+
+        if (userRuntimeConfigOrError === null) {
+            Log.info("Configuration was null; skipping")
+            return
+        }
+
         if (isError(userRuntimeConfigOrError)) {
             Log.error(userRuntimeConfigOrError)
             this._config = { ...DefaultConfiguration, ...this._setValues }

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -20,6 +20,7 @@ export class Configuration implements Oni.Configuration {
     private _onConfigurationChangedEvent: Event<Partial<IConfigurationValues>> = new Event<Partial<IConfigurationValues>>()
     private _oniApi: Oni.Plugin.Api = null
     private _config: IConfigurationValues = null
+    private _configEverHadValue: boolean = false
 
     private _setValues: { [configValue: string]: any } = { }
 
@@ -110,7 +111,10 @@ export class Configuration implements Oni.Configuration {
 
         const userRuntimeConfigOrError = this.getUserRuntimeConfig()
 
-        if (userRuntimeConfigOrError === null) {
+        // If the configuration is null, but it had some value at some point,
+        // we assume this is due to reading while the file write is still in
+        // transition, and ignore it
+        if (userRuntimeConfigOrError === null && this._configEverHadValue) {
             Log.info("Configuration was null; skipping")
             return
         }
@@ -119,6 +123,7 @@ export class Configuration implements Oni.Configuration {
             Log.error(userRuntimeConfigOrError)
             this._config = { ...DefaultConfiguration, ...this._setValues }
         } else {
+            this._configEverHadValue = true
             this._config = { ...DefaultConfiguration, ...this._setValues, ...userRuntimeConfigOrError}
         }
 


### PR DESCRIPTION
While testing the latest master, found a couple of issues:

- Setting `colors.tabs.background` via configuration isn't respected when re-loading Oni.
- In some cases, when modifying the configuration, the colorscheme would be reset.

This addresses both of these bugs