### PR TITLE
Update to oni-api@0.0.7

### DIFF
--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -22,6 +22,7 @@ export class Editor implements Oni.Editor {
     private _onBufferLeaveEvent = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferChangedEvent = new Event<Oni.EditorBufferChangedEventArgs>()
     private _onBufferSavedEvent = new Event<Oni.EditorBufferEventArgs>()
+    private _onBufferScrolledEvent = new Event<Oni.EditorBufferScrolledEventArgs>()
     private _onCursorMoved = new Event<Oni.Cursor>()
     private _onModeChangedEvent = new Event<Oni.Vim.Mode>()
 
@@ -58,6 +59,10 @@ export class Editor implements Oni.Editor {
         return this._onBufferSavedEvent
     }
 
+    public get onBufferScrolled(): IEvent<Oni.EditorBufferScrolledEventArgs> {
+        return this._onBufferScrolledEvent
+    }
+
     public /* virtual */ openFile(filePath: string): Promise<Oni.Buffer> {
         return Promise.reject("Not implemented")
     }
@@ -87,5 +92,9 @@ export class Editor implements Oni.Editor {
 
     protected notifyBufferSaved(bufferEvent: Oni.EditorBufferEventArgs): void {
         this._onBufferSavedEvent.dispatch(bufferEvent)
+    }
+
+    protected notifyBufferScrolled(bufferScrollEvent: Oni.EditorBufferScrolledEventArgs): void {
+        this._onBufferScrolledEvent.dispatch(bufferScrollEvent)
     }
 }

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -62,8 +62,6 @@ export class NeovimEditor extends Editor implements IEditor {
 
     private _pendingAnimationFrame: boolean = false
 
-    private _onBufferScrolledEvent = new Event<Oni.EditorBufferScrolledEventArgs>()
-
     private _modeChanged$: Observable<Oni.Vim.Mode>
     private _cursorMoved$: Observable<Oni.Cursor>
     private _cursorMovedI$: Observable<Oni.Cursor>
@@ -85,10 +83,6 @@ export class NeovimEditor extends Editor implements IEditor {
 
     public /* override */ get activeBuffer(): Oni.Buffer {
         return this._bufferManager.getBufferById(this._lastBufferId)
-    }
-
-    public get onBufferScrolled(): IEvent<Oni.EditorBufferScrolledEventArgs> {
-        return this._onBufferScrolledEvent
     }
 
     // Capabilities
@@ -237,7 +231,7 @@ export class NeovimEditor extends Editor implements IEditor {
                 windowTopLine: args.windowTopLine,
                 windowBottomLine: args.windowBottomLine,
             }
-            this._onBufferScrolledEvent.dispatch(converted_args)
+            this.notifyBufferScrolled(converted_args)
         })
 
         addInsertModeLanguageFunctionality(this._cursorMovedI$, this._modeChanged$)

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -226,12 +226,12 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         this._neovimInstance.onScroll.subscribe((args: EventContext) => {
-            const converted_args: Oni.EditorBufferScrolledEventArgs = {
+            const convertedArgs: Oni.EditorBufferScrolledEventArgs = {
                 bufferTotalLines: args.bufferTotalLines,
                 windowTopLine: args.windowTopLine,
                 windowBottomLine: args.windowBottomLine,
             }
-            this.notifyBufferScrolled(converted_args)
+            this.notifyBufferScrolled(convertedArgs)
         })
 
         addInsertModeLanguageFunctionality(this._cursorMovedI$, this._modeChanged$)

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -63,6 +63,7 @@ class AllEditors implements Oni.Editor {
     private _onBufferLeave = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferChanged = new Event<Oni.EditorBufferChangedEventArgs>()
     private _onBufferSaved = new Event<Oni.EditorBufferEventArgs>()
+    private _onBufferScrolled = new Event<Oni.EditorBufferScrolledEventArgs>()
 
     /**
      * API Methods
@@ -123,6 +124,10 @@ class AllEditors implements Oni.Editor {
         return this._onBufferSaved
     }
 
+    public get onBufferScrolled(): IEvent<Oni.EditorBufferScrolledEventArgs> {
+        return this._onBufferScrolled
+    }
+
     public dispose(): void {
         // tslint:disable-line
     }
@@ -140,6 +145,7 @@ class AllEditors implements Oni.Editor {
         this._subscriptions.push(newEditor.onBufferLeave.subscribe((val) => this._onBufferLeave.dispatch(val)))
         this._subscriptions.push(newEditor.onBufferChanged.subscribe((val) => this._onBufferChanged.dispatch(val)))
         this._subscriptions.push(newEditor.onBufferSaved.subscribe((val) => this._onBufferSaved.dispatch(val)))
+        this._subscriptions.push(newEditor.onBufferScrolled.subscribe((val) => this._onBufferScrolled.dispatch(val)))
     }
 
     public getUnderlyingEditor(): Oni.Editor {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
     "ocaml-language-server": "1.0.12",
-    "oni-api": "0.0.6",
+    "oni-api": "0.0.7",
     "oni-neovim-binaries": "0.1.0",
     "oni-ripgrep": "0.0.3",
     "oni-types": "0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,9 +4145,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.6.tgz#8f7e76394a86f564a3182ed1fb901397cb917aa2"
+oni-api@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.7.tgz#190cdf07c5868b4be72d8c7cdec36ca4a1d565f6"
 
 oni-neovim-binaries@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Bring in @TalAmuyal 's api update to add the `onBufferScrolled` event to `IEditor`, and update usages to reflect that.

Most of this is based on this commit: https://github.com/TalAmuyal/oni/commit/ea2e12f80809e818a8458a12980e5ede89d5e570

Just merged in some of the changes that occurred on master (lifting of `Editor` out of `NeovimEditor` to simplify creation of a mock for unit testing).