### PR TITLE
TypeScript & JavaScript: Use "definition" instead of "typeDefinition"

### DIFF
--- a/vim/core/oni-plugin-typescript/src/Definition.ts
+++ b/vim/core/oni-plugin-typescript/src/Definition.ts
@@ -21,7 +21,7 @@ export const getDefinition = (oni: Oni.Plugin.Api, host: TypeScriptServerHost) =
     const position: types.Position = payload.position
 
     const filePath = oni.language.unwrapFileUriPath(textDocument.uri)
-    const val: any = await host.getTypeDefinition(filePath, position.line + 1, position.character + 1)
+    const val: any = await host.getDefinition(filePath, position.line + 1, position.character + 1)
 
     const resultPos = val[0]
 

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -97,6 +97,13 @@ export class TypeScriptServerHost extends events.EventEmitter {
             needFileNameList: true,
         })
     }
+    public getDefinition(file: string, line: number, offset: number): Promise<void> {
+        return this._makeTssRequest<void>("definition", {
+            file,
+            line,
+            offset,
+        })
+    }
 
     public getTypeDefinition(file: string, line: number, offset: number): Promise<void> {
         return this._makeTssRequest<void>("typeDefinition", {


### PR DESCRIPTION
__Issue:__ The `definition` LSP request is sending the user to the _type definition_ instead of the _variable definition_ (the latter case is the expected).

__Fix:__ Use the `definition` request instead of `typeDefinition`