### PR TITLE
Bugfix/path concatenation

### DIFF
--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -17,7 +17,7 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
 
     const joinedPathsToAdd = pathsToAdd.join(separator)
 
-    return currentPath + separator + joinedPathsToAdd + separator
+    return currentPath + separator + joinedPathsToAdd
 }
 
 const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
@@ -31,8 +31,9 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
     let existingPath: string
 
     try {
-        const { PATH: path } = await shellEnv()
-        existingPath = path || process.env.Path || process.env.PATH
+        const shellEnvironment = await shellEnv()
+        process.env = { ...process.env, ...shellEnvironment }
+        existingPath = process.env.Path || process.env.PATH
     } catch (e) {
         existingPath = process.env.Path || process.env.PATH
     }

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -1,11 +1,8 @@
 import * as ChildProcess from "child_process"
-// import * as util from "util"
 import * as shellEnv from "shell-env"
 
 import * as Platform from "./../../Platform"
 import { configuration } from "./../../Services/Configuration"
-
-// const exec = util.promisify(ChildProcess.exec)
 
 const getPathSeparator = () => {
     return Platform.isWindows() ? ";" : ":"
@@ -20,7 +17,7 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
 
     const joinedPathsToAdd = pathsToAdd.join(separator)
 
-    return (currentPath + separator + joinedPathsToAdd + separator).replace(/[\n\r]/g, "")
+    return currentPath + separator + joinedPathsToAdd + separator
 }
 
 const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
@@ -34,17 +31,13 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
     let existingPath: string
 
     try {
-        // const pathCommand = Platform.isWindows() ? "echo %PATH%" : "echo $PATH"
         const { PATH: path } = await shellEnv()
-        console.log("Path ==============================", path)
         existingPath = path || process.env.Path || process.env.PATH
     } catch (e) {
-        console.log("error: ", e)
         existingPath = process.env.Path || process.env.PATH
     }
 
     requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))
-    console.log("requireOptions.env.PATH: ", requiredOptions.env.PATH);
     return {
         ...originalSpawnOptions,
         ...requiredOptions,

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -5,13 +5,12 @@ import * as Platform from "./../../Platform"
 import { configuration } from "./../../Services/Configuration"
 
 const exec = util.promisify(ChildProcess.exec)
-type ExecReturn = string | { stdout: string, stderr: string }
 
 const getPathSeparator = () => {
     return Platform.isWindows() ? ";" : ":"
 }
 
-const mergePathEnvironmentVariable = (currentPath: ExecReturn, pathsToAdd: string[]): ExecReturn => {
+const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[]): string => {
     if (!pathsToAdd || !pathsToAdd.length) {
         return currentPath
     }
@@ -20,7 +19,7 @@ const mergePathEnvironmentVariable = (currentPath: ExecReturn, pathsToAdd: strin
 
     const joinedPathsToAdd = pathsToAdd.join(separator)
 
-    return currentPath + separator + joinedPathsToAdd + separator
+    return currentPath + separator + joinedPathsToAdd
 }
 
 const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
@@ -31,11 +30,12 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
         },
     }
 
-    let existingPath: ExecReturn
+    let existingPath: string
 
     try {
         const pathCommand = Platform.isWindows() ? "echo %PATH%" : "echo $PATH"
-        const path = await exec(pathCommand)
+        const rawPath = await exec(pathCommand)
+        const path = rawPath.toString().replace(/[\n\r]/g, "")
 
         existingPath = path || process.env.Path || process.env.PATH
     } catch (e) {

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -21,24 +21,25 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
 }
 
 const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
-    const requiredOptions = {
-        env: {
-            ...process.env,
-            ...originalSpawnOptions.env,
-        },
-    }
-
     let existingPath: string
+    let requiredOptions
 
     try {
         const shellEnvironment = await shellEnv()
         process.env = { ...process.env, ...shellEnvironment }
         existingPath = process.env.Path || process.env.PATH
+        requiredOptions = {
+            env: {
+                ...process.env,
+                ...originalSpawnOptions.env,
+            },
+        }
     } catch (e) {
         existingPath = process.env.Path || process.env.PATH
     }
 
     requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))
+
     return {
         ...originalSpawnOptions,
         ...requiredOptions,

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -22,20 +22,20 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
 
 const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
     let existingPath: string
-    let requiredOptions
 
     try {
         const shellEnvironment = await shellEnv()
         process.env = { ...process.env, ...shellEnvironment }
         existingPath = process.env.Path || process.env.PATH
-        requiredOptions = {
-            env: {
-                ...process.env,
-                ...originalSpawnOptions.env,
-            },
-        }
     } catch (e) {
         existingPath = process.env.Path || process.env.PATH
+    }
+
+    const requiredOptions = {
+        env: {
+            ...process.env,
+            ...originalSpawnOptions.env,
+        },
     }
 
     requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -1,10 +1,11 @@
 import * as ChildProcess from "child_process"
-import * as util from "util"
+// import * as util from "util"
+import * as shellEnv from "shell-env"
 
 import * as Platform from "./../../Platform"
 import { configuration } from "./../../Services/Configuration"
 
-const exec = util.promisify(ChildProcess.exec)
+// const exec = util.promisify(ChildProcess.exec)
 
 const getPathSeparator = () => {
     return Platform.isWindows() ? ";" : ":"
@@ -33,18 +34,17 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
     let existingPath: string
 
     try {
-        const pathCommand = Platform.isWindows() ? "echo %PATH%" : "echo $PATH"
-        const rawPath = await exec(pathCommand)
-        const path = rawPath.toString()
+        // const pathCommand = Platform.isWindows() ? "echo %PATH%" : "echo $PATH"
+        const { PATH: path } = await shellEnv()
         console.log("Path ==============================", path)
         existingPath = path || process.env.Path || process.env.PATH
     } catch (e) {
-        console.log('error: ', e);
+        console.log("error: ", e)
         existingPath = process.env.Path || process.env.PATH
     }
 
     requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))
-    console.log('requireOptions.env.PATH: ', requiredOptions.env.PATH);
+    console.log("requireOptions.env.PATH: ", requiredOptions.env.PATH);
     return {
         ...originalSpawnOptions,
         ...requiredOptions,

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -19,7 +19,7 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
 
     const joinedPathsToAdd = pathsToAdd.join(separator)
 
-    return currentPath + separator + joinedPathsToAdd
+    return (currentPath + separator + joinedPathsToAdd + separator).replace(/[\n\r]/g, "")
 }
 
 const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
@@ -35,15 +35,16 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
     try {
         const pathCommand = Platform.isWindows() ? "echo %PATH%" : "echo $PATH"
         const rawPath = await exec(pathCommand)
-        const path = rawPath.toString().replace(/[\n\r]/g, "")
-
+        const path = rawPath.toString()
+        console.log("Path ==============================", path)
         existingPath = path || process.env.Path || process.env.PATH
     } catch (e) {
+        console.log('error: ', e);
         existingPath = process.env.Path || process.env.PATH
     }
 
     requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))
-
+    console.log('requireOptions.env.PATH: ', requiredOptions.env.PATH);
     return {
         ...originalSpawnOptions,
         ...requiredOptions,

--- a/browser/src/Plugins/Api/shell-env.d.ts
+++ b/browser/src/Plugins/Api/shell-env.d.ts
@@ -1,0 +1,1 @@
+declare module "shell-env"

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -122,7 +122,6 @@ export class LanguageClientProcess {
         }
 
         if (!this._process || !this._process.pid) {
-            console.log("this._process: ", this._process)
             throw new Error("Unable to start language server process")
         }
 

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -122,6 +122,7 @@ export class LanguageClientProcess {
         }
 
         if (!this._process || !this._process.pid) {
+            console.log("this._process: ", this._process)
             throw new Error("Unable to start language server process")
         }
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "oni-ripgrep": "0.0.3",
     "oni-types": "0.0.4",
     "redux-batched-subscribe": "^0.1.6",
+    "shell-env": "^0.3.0",
     "typescript": "2.6.1",
     "vscode-jsonrpc": "3.5.0",
     "vscode-languageserver": "3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,6 +1527,13 @@ cross-spawn@^3.0.1:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-spawn@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1753,6 +1760,10 @@ deepmerge@~1.3.2:
 deepmerge@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
+
+default-shell@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -2274,6 +2285,18 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -2615,6 +2638,13 @@ get-caller-file@^1.0.1:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -5467,6 +5497,14 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shell-env@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-0.3.0.tgz#2250339022989165bda4eb7bf383afeaaa92dc34"
+  dependencies:
+    default-shell "^1.0.0"
+    execa "^0.5.0"
+    strip-ansi "^3.0.0"
 
 shelljs@0.7.7:
   version "0.7.7"


### PR DESCRIPTION
@bryphe, whilst investigating a solution to #1061, I realised that swapping out `shell-env` for the call to `childProcess.exec` does not actually work the same way i.e. logging the path output of both processes, `shell-env` correctly picks up the path and plain process call doesn't once the app is built. I hadn't realised that that wasn't working as I still had the additional env variables set in my config so it was picking up my executables which led me to believe the process exec method was working.

With `shell-env` things appear to work correctly and the `which go-langserver` returns the correct response. Apologies thought we had cracked it earlier and wouldn't need the extra dependency, which I've re-added. I've also left out shell-env's associated dependencies and just installed shell-env.