### PR TITLE
Fix #1063: Overly aggressive definition underlining

### DIFF
--- a/browser/src/Services/Language/LanguageEditorIntegration.ts
+++ b/browser/src/Services/Language/LanguageEditorIntegration.ts
@@ -115,15 +115,13 @@ export class LanguageEditorIntegration implements OniTypes.IDisposable {
     }
 
     private _onStateUpdate(newState: ILanguageState): void {
-        if (newState.definitionResult.result && !this._lastState.definitionResult.result) {
-
-            // Only show if there is actually a location specified...
-            if (newState.definitionResult.result.location) {
-                this._onShowDefinition.dispatch(newState.definitionResult.result)
-            }
+        const newLocationResult = getLocationFromState(newState)
+        const lastLocationResult = getLocationFromState(this._lastState)
+        if (newLocationResult && !lastLocationResult) {
+            this._onShowDefinition.dispatch(newState.definitionResult.result)
         }
 
-        if (!newState.definitionResult.result && this._lastState.definitionResult.result) {
+        if (!newLocationResult && lastLocationResult) {
             this._onHideDefinition.dispatch()
         }
 
@@ -136,5 +134,13 @@ export class LanguageEditorIntegration implements OniTypes.IDisposable {
         }
 
         this._lastState = newState
+    }
+}
+
+const getLocationFromState = (state: ILanguageState): types.Location => {
+    if (state && state.definitionResult && state.definitionResult.result && state.definitionResult.result.location) {
+        return state.definitionResult.result.location
+    } else {
+        return null
     }
 }

--- a/browser/src/Services/Language/LanguageEditorIntegration.ts
+++ b/browser/src/Services/Language/LanguageEditorIntegration.ts
@@ -10,6 +10,8 @@ import { Store, Unsubscribe } from "redux"
 import * as Oni from "oni-api"
 import * as OniTypes from "oni-types"
 
+import * as types from "vscode-languageserver-types"
+
 import { Configuration } from "./../Configuration"
 
 import { createStore, DefaultLanguageState, ILanguageState } from "./LanguageStore"

--- a/browser/src/Services/Language/LanguageEditorIntegration.ts
+++ b/browser/src/Services/Language/LanguageEditorIntegration.ts
@@ -116,7 +116,11 @@ export class LanguageEditorIntegration implements OniTypes.IDisposable {
 
     private _onStateUpdate(newState: ILanguageState): void {
         if (newState.definitionResult.result && !this._lastState.definitionResult.result) {
-            this._onShowDefinition.dispatch(newState.definitionResult.result)
+
+            // Only show if there is actually a location specified...
+            if (newState.definitionResult.result.location) {
+                this._onShowDefinition.dispatch(newState.definitionResult.result)
+            }
         }
 
         if (!newState.definitionResult.result && this._lastState.definitionResult.result) {

--- a/browser/test/Services/Language/LanguageEditorIntegrationTests.ts
+++ b/browser/test/Services/Language/LanguageEditorIntegrationTests.ts
@@ -4,9 +4,21 @@
 
 import * as assert from "assert"
 
+import * as types from "vscode-languageserver-types"
+
 import * as Language from "./../../../src/Services/Language"
 
 import * as Mocks from "./../../Mocks"
+
+const createSuccessfulDefinitionResult = (): Language.IDefinitionResult => {
+    return {
+        location: types.Location.create("testuri", types.Range.create(1, 1, 5, 5)),
+        token: {
+            tokenName: "test",
+            range: types.Range.create(1, 1, 2, 2),
+        }
+    }
+}
 
 describe("LanguageEditorIntegration", () => {
     const clock: any = global["clock"] // tslint:disable-line
@@ -54,7 +66,7 @@ describe("LanguageEditorIntegration", () => {
         assert.strictEqual(mockHoverRequestor.pendingCallCount, 1)
 
         // Resolve the calls
-        mockDefinitionRequestor.resolve({} as any)
+        mockDefinitionRequestor.resolve(createSuccessfulDefinitionResult())
         mockHoverRequestor.resolve({} as any)
 
         await waitForPromiseResolution()

--- a/browser/test/Services/Language/LanguageEditorIntegrationTests.ts
+++ b/browser/test/Services/Language/LanguageEditorIntegrationTests.ts
@@ -16,7 +16,7 @@ const createSuccessfulDefinitionResult = (): Language.IDefinitionResult => {
         token: {
             tokenName: "test",
             range: types.Range.create(1, 1, 2, 2),
-        }
+        },
     }
 }
 
@@ -211,7 +211,7 @@ describe("LanguageEditorIntegration", () => {
         mockDefinitionRequestor.resolve({
             token: {
                 tokenName: "test",
-                range: null
+                range: null,
             },
             location: null,
         })


### PR DESCRIPTION
__Issue:__ We are underlining every token, not just ones that actually have a definition provided by a language server.

__Defect:__ The result form of the definition needs two parts - a token and a location. We assumed if we got a result at all, we have a definition, but it's really gated on whether the location is available.

__Fix:__ Update logic to check for location, rather than result, and add a unit test to cover this case.