### PR TITLE
Automation: Add explicit wait for Neovim initialization

### DIFF
--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -36,7 +36,7 @@ export class Automation implements OniApi.Automation.Api {
         return new Promise<void>((r) => window.setTimeout(() => r(), time))
     }
 
-    public async waitFor(condition: () => boolean, timeout: number = 5000): Promise<void> {
+    public async waitFor(condition: () => boolean, timeout: number = 10000): Promise<void> {
         Log.info("[AUTOMATION] Starting wait - limit: " + timeout)
         let time = 0
         const interval = 1000

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -73,7 +73,7 @@ export class Automation implements OniApi.Automation.Api {
             // TODO: Replace with a more explicit condition, once our startup
             // path is well-defined (#89, #355, #372)
             Log.info("[AUTOMATION] Waiting for neovim to attach...")
-            await this.waitFor(() => oni.editors.activeEditor.neovim && (oni.editors.activeEditor as any).neovim.isAttached, 30000)
+            await this.waitFor(() => oni.editors.activeEditor.neovim && (oni.editors.activeEditor as any).neovim.isInitialized, 30000)
             Log.info("[AUTOMATION] Neovim attached!")
             await testCase.test(oni)
             Log.info("[AUTOMATION] Completed test: " + testPath)

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -70,8 +70,10 @@ export class Automation implements OniApi.Automation.Api {
             const oni = new Oni()
             // Add explicit wait for Neovim to be initialized
             // The CI machines can often be slow, so we need a longer timout for it
+            // TODO: Replace with a more explicit condition, once our startup
+            // path is well-defined (#89, #355, #372)
             Log.info("[AUTOMATION] Waiting for neovim to attach...")
-            await this.waitFor(() => oni.editors.activeEditor.neovim && (<any>oni.editors.activeEditor).neovim.isAttached, 30000)
+            await this.waitFor(() => oni.editors.activeEditor.neovim && (oni.editors.activeEditor as any).neovim.isAttached, 30000)
             Log.info("[AUTOMATION] Neovim attached!")
             await testCase.test(oni)
             Log.info("[AUTOMATION] Completed test: " + testPath)

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -67,7 +67,13 @@ export class Automation implements OniApi.Automation.Api {
         try {
             Log.info("[AUTOMATION] Starting test: " + testPath)
             const testCase: any = Utility.nodeRequire(testPath2)
-            await testCase.test(new Oni())
+            const oni = new Oni()
+            // Add explicit wait for Neovim to be initialized
+            // The CI machines can often be slow, so we need a longer timout for it
+            Log.info("[AUTOMATION] Waiting for neovim to attach...")
+            await this.waitFor(() => oni.editors.activeEditor.neovim && (<any>oni.editors.activeEditor).neovim.isAttached, 30000)
+            Log.info("[AUTOMATION] Neovim attached!")
+            await testCase.test(oni)
             Log.info("[AUTOMATION] Completed test: " + testPath)
             this._reportResult(true)
         } catch (ex) {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -159,6 +159,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _cols: number
 
     private _quickFix: QuickFixList
+    private _attached: boolean
 
     private _onDirectoryChanged = new Event<string>()
     private _onErrorEvent = new Event<Error | string>()
@@ -178,6 +179,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _onColorsChanged = new Event<void>()
 
     private _pendingScrollTimeout: number | null = null
+
+    public get isAttached(): boolean {
+        return this._attached
+    }
 
     public get quickFix(): IQuickFixList {
         return this._quickFix
@@ -366,6 +371,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                         // set title after attaching listeners so we can get the initial title
                         await this.command("set title")
                         await this.callFunction("OniConnect", [])
+
+                        this._attached = true
                     },
                     (err: any) => {
                         this._onError(err)

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -159,7 +159,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _cols: number
 
     private _quickFix: QuickFixList
-    private _attached: boolean
+    private _initComplete: boolean
 
     private _onDirectoryChanged = new Event<string>()
     private _onErrorEvent = new Event<Error | string>()
@@ -180,8 +180,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private _pendingScrollTimeout: number | null = null
 
-    public get isAttached(): boolean {
-        return this._attached
+    public get isInitialized(): boolean {
+        return this._initComplete
     }
 
     public get quickFix(): IQuickFixList {
@@ -372,10 +372,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                         await this.command("set title")
                         await this.callFunction("OniConnect", [])
 
-                        this._attached = true
+                        this._initComplete = true
                     },
                     (err: any) => {
                         this._onError(err)
+                        this._initComplete = true
                     })
             })
 

--- a/test/ci/AutoCompletionTest-TypeScript.ts
+++ b/test/ci/AutoCompletionTest-TypeScript.ts
@@ -3,18 +3,12 @@
  */
 
 import * as assert from "assert"
-import * as os from "os"
-import * as path from "path"
 
-import { getCompletionElement } from "./Common"
+import { createNewFile, getCompletionElement } from "./Common"
 
 export const test = async (oni: any) => {
-    const dir = os.tmpdir()
-    const testFileName = `testFile-${new Date().getTime()}.ts`
-    const tempFilePath = path.join(dir, testFileName)
-    oni.automation.sendKeys(":e " + tempFilePath)
-    oni.automation.sendKeys("<cr>")
-    await oni.automation.sleep(500)
+    await createNewFile("ts", oni)
+
     oni.automation.sendKeys("i")
     await oni.automation.sleep(500)
     oni.automation.sendKeys("window.a")

--- a/test/ci/Common.ts
+++ b/test/ci/Common.ts
@@ -2,6 +2,11 @@
  * Test scripts for QuickOpen
  */
 
+import * as Oni from "oni-api"
+
+import * as os from "os"
+import * as path from "path"
+
 export const getCompletionElement = () => {
     return getElementByClassName("autocompletion")
 }
@@ -15,4 +20,15 @@ export const getElementByClassName = (className: string) => {
     } else {
         return elements[0]
     }
+}
+
+export const createNewFile = async (fileExtension: string, oni: Oni.Plugin.Api): Promise<void> => {
+    const dir = os.tmpdir()
+    const testFileName = `testFile-${new Date().getTime()}.${fileExtension}`
+    const tempFilePath = path.join(dir, testFileName)
+
+    oni.automation.sendKeys(":e " + tempFilePath)
+    oni.automation.sendKeys("<cr>")
+
+    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.filePath === tempFilePath, 10000)
 }

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -41,7 +41,7 @@ export const test = async (oni: any) => {
 
     oni.automation.sendKeys(":e " + filePath + "<CR>")
 
-    await oni.automation.sleep(500)
+    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.filePath === filePath)
 
     oni.automation.sendKeys("/switchMap<CR>")
 


### PR DESCRIPTION
Our automation is less stable on the OSX build machines, and it seems that TravisCI is actually using VMs that are somewhat slow. From looking at the logs, it appears that our tests are executing prior to Neovim being fully initialized (which wouldn't work!).

This change adds an explicit wait for Neovim initialization, to get more consistent test results.