### PR TITLE
Automation: Re-enable CSS test

### DIFF
--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -11,7 +11,7 @@ const LongTimeout = 5000
 
 const CiTests = [
     "BasicEditingTest",
-//    "AutoCompletionTest-CSS",
+    "AutoCompletionTest-CSS",
     "AutoCompletionTest-TypeScript",
     "QuickOpenTest",
     "StatusBar-Mode",

--- a/test/ci/AutoCompletionTest-CSS.ts
+++ b/test/ci/AutoCompletionTest-CSS.ts
@@ -3,18 +3,12 @@
  */
 
 import * as assert from "assert"
-import * as os from "os"
-import * as path from "path"
 
-import { getCompletionElement } from "./Common"
+import { createNewFile, getCompletionElement } from "./Common"
 
 export const test = async (oni: any) => {
-    const dir = os.tmpdir()
-    const testFileName = `testFile-${new Date().getTime()}.css`
-    const tempFilePath = path.join(dir, testFileName)
-    oni.automation.sendKeys(":e " + tempFilePath)
-    oni.automation.sendKeys("<cr>")
-    await oni.automation.sleep(500)
+    await createNewFile("css", oni)
+
     oni.automation.sendKeys("i")
     await oni.automation.sleep(500)
     oni.automation.sendKeys(".test { pos")


### PR DESCRIPTION
The `createNewFile` utility, which deterministically  waits for the file to be created and the buffer to be entered, should address the failures we had previously.