### PR TITLE
Bugfix: Hide neovim popup menu when switching buffer

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -116,7 +116,7 @@ export class NeovimEditor extends Editor implements IEditor {
             this._neovimInstance.onShowPopupMenu,
             this._neovimInstance.onHidePopupMenu,
             this._neovimInstance.onSelectPopupMenu,
-            this.onBufferChanged,
+            this.onBufferEnter,
         )
 
         this._renderer = new CanvasRenderer()

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -116,6 +116,7 @@ export class NeovimEditor extends Editor implements IEditor {
             this._neovimInstance.onShowPopupMenu,
             this._neovimInstance.onHidePopupMenu,
             this._neovimInstance.onSelectPopupMenu,
+            this.onBufferChanged,
         )
 
         this._renderer = new CanvasRenderer()

--- a/browser/src/Editor/NeovimPopupMenu.tsx
+++ b/browser/src/Editor/NeovimPopupMenu.tsx
@@ -6,8 +6,8 @@
 
 import * as React from "react"
 
-import { IEvent } from "oni-types"
 import * as Oni from "oni-api"
+import { IEvent } from "oni-types"
 
 import { INeovimCompletionInfo, INeovimCompletionItem } from "./../neovim"
 
@@ -30,7 +30,7 @@ export class NeovimPopupMenu {
         private _popupMenuShowEvent: IEvent<INeovimCompletionInfo>,
         private _popupMenuHideEvent: IEvent<void>,
         private _popupMenuSelectEvent: IEvent<number>,
-        private _onBufferEnterEvent: IEvent<Oni.EditorBufferEventArgs>
+        private _onBufferEnterEvent: IEvent<Oni.EditorBufferEventArgs>,
     ) {
 
         this._popupMenuShowEvent.subscribe((completionInfo) => {

--- a/browser/src/Editor/NeovimPopupMenu.tsx
+++ b/browser/src/Editor/NeovimPopupMenu.tsx
@@ -7,6 +7,8 @@
 import * as React from "react"
 
 import { IEvent } from "oni-types"
+import * as Oni from "oni-api"
+
 import { INeovimCompletionInfo, INeovimCompletionItem } from "./../neovim"
 
 import * as UI from "./../UI"
@@ -28,6 +30,7 @@ export class NeovimPopupMenu {
         private _popupMenuShowEvent: IEvent<INeovimCompletionInfo>,
         private _popupMenuHideEvent: IEvent<void>,
         private _popupMenuSelectEvent: IEvent<number>,
+        private _onBufferEnterEvent: IEvent<Oni.EditorBufferEventArgs>
     ) {
 
         this._popupMenuShowEvent.subscribe((completionInfo) => {
@@ -37,11 +40,14 @@ export class NeovimPopupMenu {
         })
 
         this._popupMenuSelectEvent.subscribe((idx) => {
-
             this._renderCompletionMenu(idx)
         })
 
         this._popupMenuHideEvent.subscribe(() => {
+            UI.Actions.hideToolTip("nvim-popup")
+        })
+
+        this._onBufferEnterEvent.subscribe(() => {
             UI.Actions.hideToolTip("nvim-popup")
         })
     }


### PR DESCRIPTION
While testing out the rendering issue in #1014 , saw an issue where the NeovimPopupMenu will stay open after switching buffers. 

It's easy to reproduce by:
1) Open a file a.txt
2) Open a file b.txt
3) In b, trigger the vim popup menu
4) Switch to a

Expected: Popup menu should disappear
Actual: Popup menu stays open

Fixed by closing the popup menu on buffer enter