### PR TITLE
#1076 - Crash on buffer change event

### DIFF
--- a/browser/src/Services/Completion/Completion.ts
+++ b/browser/src/Services/Completion/Completion.ts
@@ -146,7 +146,7 @@ export class Completion implements IDisposable {
 
         const newLine = firstChange.text
 
-        if (range.start.line === this._lastCursorPosition.line) {
+        if (this._lastCursorPosition && range.start.line === this._lastCursorPosition.line) {
             this._store.dispatch({
                 type: "CURSOR_MOVED",
                 line: this._lastCursorPosition.line,

--- a/browser/test/Services/Completion/CompletionTests.ts
+++ b/browser/test/Services/Completion/CompletionTests.ts
@@ -230,4 +230,17 @@ describe("Completion", () => {
 
         assert.strictEqual(lastItems, null, "Completions should be null, as the only request that was completed was outdated")
     })
+
+    it("#1076 - should not crash if buffer change comes before first cursor move", () => {
+        mockEditor.simulateBufferEnter(new Mocks.MockBuffer("typescript", "test1.ts", []))
+
+        // Switch to insert mode
+        mockEditor.simulateModeChange("insert")
+
+        // Simulate typing, but with the buffer update coming prior to the cursor move.
+        mockEditor.setActiveBufferLine(0, "win")
+        mockEditor.simulateCursorMoved(0, 3)
+
+        assert.ok(true, "Did not crash")
+    })
 })


### PR DESCRIPTION
__Issue:__ The code in `Completion.ts` makes the assumption that the order of events will always be `cursor_moved` and then `buffer_changed`. Because of this, when there is a buffer update, it assumes that `this._lastCursorPosition` will be populated. If that assumption is not true, there will be a crash.

__Fix:__ Guard against the initial case where `this._lastCursorPosition` isn't populated. This should prevent the crash, but further investigation is needed to make sure that completion works correctly (the worst case would be that the cursor movement event, in some cases, _always_ comes after the buffer update, which would give out-of-date or incorrect completions).