### PR TITLE
Feature - Sidebar (Part 1)

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -48,6 +48,8 @@ const BaseConfiguration: IConfigurationValues = {
     // TODO: Enable pipe transport for Windows
     // "experimental.neovim.transport": Platform.isWindows() ? "pipe" : "stdio",
 
+    "experimental.sidebar.enabled": false,
+
     "oni.audio.bellUrl": null,
 
     "oni.useDefaultConfig": true,

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -171,6 +171,8 @@ const BaseConfiguration: IConfigurationValues = {
     "recorder.copyScreenshotToClipboard": false,
     "recorder.outputPath": os.tmpdir(),
 
+    "sidebar.width": "50px",
+
     "statusbar.enabled": true,
     "statusbar.fontSize": "0.9em",
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -49,6 +49,8 @@ export interface IConfigurationValues {
     // If a file has more lines than this value, syntax highlighting will be disabled
     "experimental.editor.textMateHighlighting.maxLines": number
 
+    "experimental.sidebar.enabled": boolean
+
     // The transport to use for Neovim
     // Valid values are "stdio" and "pipe"
     "experimental.neovim.transport": string

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -177,6 +177,8 @@ export interface IConfigurationValues {
     // of saving to file
     "recorder.copyScreenshotToClipboard": boolean
 
+    "sidebar.width": string
+
     "statusbar.enabled": boolean
     "statusbar.fontSize": string
 

--- a/browser/src/Services/Sidebar/Sidebar.less
+++ b/browser/src/Services/Sidebar/Sidebar.less
@@ -9,6 +9,7 @@
         justify-content: center;
         align-items: center;
         opacity: 0.2;
+        outline: none;
 
         &.active {
             cursor: pointer;

--- a/browser/src/Services/Sidebar/Sidebar.less
+++ b/browser/src/Services/Sidebar/Sidebar.less
@@ -1,0 +1,29 @@
+@import (reference) "./../../UI/components/common.less";
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+
+    .sidebar-icon-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        opacity: 0.2;
+
+        &.active {
+            cursor: pointer;
+            opacity: 0.75;
+        }
+
+        &.active:hover {
+            .box-shadow;
+            transform: translateY(2px);
+            opacity: 0.9;
+        }
+
+        .sidebar-icon {
+            margin-top: 16px;
+            margin-bottom: 16px;
+        }
+    }
+}

--- a/browser/src/Services/Sidebar/SidebarSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarSplit.tsx
@@ -1,0 +1,74 @@
+/**
+ * UI/index.tsx
+ *
+ * Root setup & state for the UI
+ * - Top-level render function lives here
+ */
+
+import * as React from "react"
+
+import { connect } from "react-redux"
+
+import { Icon, IconSize } from "./../../UI/Icon"
+import * as State from "./../../UI/State"
+
+require("./Sidebar.less")
+
+export interface ISidebarIconProps {
+    active: boolean
+    iconName: string
+}
+
+export class SidebarIcon extends React.PureComponent<ISidebarIconProps, {}> {
+    public render(): JSX.Element {
+
+        const className = "sidebar-icon-container " + (this.props.active ? "active" : "inactive")
+        return <div className={className} tabIndex={0}>
+                    <div className="sidebar-icon">
+                        <Icon name={this.props.iconName} size={IconSize.Large} />
+                    </div>
+                </div>
+    }
+}
+
+export interface ISidebarProps {
+    backgroundColor: string
+    foregroundColor: string
+    width: string
+}
+
+export class SidebarView extends React.PureComponent<ISidebarProps, {}> {
+    public render(): JSX.Element {
+        const style: React.CSSProperties = {
+            color: this.props.foregroundColor,
+            backgroundColor: this.props.backgroundColor,
+            width: this.props.width,
+        }
+        
+        return <div className="sidebar enable-mouse" style={style}>
+                <SidebarIcon iconName={"files-o"} active={true}/>
+                <SidebarIcon iconName={"search"} active={false}/>
+                <SidebarIcon iconName={"graduation-cap"} active={false}/>
+                <SidebarIcon iconName={"code-fork"} active={false}/>
+                <SidebarIcon iconName={"bug"} active={false}/>
+            </div>
+
+    }
+}
+
+export const mapStateToProps = (state: State.IState): ISidebarProps => {
+    return {
+        backgroundColor: state.colors["background"],
+        foregroundColor: state.colors["foreground"],
+        width: state.configuration["sidebar.width"],
+    }
+}
+
+const Sidebar = connect(mapStateToProps)(SidebarView)
+
+export class SidebarSplit {
+    public render(): JSX.Element {
+        return <Sidebar />
+    }
+}
+

--- a/browser/src/Services/Sidebar/SidebarSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarSplit.tsx
@@ -46,6 +46,10 @@ export class SidebarView extends React.PureComponent<ISidebarProps, {}> {
             width: this.props.width,
         }
 
+        if (!this.props.visible) {
+            return null
+        }
+
         return <div className="sidebar enable-mouse" style={style}>
                 <SidebarIcon iconName={"files-o"} active={true}/>
                 <SidebarIcon iconName={"search"} active={false}/>
@@ -60,8 +64,8 @@ export class SidebarView extends React.PureComponent<ISidebarProps, {}> {
 export const mapStateToProps = (state: State.IState): ISidebarProps => {
     return {
         visible: state.configuration["experimental.sidebar.enabled"],
-        backgroundColor: state.colors["background"],
-        foregroundColor: state.colors["foreground"],
+        backgroundColor: state.colors.background,
+        foregroundColor: state.colors.foreground,
         width: state.configuration["sidebar.width"],
     }
 }
@@ -73,4 +77,4 @@ export class SidebarSplit {
         return <Sidebar />
     }
 }
-
+

--- a/browser/src/Services/Sidebar/SidebarSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarSplit.tsx
@@ -35,6 +35,7 @@ export interface ISidebarProps {
     backgroundColor: string
     foregroundColor: string
     width: string
+    visible: boolean
 }
 
 export class SidebarView extends React.PureComponent<ISidebarProps, {}> {
@@ -44,7 +45,7 @@ export class SidebarView extends React.PureComponent<ISidebarProps, {}> {
             backgroundColor: this.props.backgroundColor,
             width: this.props.width,
         }
-        
+
         return <div className="sidebar enable-mouse" style={style}>
                 <SidebarIcon iconName={"files-o"} active={true}/>
                 <SidebarIcon iconName={"search"} active={false}/>
@@ -58,6 +59,7 @@ export class SidebarView extends React.PureComponent<ISidebarProps, {}> {
 
 export const mapStateToProps = (state: State.IState): ISidebarProps => {
     return {
+        visible: state.configuration["experimental.sidebar.enabled"],
         backgroundColor: state.colors["background"],
         foregroundColor: state.colors["foreground"],
         width: state.configuration["sidebar.width"],

--- a/browser/src/Services/Sidebar/SidebarSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarSplit.tsx
@@ -12,7 +12,7 @@ import { connect } from "react-redux"
 import { Icon, IconSize } from "./../../UI/Icon"
 import * as State from "./../../UI/State"
 
-require("./Sidebar.less")
+require("./Sidebar.less") // tslint:disable-line
 
 export interface ISidebarIconProps {
     active: boolean
@@ -77,4 +77,3 @@ export class SidebarSplit {
         return <Sidebar />
     }
 }
-

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from "./SidebarSplit"

--- a/browser/src/Services/WindowManager.ts
+++ b/browser/src/Services/WindowManager.ts
@@ -26,19 +26,48 @@ import { applySplit, closeSplit, createSplitLeaf, createSplitRoot, ISplitInfo, S
 export interface IWindowDock {
     splits: Oni.IWindowSplit[]
 
-    onSplitsChanged(): IEvent<void>
+    onSplitsChanged: IEvent<void>
 
     addSplit(split: Oni.IWindowSplit): void 
     removeSplit(split: Oni.IWindowSplit): void
 }
 
+export class WindowDock implements IWindowDock {
+
+    private _splits: Oni.IWindowSplit[] = []
+    private _onSplitsChangedEvent: Event<void> = new Event<void>()
+
+    public get splits(): Oni.IWindowSplit[] {
+        return this._splits
+    }
+
+    public get onSplitsChanged(): IEvent<void> {
+        return this._onSplitsChangedEvent
+    }
+
+    public addSplit(split: Oni.IWindowSplit): void {
+        this._splits.push(split)
+        this._onSplitsChangedEvent.dispatch()
+    }
+
+    public removeSplit(split: Oni.IWindowSplit): void {
+        this._splits = this._splits.filter((s) => s !== split)
+        this._onSplitsChangedEvent.dispatch()
+    }
+}
+
 export class WindowManager implements Oni.IWindowManager {
-    // private _activeSplit: ISplitLeaf<Oni.IWindowSplit>
+    private _activeSplit: Oni.IWindowSplit
     private _splitRoot: ISplitInfo<Oni.IWindowSplit>
 
+    private _onActiveSplitChangedEvent = new Event<Oni.IWindowSplit>()
     private _onSplitChanged = new Event<ISplitInfo<Oni.IWindowSplit>>()
 
     private _leftDock: IWindowDock = null
+
+    public get onActiveSplitChanged(): IEvent<Oni.IWindowSplit> {
+        return this._onActiveSplitChangedEvent
+    }
 
     public get onSplitChanged(): IEvent<ISplitInfo<Oni.IWindowSplit>> {
         return this._onSplitChanged
@@ -48,7 +77,12 @@ export class WindowManager implements Oni.IWindowManager {
         return this._splitRoot
     }
 
+    public get activeSplit(): Oni.IWindowSplit {
+        return this._activeSplit
+    }
+
     constructor() {
+        this._leftDock = new WindowDock()
         this._splitRoot = createSplitRoot(SplitDirection.Horizontal)
         // this._activeSplit = null
     }

--- a/browser/src/Services/WindowManager.ts
+++ b/browser/src/Services/WindowManager.ts
@@ -28,7 +28,7 @@ export interface IWindowDock {
 
     onSplitsChanged: IEvent<void>
 
-    addSplit(split: Oni.IWindowSplit): void 
+    addSplit(split: Oni.IWindowSplit): void
     removeSplit(split: Oni.IWindowSplit): void
 }
 

--- a/browser/src/Services/WindowManager.ts
+++ b/browser/src/Services/WindowManager.ts
@@ -11,13 +11,34 @@
 import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 
+// TODO: Add 'direction' enum to `oni-types'
+export enum Direction {
+    Right = 0,
+    Bottom = 1,
+    Left = 2,
+    Top = 3,
+}
+
+// TODO: Add optional `enter` and `leave` methods to `oni-api`
+
 import { applySplit, closeSplit, createSplitLeaf, createSplitRoot, ISplitInfo, SplitDirection } from "./WindowSplit"
+
+export interface IWindowDock {
+    splits: Oni.IWindowSplit[]
+
+    onSplitsChanged(): IEvent<void>
+
+    addSplit(split: Oni.IWindowSplit): void 
+    removeSplit(split: Oni.IWindowSplit): void
+}
 
 export class WindowManager implements Oni.IWindowManager {
     // private _activeSplit: ISplitLeaf<Oni.IWindowSplit>
     private _splitRoot: ISplitInfo<Oni.IWindowSplit>
 
     private _onSplitChanged = new Event<ISplitInfo<Oni.IWindowSplit>>()
+
+    private _leftDock: IWindowDock = null
 
     public get onSplitChanged(): IEvent<ISplitInfo<Oni.IWindowSplit>> {
         return this._onSplitChanged
@@ -55,6 +76,16 @@ export class WindowManager implements Oni.IWindowManager {
         // TODO
     }
 
+    public getDock(direction: Direction): IWindowDock {
+        if (direction === Direction.Left) {
+            return this._leftDock
+        } else {
+            // TODO
+            return null
+        }
+    }
+
+    // TODO: Deprecate
     public showDock(direction: SplitDirection, split: Oni.IWindowSplit) {
         // TODO
     }

--- a/browser/src/UI/components/WindowSplitHost.tsx
+++ b/browser/src/UI/components/WindowSplitHost.tsx
@@ -10,6 +10,8 @@ import * as Oni from "oni-api"
 
 export interface IWindowSplitHostProps {
     split: Oni.IWindowSplit
+    containerClassName: string
+    isFocused: boolean
 }
 
 /**
@@ -18,8 +20,11 @@ export interface IWindowSplitHostProps {
 export class WindowSplitHost extends React.PureComponent<IWindowSplitHostProps, {}> {
 
     public render(): JSX.Element {
+
+        const className = this.props.containerClassName + (this.props.isFocused ? " focus" : " not-focused")
+
         return <div className="container vertical full">
-                <div className="editor">
+                <div className={className}>
                     {this.props.split.render()}
                 </div>
         </div>

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -10,7 +10,7 @@ import * as Oni from "oni-api"
 
 import { WindowSplitHost } from "./WindowSplitHost"
 
-import { WindowManager } from "./../../Services/WindowManager"
+import { Direction, WindowManager } from "./../../Services/WindowManager"
 import { ISplitInfo } from "./../../Services/WindowSplit"
 
 export interface IWindowSplitsProps {
@@ -18,7 +18,24 @@ export interface IWindowSplitsProps {
 }
 
 export interface IWindowSplitsState {
+    activeSplit: Oni.IWindowSplit
     splitRoot: ISplitInfo<Oni.IWindowSplit>
+    leftDock: Oni.IWindowSplit[]
+}
+
+export interface IDockProps {
+    activeSplit: Oni.IWindowSplit
+    splits: Oni.IWindowSplit[]
+}
+
+export class Dock extends React.PureComponent<IDockProps, {}> {
+    public render(): JSX.Element {
+        const docks = this.props.splits.map((s) => <WindowSplitHost containerClassName="split" split={s} isFocused={this.props.activeSplit === s} />)
+
+        return <div className = "dock container fixed horizointal">
+            {docks}
+            </div>
+    }
 }
 
 export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindowSplitsState> {
@@ -27,7 +44,9 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
         super(props)
 
         this.state = {
+            activeSplit: props.windowManager.activeSplit,
             splitRoot: props.windowManager.splitRoot,
+            leftDock: props.windowManager.getDock(Direction.Left).splits,
         }
     }
 
@@ -35,6 +54,12 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
         this.props.windowManager.onSplitChanged.subscribe((newSplit) => {
             this.setState({
                 splitRoot: newSplit,
+            })
+        })
+
+        this.props.windowManager.getDock(Direction.Left).onSplitsChanged.subscribe(() => {
+            this.setState({
+                leftDock: this.props.windowManager.getDock(Direction.Left).splits,
             })
         })
     }
@@ -60,13 +85,16 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
                 if (!split) {
                     return <div className="container vertical full" key={i}>TODO: Implement an editor here...</div>
                 } else {
-                    return <WindowSplitHost key={i} split={split} />
+                    return <WindowSplitHost containerClassName={"editor"} key={i} split={split} isFocused={split === this.state.activeSplit}/>
                 }
             }
         })
 
         return <div style={containerStyle}>
-                    {editors}
+                    <div className="container horizontal full">
+                        <Dock splits={this.state.leftDock} activeSplit={this.state.activeSplit} />
+                        {editors}
+                    </div>
                 </div>
     }
 }

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -22,6 +22,7 @@ import * as State from "./State"
 import { editorManager } from "./../Services/EditorManager"
 import { focusManager } from "./../Services/FocusManager"
 import { listenForDiagnostics } from "./../Services/Language"
+import { SidebarSplit } from "./../Services/Sidebar"
 import { windowManager } from "./../Services/WindowManager"
 
 import { PluginManager } from "./../Plugins/PluginManager"
@@ -52,12 +53,6 @@ const updateViewport = () => {
     const height = document.body.offsetHeight
 
     Actions.setViewport(width, height)
-}
-
-export class SidebarSplit {
-    public render(): JSX.Element {
-        return <div className="sidebar enable-mouse">Hello</div>
-    }
 }
 
 function render(_state: State.IState, pluginManager: PluginManager, args: any): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -54,6 +54,12 @@ const updateViewport = () => {
     Actions.setViewport(width, height)
 }
 
+export class SidebarSplit {
+    public render(): JSX.Element {
+        return <div className="sidebar enable-mouse">Hello</div>
+    }
+}
+
 function render(_state: State.IState, pluginManager: PluginManager, args: any): void {
     const hostElement = document.getElementById("host")
 
@@ -63,6 +69,8 @@ function render(_state: State.IState, pluginManager: PluginManager, args: any): 
     editorManager.setActiveEditor(editor)
 
     windowManager.split(0, editor)
+    const leftDock = windowManager.getDock(2)
+    leftDock.addSplit(new SidebarSplit())
 
     ReactDOM.render(
         <Provider store={store}>


### PR DESCRIPTION
__Issue:__ The new features we're working on adding - like the file explorer (#886), search and replace (#614), improved vimtutor (#430), debugger (#85), and plugin management (#186) need a visible entry point. as part of lowering the bar.

This implements the UX portion of the change (making the sidebar mouse-enabled and showing it).
![test](https://user-images.githubusercontent.com/13532591/33636452-0c99fad4-d9d1-11e7-9551-cf9c69fbbc53.png)

Part 2 will implement the Neovim keybindings such that it can be navigated to like a window (`<C-w><C-h>`)

This is currently behind an experimental flag - `experimental.sidebar.enabled`.