### PR TITLE
Fix buffer deletion

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -482,6 +482,7 @@ export class NeovimEditor extends Editor implements IEditor {
         } else if (eventName === "BufDelete") {
 
             this._neovimInstance.getBufferIds()
+                .then((ids) => ids.filter(id => evt.bufferNumber !== id))
                 .then((ids) => UI.Actions.setCurrentBuffers(ids))
         }
     }


### PR DESCRIPTION
@bryphe, I'm working on resolving some of the various quirks with the buffer bar (relates to #852), largely surrounding deleting buffers and having them disappear as well as loading all buffers on `bufenter` and removing non-interactive buffers like that of `NERD_TREE` etc. from the the bar which cause crashes anyway if you try to open these.

As part of that I've been looking to correctly update the buffer bar when `bufDelete` is triggered. I tried using the `getBufferIds` function which communicates with the `msgpack api` but have found that the api returns a list of buffers which *still* includes the deleted buffer.

I've done a fair bit of googling and have not found any related issues but it seems that there's possibly a delay?? 😕 on updating the api.

Anyway a solution I've been using locally for a little while is just filtering out the buffer that triggered the buffer delete autocommand from the list of buffers and dispatching the set current buffers action.

I imagine that a solution via the `msgpack` api would be preferable in the future whether an issue might need to be raised on neovim repo? (if i'm not just mistaken about how the api is used). Another possible solution is that for the other issues re buffers, i've expanded on your `vim interop` plugin and created a function which gets (which gets whatever metadata is available) for each buffer which I plan to trigger on `bufenter` but can also trigger on `bufdelete` and use the result from that to update the state at least that way the answer to what buffers exist is coming from neovim.

What are your thought re this approach or either of the other ones?