### PR TITLE
Refactor start method to better facilitate asynchronous loading

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -61,6 +61,7 @@ export class NeovimEditor extends Editor implements IEditor {
     private _completionMenu: CompletionMenu
     private _popupMenu: NeovimPopupMenu
     private _colors: Colors // TODO: Factor this out to the UI 'Shell'
+    private _errorInitializing: boolean = false
 
     private _pendingAnimationFrame: boolean = false
 
@@ -177,6 +178,7 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         this._neovimInstance.onError.subscribe((err) => {
+            this._errorInitializing = true
             UI.Actions.setNeovimError(true)
         })
 
@@ -378,6 +380,11 @@ export class NeovimEditor extends Editor implements IEditor {
         }
 
         await this._neovimInstance.start(startOptions)
+
+        if (this._errorInitializing) {
+            return
+        }
+
         VimConfigurationSynchronizer.synchronizeConfiguration(this._neovimInstance, this._config.getValues())
 
         this._themeManager.onThemeChanged.subscribe(() => {

--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -4,8 +4,7 @@
  * Takes configuration settings, and applies them to the BrowserWindow
  */
 
-import { Configuration } from "./Configuration"
-import { IConfigurationValues } from "./IConfigurationValues"
+import { Configuration, IConfigurationValues } from "./Configuration"
 
 import { remote, ipcRenderer } from "electron"
 

--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -1,0 +1,51 @@
+/**
+ * BrowserWindowConfigurationSynchronizer
+ *
+ * Takes configuration settings, and applies them to the BrowserWindow
+ */
+
+import { Configuration } from "./Configuration"
+import { IConfigurationValues } from "./IConfigurationValues"
+
+import { remote, ipcRenderer } from "electron"
+
+export const activate = (configuration: Configuration) => {
+    const browserWindow = remote.getCurrentWindow()
+
+    let loadInitVim: boolean = false
+    let maximizeScreenOnStart: boolean = false
+
+    const onConfigChanged = (newConfigValues: Partial<IConfigurationValues>) => {
+
+        document.body.style.fontFamily = configuration.getValue("ui.fontFamily")
+        document.body.style.fontSize = configuration.getValue("ui.fontSize")
+        document.body.style.fontVariant = configuration.getValue("editor.fontLigatures") ? "normal" : "none"
+
+        const fontSmoothing = configuration.getValue("ui.fontSmoothing")
+
+        if (fontSmoothing) {
+            document.body.style["-webkit-font-smoothing"] = fontSmoothing
+        }
+
+        const hideMenu: boolean = configuration.getValue("oni.hideMenu")
+        browserWindow.setAutoHideMenuBar(hideMenu)
+        browserWindow.setMenuBarVisibility(!hideMenu)
+
+        const loadInit: boolean = configuration.getValue("oni.loadInitVim")
+        if (loadInit !== loadInitVim) {
+            ipcRenderer.send("rebuild-menu", loadInit)
+            // don't rebuild menu unless oni.loadInitVim actually changed
+            loadInitVim = loadInit
+        }
+
+        const maximizeScreen: boolean = configuration.getValue("editor.maximizeScreenOnStart")
+        if (maximizeScreen !== maximizeScreenOnStart) {
+            browserWindow.maximize()
+        }
+
+        browserWindow.setFullScreen(configuration.getValue("editor.fullScreenOnStart"))
+    }
+
+    onConfigChanged(configuration.getValues())
+    configuration.onConfigurationChanged.subscribe(onConfigChanged)
+}

--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -5,6 +5,9 @@
  */
 
 import { Configuration, IConfigurationValues } from "./Configuration"
+import * as Colors from "./Colors"
+
+import * as Color from "color"
 
 import { remote, ipcRenderer } from "electron"
 
@@ -13,6 +16,19 @@ export const activate = (configuration: Configuration) => {
 
     let loadInitVim: boolean = false
     let maximizeScreenOnStart: boolean = false
+
+    const colors = Colors.getInstance()
+
+    const onColorsChanged = () => {
+        // TODO: Read from 'persisted setting' instead
+        const backgroundColor = colors.getColor("background")
+        if (backgroundColor) {
+            const background: string = Color(backgroundColor).lighten(0.1).hex().toString();
+            (browserWindow as any).setBackgroundColor(background)
+        }
+    }
+
+    colors.onColorsChanged.subscribe(() => onColorsChanged())
 
     const onConfigChanged = (newConfigValues: Partial<IConfigurationValues>) => {
 

--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -4,18 +4,18 @@
  * Takes configuration settings, and applies them to the BrowserWindow
  */
 
-import { Configuration, IConfigurationValues } from "./Configuration"
 import * as Colors from "./Colors"
+import { Configuration, IConfigurationValues } from "./Configuration"
 
 import * as Color from "color"
 
-import { remote, ipcRenderer } from "electron"
+import { ipcRenderer, remote } from "electron"
 
 export const activate = (configuration: Configuration) => {
     const browserWindow = remote.getCurrentWindow()
 
     let loadInitVim: boolean = false
-    let maximizeScreenOnStart: boolean = false
+    const maximizeScreenOnStart: boolean = false
 
     const colors = Colors.getInstance()
 

--- a/browser/src/Services/Configuration/index.ts
+++ b/browser/src/Services/Configuration/index.ts
@@ -1,3 +1,2 @@
 export * from "./Configuration"
 export * from "./IConfigurationValues"
-

--- a/browser/src/Services/Configuration/index.ts
+++ b/browser/src/Services/Configuration/index.ts
@@ -1,2 +1,3 @@
 export * from "./Configuration"
 export * from "./IConfigurationValues"
+

--- a/browser/src/Services/Sidebar/Sidebar.less
+++ b/browser/src/Services/Sidebar/Sidebar.less
@@ -2,7 +2,7 @@
 
 .sidebar {
 
-    transform: translateX(-6px);
+    transform: translateX(-3px);
     transition: transform 0.25s ease;
 
     .loaded & {

--- a/browser/src/Services/Sidebar/Sidebar.less
+++ b/browser/src/Services/Sidebar/Sidebar.less
@@ -1,6 +1,15 @@
 @import (reference) "./../../UI/components/common.less";
 
 .sidebar {
+
+    transform: translateX(-6px);
+    transition: transform 0.25s ease;
+
+    .loaded & {
+        transform: translateX(0px);
+    }
+
+
     display: flex;
     flex-direction: column;
 

--- a/browser/src/Services/Themes/ThemeManager.ts
+++ b/browser/src/Services/Themes/ThemeManager.ts
@@ -78,11 +78,11 @@ export const getBorderColor = (bgColor: string, fgColor: string): string => {
     const foregroundColor = Color(fgColor)
 
     const borderColor = backgroundColor.luminosity() > 0.5 ? foregroundColor.lighten(0.6) : foregroundColor.darken(0.6)
-    return borderColor.rgb().toString()
+    return borderColor.hex().toString()
 }
 
 export const getBackgroundColor = (editorBackground: string): string => {
-    return Color(editorBackground).darken(0.25).toString()
+    return Color(editorBackground).darken(0.25).hex().toString()
 }
 
 export const getColorsFromBackgroundAndForeground = (background: string, foreground: string) => {

--- a/browser/src/Services/Themes/index.ts
+++ b/browser/src/Services/Themes/index.ts
@@ -3,9 +3,9 @@ export * from "./ThemeManager"
 import { Configuration, IConfigurationValues } from "./../Configuration"
 import { getThemeManagerInstance } from "./ThemeManager"
 
-export const activate = (configuration: Configuration) => {
+export const activate = async (configuration: Configuration): Promise<void> => {
 
-    const updateColorScheme = (configurationValues: Partial<IConfigurationValues>) => {
+    const updateColorScheme = async (configurationValues: Partial<IConfigurationValues>): Promise<void> => {
         const colorscheme = configurationValues["ui.colorscheme"]
         if (colorscheme) {
             const themeManager = getThemeManagerInstance()

--- a/browser/src/Services/Themes/index.ts
+++ b/browser/src/Services/Themes/index.ts
@@ -9,7 +9,7 @@ export const activate = async (configuration: Configuration): Promise<void> => {
         const colorscheme = configurationValues["ui.colorscheme"]
         if (colorscheme) {
             const themeManager = getThemeManagerInstance()
-            themeManager.setTheme(colorscheme)
+            await themeManager.setTheme(colorscheme)
         }
     }
 
@@ -17,5 +17,5 @@ export const activate = async (configuration: Configuration): Promise<void> => {
         updateColorScheme(newValues)
     })
 
-    updateColorScheme(configuration.getValues())
+    await updateColorScheme(configuration.getValues())
 }

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -31,6 +31,10 @@ import { IThemeColors } from "./../Services/Themes"
 export type DispatchFunction = (action: any) => void
 export type GetStateFunction = () => State.IState
 
+export const setLoadingComplete = () => ({
+    type: "SET_LOADING_COMPLETE",
+})
+
 export const setWindowTitle = (title: string) => {
 
     document.title = title

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -31,9 +31,14 @@ import { IThemeColors } from "./../Services/Themes"
 export type DispatchFunction = (action: any) => void
 export type GetStateFunction = () => State.IState
 
-export const setLoadingComplete = () => ({
-    type: "SET_LOADING_COMPLETE",
-})
+export const setLoadingComplete = () => {
+
+    document.body.classList.add("loaded")
+
+    return {
+        type: "SET_LOADING_COMPLETE",
+    }
+}
 
 export const setWindowTitle = (title: string) => {
 

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -18,6 +18,10 @@ import { IThemeColors } from "./../Services/Themes"
 
 import * as types from "vscode-languageserver-types"
 
+export interface ISetLoadingCompleteAction {
+    type: "SET_LOADING_COMPLETE",
+}
+
 export interface ISetWindowTitleAction {
     type: "SET_WINDOW_TITLE",
     payload: {
@@ -257,6 +261,7 @@ export type SimpleAction =
     ISetCurrentBuffersAction |
     ISetNeovimErrorAction |
     ISetTabs |
+    ISetLoadingCompleteAction |
     ISetViewportAction |
     ISetWindowCursor |
     ISetWindowState |

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -21,6 +21,11 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
     }
 
     switch (a.type) {
+        case "SET_LOADING_COMPLETE":
+            return {
+                ...s,
+                isLoaded: true,
+            }
         case "SET_WINDOW_TITLE":
             return {
                 ...s,

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -19,6 +19,21 @@ interface IRootComponentProps {
 
 const titleBarVisible = Platform.isMac()
 
+export class LoadingView extends React.PureComponent<{}, {}> { 
+    public render(): JSX.Element {
+        const style: React.CSSProperties = {
+            position: "absolute",
+            top: "0px",
+            left: "0px",
+            right: "0px",
+            bottom: "0px",
+            backgroundColor: "black",
+        }
+
+        return <div style={style}>LOADING</div>
+    }
+}
+
 export class RootComponent extends React.PureComponent<IRootComponentProps, {}> {
 
     public render() {
@@ -44,6 +59,7 @@ export class RootComponent extends React.PureComponent<IRootComponentProps, {}> 
                     </div>
                 </div>
             </div>
+            <LoadingView />
         </div>
     }
 

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -9,6 +9,7 @@ import { MenuContainer } from "./../Services/Menu"
 import * as WindowManager from "./../Services/WindowManager"
 
 import { Background } from "./components/Background"
+import { Loading } from "./components/Loading"
 import StatusBar from "./components/StatusBar"
 import { WindowSplits } from "./components/WindowSplits"
 import { WindowTitle } from "./components/WindowTitle"
@@ -18,37 +19,6 @@ interface IRootComponentProps {
 }
 
 const titleBarVisible = Platform.isMac()
-
-import { connect } from "react-redux"
-import * as State from "./State"
-
-export interface ILoadingViewProps {
-    visible: boolean
-}
-
-export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> {
-    public render(): JSX.Element {
-        const style: React.CSSProperties = {
-            position: "absolute",
-            top: "0px",
-            left: "0px",
-            right: "0px",
-            bottom: "0px",
-            backgroundColor: "black",
-            display: this.props.visible ? "block" : "none",
-        }
-
-        return <div style={style}>LOADING</div>
-    }
-}
-
-const mapStateToProps = (state: State.IState): ILoadingViewProps => {
-    return {
-        visible: !state.isLoaded,
-    }
-}
-
-export const Loading = connect(mapStateToProps)(LoadingView)
 
 export class RootComponent extends React.PureComponent<IRootComponentProps, {}> {
 

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -19,14 +19,14 @@ interface IRootComponentProps {
 
 const titleBarVisible = Platform.isMac()
 
-import * as State from "./State"
 import { connect } from "react-redux"
+import * as State from "./State"
 
 export interface ILoadingViewProps {
     visible: boolean
 }
 
-export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> { 
+export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> {
     public render(): JSX.Element {
         const style: React.CSSProperties = {
             position: "absolute",
@@ -44,7 +44,7 @@ export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> {
 
 const mapStateToProps = (state: State.IState): ILoadingViewProps => {
     return {
-        visible: !state.isLoaded
+        visible: !state.isLoaded,
     }
 }
 

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -19,7 +19,14 @@ interface IRootComponentProps {
 
 const titleBarVisible = Platform.isMac()
 
-export class LoadingView extends React.PureComponent<{}, {}> { 
+import * as State from "./State"
+import { connect } from "react-redux"
+
+export interface ILoadingViewProps {
+    visible: boolean
+}
+
+export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> { 
     public render(): JSX.Element {
         const style: React.CSSProperties = {
             position: "absolute",
@@ -28,11 +35,20 @@ export class LoadingView extends React.PureComponent<{}, {}> {
             right: "0px",
             bottom: "0px",
             backgroundColor: "black",
+            display: this.props.visible ? "block" : "none",
         }
 
         return <div style={style}>LOADING</div>
     }
 }
+
+const mapStateToProps = (state: State.IState): ILoadingViewProps => {
+    return {
+        visible: !state.isLoaded
+    }
+}
+
+export const Loading = connect(mapStateToProps)(LoadingView)
 
 export class RootComponent extends React.PureComponent<IRootComponentProps, {}> {
 
@@ -59,7 +75,7 @@ export class RootComponent extends React.PureComponent<IRootComponentProps, {}> 
                     </div>
                 </div>
             </div>
-            <LoadingView />
+            <Loading/>
         </div>
     }
 

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -8,7 +8,7 @@ import * as types from "vscode-languageserver-types"
 
 import * as Oni from "oni-api"
 
-import { configuration , IConfigurationValues } from "./../Services/Configuration"
+import { IConfigurationValues } from "./../Services/Configuration"
 
 import { DefaultThemeColors, IThemeColors } from "./../Services/Themes"
 
@@ -55,7 +55,7 @@ export interface IState {
     neovimError: boolean
 
     // Shell
-    isLoading: boolean
+    isLoaded: boolean
     colors: IThemeColors
     windowTitle: string
 
@@ -170,7 +170,12 @@ export interface IStatusBarItem {
 }
 
 export function readConf<K extends keyof IConfigurationValues>(conf: IConfigurationValues, k: K): IConfigurationValues[K] {
-    return conf[k]
+
+    if (!conf) {
+        return null
+    } else {
+        return conf[k]
+    }
 }
 
 export const createDefaultState = (): IState => ({
@@ -196,9 +201,9 @@ export const createDefaultState = (): IState => ({
     cursorLineOpacity: 0,
     cursorColumnOpacity: 0,
     neovimError: false,
-    isLoading: true,
+    isLoaded: false,
 
-    configuration: configuration.getValues(),
+    configuration: {} as IConfigurationValues,
 
     buffers: {
         activeBufferId: null,

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -33,6 +33,7 @@ export interface IToolTip {
 }
 
 export interface IState {
+    // Editor
     cursorScale: number
     cursorPixelX: number
     cursorPixelY: number
@@ -49,14 +50,16 @@ export interface IState {
     configuration: IConfigurationValues
     imeActive: boolean
     viewport: IViewport
-    windowTitle: string
 
+    toolTips: { [id: string]: IToolTip }
     neovimError: boolean
 
+    // Shell
+    isLoading: boolean
     colors: IThemeColors
+    windowTitle: string
 
     statusBar: { [id: string]: IStatusBarItem }
-    toolTips: { [id: string]: IToolTip }
 
     /**
      * Tabs refer to the Vim-concept of tabs
@@ -193,6 +196,7 @@ export const createDefaultState = (): IState => ({
     cursorLineOpacity: 0,
     cursorColumnOpacity: 0,
     neovimError: false,
+    isLoading: true,
 
     configuration: configuration.getValues(),
 

--- a/browser/src/UI/components/Cursor.less
+++ b/browser/src/UI/components/Cursor.less
@@ -1,5 +1,10 @@
 .cursor {
-    opacity: 1;
+    opacity: 0;
+    transition: opacity 0.35s ease 0.25s;
+
+    .loaded & {
+        opacity: 1;
+    }
 
     /* Cover up 'holes' due to subpixel rendering on canvas */
     padding-left: 1px;

--- a/browser/src/UI/components/Cursor.less
+++ b/browser/src/UI/components/Cursor.less
@@ -1,6 +1,6 @@
 .cursor {
     opacity: 0;
-    transition: opacity 0.35s ease 0.15s;
+    transition: opacity 0.35s ease 0.25s;
 
     .loaded & {
         opacity: 1;

--- a/browser/src/UI/components/Cursor.less
+++ b/browser/src/UI/components/Cursor.less
@@ -1,6 +1,6 @@
 .cursor {
     opacity: 0;
-    transition: opacity 0.35s ease 0.25s;
+    transition: opacity 0.35s ease 0.15s;
 
     .loaded & {
         opacity: 1;

--- a/browser/src/UI/components/Loading.tsx
+++ b/browser/src/UI/components/Loading.tsx
@@ -35,7 +35,7 @@ export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> {
 const mapStateToProps = (state: State.IState): ILoadingViewProps => {
     return {
         visible: !state.isLoaded,
-        backgroundColor: state.colors["background"],
+        backgroundColor: state.colors.background,
     }
 }
 

--- a/browser/src/UI/components/Loading.tsx
+++ b/browser/src/UI/components/Loading.tsx
@@ -1,0 +1,42 @@
+/**
+ * Loading.tsx
+ *
+ * Component to show loading experience
+ */
+
+import * as React from "react"
+import { connect } from "react-redux"
+
+import * as State from "./../State"
+
+export interface ILoadingViewProps {
+    visible: boolean
+    backgroundColor: string
+}
+
+export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> {
+    public render(): JSX.Element {
+        const style: React.CSSProperties = {
+            position: "absolute",
+            top: "0px",
+            left: "0px",
+            right: "0px",
+            bottom: "0px",
+            backgroundColor: this.props.backgroundColor,
+            display: this.props.visible ? "block" : "none",
+            opacity: 1,
+            transition: "opacity 0.5s ease",
+        }
+
+        return <div style={style}></div>
+    }
+}
+
+const mapStateToProps = (state: State.IState): ILoadingViewProps => {
+    return {
+        visible: !state.isLoaded,
+        backgroundColor: state.colors["background"],
+    }
+}
+
+export const Loading = connect(mapStateToProps)(LoadingView)

--- a/browser/src/UI/components/StatusBar.less
+++ b/browser/src/UI/components/StatusBar.less
@@ -3,7 +3,7 @@
 .status-bar {
     .box-shadow-up;
 
-    transform: translateY(6px);
+    transform: translateY(4px);
     transition: transform 0.25s ease;
 
     .loaded & {

--- a/browser/src/UI/components/StatusBar.less
+++ b/browser/src/UI/components/StatusBar.less
@@ -7,7 +7,7 @@
     transition: transform 0.25s ease;
 
     .loaded & {
-        transform: translateY(0px;)
+        transform: translateY(0px);
     }
 
     height: 2em;

--- a/browser/src/UI/components/StatusBar.less
+++ b/browser/src/UI/components/StatusBar.less
@@ -3,6 +3,13 @@
 .status-bar {
     .box-shadow-up;
 
+    transform: translateY(6px);
+    transition: transform 0.25s ease;
+
+    .loaded & {
+        transform: translateY(0px;)
+    }
+
     height: 2em;
     position: relative;
     width: 100%;

--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -15,7 +15,7 @@
 
 .tab-icon-appear-animation {
     animation-name: tab-icon-appear;
-    animation-duration: 0.5s;
+    animation-duration: 0.6s;
     animation-function: ease-in;
     animation-fill-mode: forwards;
     opacity: 1;
@@ -28,6 +28,13 @@
 
     width: 100%;
     overflow-x: hidden;
+
+    transform: translateY(-5px);
+    transition: transform 0.25s ease;
+
+    .loaded & {
+        transform: translateY(0px);
+    }
 
     &:hover {
         overflow-x: overlay;

--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -29,7 +29,7 @@
     width: 100%;
     overflow-x: hidden;
 
-    transform: translateY(-5px);
+    transform: translateY(-3px);
     transition: transform 0.25s ease;
 
     .loaded & {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -25,8 +25,6 @@ import { listenForDiagnostics } from "./../Services/Language"
 import { SidebarSplit } from "./../Services/Sidebar"
 import { windowManager } from "./../Services/WindowManager"
 
-import { PluginManager } from "./../Plugins/PluginManager"
-
 import { NeovimEditor } from "./../Editor/NeovimEditor"
 
 import { createStore } from "./../Redux"
@@ -44,8 +42,8 @@ export const Selectors = {
     getActiveDefinition: () => getActiveDefinition(store.getState() as any),
 }
 
-export function init(pluginManager: PluginManager, args: any): void {
-    render(defaultState, pluginManager, args)
+export const activate = (): void => {
+    render(defaultState)
 }
 
 const updateViewport = () => {
@@ -55,15 +53,9 @@ const updateViewport = () => {
     Actions.setViewport(width, height)
 }
 
-function render(_state: State.IState, pluginManager: PluginManager, args: any): void {
+export const render = (_state: State.IState): void => {
     const hostElement = document.getElementById("host")
 
-    const editor = new NeovimEditor()
-    editor.init(args)
-
-    editorManager.setActiveEditor(editor)
-
-    windowManager.split(0, editor)
     const leftDock = windowManager.getDock(2)
     leftDock.addSplit(new SidebarSplit())
 
@@ -71,6 +63,16 @@ function render(_state: State.IState, pluginManager: PluginManager, args: any): 
         <Provider store={store}>
             <RootComponent windowManager={windowManager}/>
         </Provider>, hostElement)
+}
+
+export const startEditors = async (args: any): Promise<void> => {
+    
+    const editor = new NeovimEditor()
+    await editor.init(args)
+
+    editorManager.setActiveEditor(editor)
+
+    windowManager.split(0, editor)
 }
 
 // Don't execute code that depends on DOM in unit-tests

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -66,7 +66,7 @@ export const render = (_state: State.IState): void => {
 }
 
 export const startEditors = async (args: any): Promise<void> => {
-    
+
     const editor = new NeovimEditor()
     await editor.init(args)
 

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -66,13 +66,12 @@ export const render = (_state: State.IState): void => {
 }
 
 export const startEditors = async (args: any): Promise<void> => {
-
     const editor = new NeovimEditor()
-    await editor.init(args)
 
     editorManager.setActiveEditor(editor)
-
     windowManager.split(0, editor)
+
+    editor.init(args)
 }
 
 // Don't execute code that depends on DOM in unit-tests

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -71,7 +71,7 @@ export const startEditors = async (args: any): Promise<void> => {
     editorManager.setActiveEditor(editor)
     windowManager.split(0, editor)
 
-    editor.init(args)
+    await editor.init(args)
 }
 
 // Don't execute code that depends on DOM in unit-tests

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -11,6 +11,7 @@ import { pluginManager } from "./Plugins/PluginManager"
 
 import * as AutoClosingPairs from "./Services/AutoClosingPairs"
 import { autoUpdater, constructFeedUrl } from "./Services/AutoUpdate"
+import * as BrowserWindowConfigurationSynchronizer from "./Services/BrowserWindowConfigurationSynchronizer"
 import { commandManager } from "./Services/CommandManager"
 import { configuration, IConfigurationValues } from "./Services/Configuration"
 import { editorManager } from "./Services/EditorManager"
@@ -22,16 +23,16 @@ import { createLanguageClientsFromConfiguration } from "./Services/Language"
 
 import * as UI from "./UI/index"
 
-const start = (args: string[]) => {
+require("./overlay.less") // tslint:disable-line
+
+const start = async (args: string[]): Promise<void> => {
+
+    UI.activate()
 
     const parsedArgs = minimist(args)
 
-    let loadInitVim: boolean = false
-    let maximizeScreenOnStart: boolean = false
-
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
-    require("./overlay.less")
 
     const initialConfigParsingError = configuration.getParsingError()
     if (initialConfigParsingError) {
@@ -45,56 +46,28 @@ const start = (args: string[]) => {
         for (prop in newConfigValues) {
             UI.Actions.setConfigValue(prop, newConfigValues[prop])
         }
-
-        document.body.style.fontFamily = configuration.getValue("ui.fontFamily")
-        document.body.style.fontSize = configuration.getValue("ui.fontSize")
-        document.body.style.fontVariant = configuration.getValue("editor.fontLigatures") ? "normal" : "none"
-
-        const fontSmoothing = configuration.getValue("ui.fontSmoothing")
-
-        if (fontSmoothing) {
-            document.body.style["-webkit-font-smoothing"] = fontSmoothing
-        }
-
-        const hideMenu: boolean = configuration.getValue("oni.hideMenu")
-        browserWindow.setAutoHideMenuBar(hideMenu)
-        browserWindow.setMenuBarVisibility(!hideMenu)
-
-        const loadInit: boolean = configuration.getValue("oni.loadInitVim")
-        if (loadInit !== loadInitVim) {
-            ipcRenderer.send("rebuild-menu", loadInit)
-            // don't rebuild menu unless oni.loadInitVim actually changed
-            loadInitVim = loadInit
-        }
-
-        const maximizeScreen: boolean = configuration.getValue("editor.maximizeScreenOnStart")
-        if (maximizeScreen !== maximizeScreenOnStart) {
-            browserWindow.maximize()
-        }
-
-        browserWindow.setFullScreen(configuration.getValue("editor.fullScreenOnStart"))
     }
 
     configuration.start()
+    BrowserWindowConfigurationSynchronizer.activate(configuration)
+
     configChange(configuration.getValues()) // initialize values
     configuration.onConfigurationChanged.subscribe(configChange)
 
     performance.mark("NeovimInstance.Plugins.Discover.Start")
     pluginManager.discoverPlugins()
     performance.mark("NeovimInstance.Plugins.Discover.End")
-    UI.init(pluginManager, parsedArgs._)
+    await UI.startEditors(parsedArgs._)
 
     const api = pluginManager.startApi()
     configuration.activate(api)
-
-    ipcRenderer.on("execute-command", (_evt: any, command: string) => {
-        commandManager.executeCommand(command, null)
-    })
 
     createLanguageClientsFromConfiguration(configuration.getValues())
 
     AutoClosingPairs.activate(configuration, editorManager, inputManager, languageManager)
     Themes.activate(configuration)
+
+    UI.Actions.setLoadingComplete()
 
     checkForUpdates()
 }
@@ -104,7 +77,11 @@ ipcRenderer.on("init", (_evt: any, message: any) => {
     start(message.args)
 })
 
-const checkForUpdates = async () => {
+ipcRenderer.on("execute-command", (_evt: any, command: string) => {
+    commandManager.executeCommand(command, null)
+})
+
+const checkForUpdates = async (): Promise<void> => {
     const feedUrl = await constructFeedUrl("https://api.onivim.io/v1/update")
 
     autoUpdater.onUpdateAvailable.subscribe(() => Log.info("Update available."))

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -52,11 +52,14 @@ const start = async (args: string[]): Promise<void> => {
     configChange(configuration.getValues()) // initialize values
     configuration.onConfigurationChanged.subscribe(configChange)
 
-    await Themes.activate(configuration)
-
     performance.mark("NeovimInstance.Plugins.Discover.Start")
     pluginManager.discoverPlugins()
     performance.mark("NeovimInstance.Plugins.Discover.End")
+
+    await Themes.activate(configuration)
+
+    UI.Actions.setColors(Themes.getThemeManagerInstance().getColors())
+
     await UI.startEditors(parsedArgs._)
 
     const api = pluginManager.startApi()

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -52,7 +52,7 @@ const start = async (args: string[]): Promise<void> => {
     configChange(configuration.getValues()) // initialize values
     configuration.onConfigurationChanged.subscribe(configChange)
 
-    Themes.activate(configuration)
+    await Themes.activate(configuration)
 
     performance.mark("NeovimInstance.Plugins.Discover.Start")
     pluginManager.discoverPlugins()

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -4,7 +4,7 @@
  * Entry point for the BrowserWindow process
  */
 
-import { ipcRenderer, remote } from "electron"
+import { ipcRenderer } from "electron"
 import * as minimist from "minimist"
 import * as Log from "./Log"
 import { pluginManager } from "./Plugins/PluginManager"
@@ -39,8 +39,6 @@ const start = async (args: string[]): Promise<void> => {
         Log.error(initialConfigParsingError)
     }
 
-    const browserWindow = remote.getCurrentWindow()
-
     const configChange = (newConfigValues: Partial<IConfigurationValues>) => {
         let prop: keyof IConfigurationValues
         for (prop in newConfigValues) {
@@ -54,6 +52,8 @@ const start = async (args: string[]): Promise<void> => {
     configChange(configuration.getValues()) // initialize values
     configuration.onConfigurationChanged.subscribe(configChange)
 
+    Themes.activate(configuration)
+
     performance.mark("NeovimInstance.Plugins.Discover.Start")
     pluginManager.discoverPlugins()
     performance.mark("NeovimInstance.Plugins.Discover.End")
@@ -65,7 +65,6 @@ const start = async (args: string[]): Promise<void> => {
     createLanguageClientsFromConfiguration(configuration.getValues())
 
     AutoClosingPairs.activate(configuration, editorManager, inputManager, languageManager)
-    Themes.activate(configuration)
 
     UI.Actions.setLoadingComplete()
 

--- a/extensions/theme-onedark/colors/onedark.json
+++ b/extensions/theme-onedark/colors/onedark.json
@@ -2,7 +2,7 @@
     "name": "onedark",
     "baseVimTheme": "onedark",
     "colors": {
-        "background": "#1F1F1F",
+        "background": "#1E2127",
         "foreground": "#ABB2BF",
 
         "title.background": "#1F1F1F",


### PR DESCRIPTION
For the file explorer / icon theming work, we need to be able to better specify the ordering of startup dependencies. This refactors the `start` method to support `async`/`await`, and creates a more granular sequence (ie, instead of initializing the UI + editors all at once, we split that out into separate tasks).