### PR TITLE
prevent text-selection of statusbar

### DIFF
--- a/browser/src/UI/components/StatusBar.less
+++ b/browser/src/UI/components/StatusBar.less
@@ -6,6 +6,8 @@
     transform: translateY(4px);
     transition: transform 0.25s ease;
 
+    user-select: none;
+
     .loaded & {
         transform: translateY(0px);
     }


### PR DESCRIPTION
Noticed shortly after closing #1010 that though it referenced only the tab bar the status bar text could still be selected, which I think isn't intentional, in which case here's a similar fix for that if needed.