### PR TITLE
Swap indexes to one indexed for quick fix window.

### DIFF
--- a/browser/src/Services/Language/FindAllReferences.ts
+++ b/browser/src/Services/Language/FindAllReferences.ts
@@ -44,14 +44,14 @@ export const findAllReferences = async () => {
 }
 
 export const showReferencesInQuickFix = async (token: string, locations: types.Location[], neovimInstance: INeovimInstance) => {
-    const convertToQuickFixItem = (location: types.Location) => ({
+    const convertToOneIndexedForQuickFix = (location: types.Location) => ({
         filename: Helpers.unwrapFileUriPath(location.uri),
-        lnum: location.range.start.line,
-        col: location.range.start.character,
+        lnum: location.range.start.line + 1,
+        col: location.range.start.character + 1,
         text: token,
     })
 
-    const quickFixItems = locations.map((item) => convertToQuickFixItem(item))
+    const quickFixItems = locations.map((item) => convertToOneIndexedForQuickFix(item))
 
     neovimInstance.quickFix.setqflist(quickFixItems, ` Find All References: ${token}`)
     neovimInstance.command("copen")


### PR DESCRIPTION
Currently, this assumes all indexes that come in are 0 indexed, which may not be true.

As far as I know, all the LSPs use 0 indexed locations, so there should be no issues, but thought it was worth checking.

I may also rename `locations` to be `zeroIndexedLocations`, just so its clearer when implementing other code around this.