### PR TITLE
Fix contributors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Thank you!
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/oni/contributors.svg?width=890" /></a>
+<a href="https://github.com/onivim/oni/graphs/contributors"><img src="https://opencollective.com/oni/contributors.svg?width=890" /></a>
 
 ## License
 


### PR DESCRIPTION
Relative path leads to https://github.com/onivim/oni/blob/master/graphs/contributors which 404s