### PR TITLE
Add default font unit when needed

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -19,6 +19,7 @@ import { Event } from "oni-types"
 
 import * as Log from "./../Log"
 
+import { addDefaultUnitIfNeeded } from "./../Font"
 import { EventContext, INeovimStartOptions, NeovimInstance, NeovimWindowManager } from "./../neovim"
 import { CanvasRenderer, INeovimRenderer } from "./../Renderer"
 import { NeovimScreen } from "./../Screen"
@@ -501,7 +502,7 @@ export class NeovimEditor extends Editor implements IEditor {
 
     private _onConfigChanged(newValues: Partial<IConfigurationValues>): void {
         const fontFamily = this._config.getValue("editor.fontFamily")
-        const fontSize = this._config.getValue("editor.fontSize")
+        const fontSize = addDefaultUnitIfNeeded(this._config.getValue("editor.fontSize"))
         const linePadding = this._config.getValue("editor.linePadding")
 
         UI.Actions.setFont(fontFamily, fontSize)

--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -34,3 +34,14 @@ export function measureFont(fontFamily: string, fontSize: string, characterToTes
         height,
     }
 }
+
+export function addDefaultUnitIfNeeded(fontSize: string) {
+
+    const defaultUnit = "px"
+
+    if (isNaN(Number(fontSize))) {
+        return fontSize
+    } else {
+        return fontSize + defaultUnit
+    }
+}

--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -10,6 +10,8 @@ import { ipcRenderer, remote } from "electron"
 import { Colors } from "./Colors"
 import { Configuration, IConfigurationValues } from "./Configuration"
 
+import { addDefaultUnitIfNeeded } from "./../Font"
+
 export const activate = (configuration: Configuration, colors: Colors) => {
     const browserWindow = remote.getCurrentWindow()
 
@@ -30,7 +32,7 @@ export const activate = (configuration: Configuration, colors: Colors) => {
     const onConfigChanged = (newConfigValues: Partial<IConfigurationValues>) => {
 
         document.body.style.fontFamily = configuration.getValue("ui.fontFamily")
-        document.body.style.fontSize = configuration.getValue("ui.fontSize")
+        document.body.style.fontSize = addDefaultUnitIfNeeded(configuration.getValue("ui.fontSize"))
         document.body.style.fontVariant = configuration.getValue("editor.fontLigatures") ? "normal" : "none"
 
         const fontSmoothing = configuration.getValue("ui.fontSmoothing")

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -7,6 +7,8 @@ import { Motion, spring } from "react-motion"
 
 import { TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 
+import { addDefaultUnitIfNeeded } from "./../../Font"
+
 export interface ICursorRendererProps {
     animated: boolean
     x: number
@@ -138,7 +140,7 @@ const mapStateToProps = (state: State.IState, props: ICursorProps): ICursorRende
         character: state.cursorCharacter,
         fontPixelWidth: state.fontPixelWidth,
         fontFamily: State.readConf(state.configuration, "editor.fontFamily"),
-        fontSize: State.readConf(state.configuration, "editor.fontSize"),
+        fontSize: addDefaultUnitIfNeeded(State.readConf(state.configuration, "editor.fontSize")),
         visible: !state.imeActive,
     }
 }

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -7,6 +7,7 @@ import * as React from "react"
 import { connect } from "react-redux"
 
 import { IState, StatusBarAlignment } from "./../State"
+import { addDefaultUnitIfNeeded } from "./../../Font"
 
 require("./StatusBar.less") // tslint:disable-line no-var-requires
 
@@ -103,7 +104,8 @@ const mapStateToProps = (state: IState): StatusBarProps => {
         backgroundColor: state.colors["statusBar.background"],
         foregroundColor: state.colors["statusBar.foreground"],
         fontFamily: state.configuration["ui.fontFamily"],
-        fontSize: state.configuration["statusbar.fontSize"] || state.configuration["ui.fontSize"],
+        fontSize: state.configuration["statusbar.fontSize"] ||
+                  addDefaultUnitIfNeeded(state.configuration["ui.fontSize"]),
         items: statusBarItems,
         enabled: state.configuration["statusbar.enabled"],
     }

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -7,6 +7,7 @@ import * as React from "react"
 import { connect } from "react-redux"
 
 import { IState, StatusBarAlignment } from "./../State"
+
 import { addDefaultUnitIfNeeded } from "./../../Font"
 
 require("./StatusBar.less") // tslint:disable-line no-var-requires

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -15,6 +15,7 @@ import * as State from "./../State"
 import { Icon } from "./../../UI/Icon"
 
 import { FileIcon } from "./../../Services/FileIcon"
+import { addDefaultUnitIfNeeded } from "./../../Font"
 
 require("./Tabs.less") // tslint:disable-line no-var-requires
 
@@ -219,7 +220,7 @@ const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITa
 
     return {
         fontFamily: state.configuration["ui.fontFamily"],
-        fontSize: state.configuration["ui.fontSize"],
+        fontSize: addDefaultUnitIfNeeded(state.configuration["ui.fontSize"]),
         backgroundColor: state.colors["tabs.background"],
         foregroundColor: state.colors["tabs.foreground"],
         onSelect: selectFunc,

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -12,10 +12,11 @@ import * as classNames from "classnames"
 import * as BufferSelectors from "./../selectors/BufferSelectors"
 import * as State from "./../State"
 
+import { addDefaultUnitIfNeeded } from "./../../Font"
+
 import { Icon } from "./../../UI/Icon"
 
 import { FileIcon } from "./../../Services/FileIcon"
-import { addDefaultUnitIfNeeded } from "./../../Font"
 
 require("./Tabs.less") // tslint:disable-line no-var-requires
 

--- a/browser/src/UI/components/TypingPredictions.tsx
+++ b/browser/src/UI/components/TypingPredictions.tsx
@@ -14,6 +14,8 @@ import * as State from "./../State"
 
 import { ITypingPrediction, TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 
+import { addDefaultUnitIfNeeded } from "./../../Font"
+
 export interface ITypingPredictionProps {
     typingPrediction: TypingPredictionManager
 }
@@ -120,7 +122,7 @@ const mapStateToProps = (state: State.IState, props: ITypingPredictionProps): IT
         color: state.colors["editor.background"],
         textColor: state.colors["editor.foreground"],
         fontFamily: State.readConf(state.configuration, "editor.fontFamily"),
-        fontSize: State.readConf(state.configuration, "editor.fontSize"),
+        fontSize: addDefaultUnitIfNeeded(State.readConf(state.configuration, "editor.fontSize")),
         visible: true,
     }
 }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -10,7 +10,7 @@ import * as Log from "./../Log"
 import { EventContext } from "./EventContext"
 
 import * as Actions from "./../actions"
-import { measureFont } from "./../Font"
+import { addDefaultUnitIfNeeded, measureFont } from "./../Font"
 import * as Platform from "./../Platform"
 import { IPixelPosition, IPosition } from "./../Screen"
 import { configuration } from "./../Services/Configuration"
@@ -152,7 +152,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _autoCommands: NeovimAutoCommands
 
     private _fontFamily: string = this._config.getValue("editor.fontFamily")
-    private _fontSize: string = this._config.getValue("editor.fontSize")
+    private _fontSize: string = addDefaultUnitIfNeeded(this._config.getValue("editor.fontSize"))
     private _fontWidthInPixels: number
     private _fontHeightInPixels: number
 


### PR DESCRIPTION
Tiny helper function that checks the font size a user enters and appends on `px` if no other unit is supplied, for #837.