### PR TITLE
Re-activate git status bar item

### DIFF
--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -80,7 +80,6 @@ class StatusBar implements Oni.StatusBar {
 
     public createItem(alignment: StatusBarAlignment, priority: number = 0, globalId?: string): Oni.StatusBarItem {
         this._id++
-
         const statusBarId = globalId || `${this._id.toString()}`
 
         return new StatusBarItem(statusBarId, alignment, priority)

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -222,7 +222,8 @@ export const hideMessageDialog = (): Actions.IHideMessageDialog => ({
 })
 
 export const showStatusBarItem = (id: string, contents: JSX.Element, alignment?: State.StatusBarAlignment, priority?: number) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
-
+    console.log('id: ', id);
+    console.log('contents: ', contents);
     const currentStatusBarItem = getState().statusBar[id]
 
     if (currentStatusBarItem) {

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -222,8 +222,7 @@ export const hideMessageDialog = (): Actions.IHideMessageDialog => ({
 })
 
 export const showStatusBarItem = (id: string, contents: JSX.Element, alignment?: State.StatusBarAlignment, priority?: number) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
-    console.log('id: ', id);
-    console.log('contents: ', contents);
+
     const currentStatusBarItem = getState().statusBar[id]
 
     if (currentStatusBarItem) {

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -1,4 +1,3 @@
-
 import * as electron from "electron"
 
 import * as keys from "lodash/keys"

--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -2,7 +2,6 @@ const fs = require("fs");
 const path = require("path");
 
 const activate = (Oni) => {
-
     const gitBranchIndicator = Oni.statusBar.createItem(0, -3);
 
     const pathIsDir = (p) => {
@@ -18,6 +17,7 @@ const activate = (Oni) => {
     };
 
     const updateBranchIndicator = (evt) => {
+        console.log('Update indicator ====================================: ', evt);
         pathIsDir(evt.bufferFullPath)
         .then((isDir) => {
             dir = null;
@@ -40,7 +40,15 @@ const activate = (Oni) => {
         });
     };
 
-    Oni.on("buffer-enter", updateBranchIndicator);
+    // Oni.on("buffer-enter", updateBranchIndicator);
+    console.log(' updateBranchIndicator: ', updateBranchIndicator);
+    console.log('Oni in [PLUGIN]!!!!!!!: ', Oni);
+    console.log(' gitBranchIndicator: ', gitBranchIndicator);
+
+    Oni.editors.allEditors.onBufferEnter.subscribe((evt) => {
+        console.log('event: ', event);
+        return updateBranchIndicator(evt);
+    });
 };
 
 module.exports = {

--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -1,54 +1,54 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const fsStat = promisify(fs.stat);
 
 const activate = (Oni) => {
-    const gitBranchIndicator = Oni.statusBar.createItem(0, -3);
+    const React = Oni.dependencies.React;
+    try {
+        const gitBranchIndicator = Oni.statusBar.createItem(1, -3, 'oni-plugin-git');
 
-    const pathIsDir = (p) => {
-        return new Promise((resolve, reject) => {
-            fs.stat(p, (error, stats) => {
-                if (error) {
-                    reject(error);
-                } else {
-                    resolve(stats.isDirectory());
-                }
-            });
-        })
-    };
-
-    const updateBranchIndicator = (evt) => {
-        console.log('Update indicator ====================================: ', evt);
-        pathIsDir(evt.bufferFullPath)
-        .then((isDir) => {
-            dir = null;
-            if (isDir) {
-                dir = evt.bufferFullPath;
-            } else {
-                dir = path.dirname(evt.bufferFullPath);
+        const pathIsDir = async (p) => {
+            try {
+                const stats = await fsStat(p);
+                return stats.isDirectory();
+            } catch(error) {
+                return error;
             }
-            return Oni.services.git.getBranch(dir);
-        })
-        .then((branchName) => {
-            const React = Oni.dependencies.React;
-            const branchIcon = Oni.ui.createIcon({ name: "code-fork", size: Oni.ui.iconSize.Large });
-            const gitBranch  = React.createElement("div", null, branchIcon, " " + branchName);
-            gitBranchIndicator.setContents(gitBranch);
-            gitBranchIndicator.show();
-        })
-        .catch((error) => {
-            gitBranchIndicator.hide();
-        });
-    };
+        };
 
-    // Oni.on("buffer-enter", updateBranchIndicator);
-    console.log(' updateBranchIndicator: ', updateBranchIndicator);
-    console.log('Oni in [PLUGIN]!!!!!!!: ', Oni);
-    console.log(' gitBranchIndicator: ', gitBranchIndicator);
+        const updateBranchIndicator = async (evt) => {
+            const filePath = evt.bufferFullPath || evt.filePath;
+            let dir;
+            try {
+                const isDir = await pathIsDir(filePath);
+                const  dir = isDir ? filePath : path.dirname(filePath);
+                let branchName;
+                try {
+                    branchName = await Oni.services.git.getBranch(dir);
+                } catch(e) {
+                    console.warn('[Oni.plugin.git]: No branch name found', e);
+                    branchName = 'Not a Git Repo';
+                }
 
-    Oni.editors.allEditors.onBufferEnter.subscribe((evt) => {
-        console.log('event: ', event);
-        return updateBranchIndicator(evt);
-    });
+                const branchIcon = Oni.ui.createIcon({ name: 'code-fork', size: Oni.ui.iconSize.Large });
+                const gitBranch  = React.createElement('div', null, branchIcon, ' ' + branchName);
+                gitBranchIndicator.setContents(gitBranch);
+                gitBranchIndicator.show();
+            } catch(e) {
+                console.log('[Oni.plugin.git]: ', e);
+                gitBranchIndicator.hide();
+            }
+        };
+
+        updateBranchIndicator(Oni.editors.activeEditor.activeBuffer);
+
+        Oni.editors.activeEditor.onBufferEnter.subscribe(async (evt) => await updateBranchIndicator(evt));
+        Oni.editors.activeEditor.onBufferChanged.subscribe(async (buf) => await updateBranchIndicator(buf));
+
+    } catch(e) {
+        console.warn('[Oni.plugin.git] ERROR', e);
+    }
 };
 
 module.exports = {


### PR DESCRIPTION
It seemed the Git status bar fell into a state of disrepair as  it fell behind changes to the `Oni` api, I've tweaked it to work with the new api so it once again appears in the status bar.

I wasn't quite clear on what the exact status of this is as I know there was discussion in #486 regarding a general VCS api that could work with different systems, I don't know whether or not there might have been a plan regarding where to go next with the status bar plugin but as it seemed like a fairly isolated thing and could be retweaked in the future I've updated the plugin so it works again.

regarding config options I wasn't sure if that was in the plan (I haven't implemented that but if thats something I could add to config object?, i'd be happy to but I guess it leads to the bigger question of how plugins config options are going to be set in oni, e.g. a sub-object like vscode?)