### PR TITLE
[WIP] Add language specific Regex tokens.

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -135,14 +135,17 @@ const BaseConfiguration: IConfigurationValues = {
     "language.css.languageServer.command": cssLanguageServerPath,
     "language.css.languageServer.arguments": ["--stdio"],
     "language.css.textMateGrammar": path.join(__dirname, "extensions", "css", "syntaxes", "css.tmLanguage.json"),
+    "language.css.tokenRegex": "[$_a-zA-Z0-9-]",
 
     "language.less.languageServer.command": cssLanguageServerPath,
     "language.less.languageServer.arguments": ["--stdio"],
     "language.less.textMateGrammar": path.join(__dirname, "extensions", "less", "syntaxes", "less.tmLanguage.json"),
+    "language.less.tokenRegex": "[$_a-zA-Z0-9-]",
 
     "language.scss.languageServer.command": cssLanguageServerPath,
     "language.scss.languageServer.arguments": ["--stdio"],
     "language.scss.textMateGrammar": path.join(__dirname, "extensions", "scss", "syntaxes", "scss.json"),
+    "language.scss.tokenRegex": "[$_a-zA-Z0-9-]",
 
     "language.reason.languageServer.command": ocamlLanguageServerPath,
     "language.reason.languageServer.arguments": ["--stdio"],

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -141,7 +141,13 @@ export class LanguageManager {
     }
 
     public getTokenRegex(language: string): RegExp {
-        return /[$_a-zA-Z0-9]/i
+        const languageSpecificTokenRegex = configuration.getValue(`language.${language}.tokenRegex`)
+
+        if (languageSpecificTokenRegex) {
+            return RegExp(languageSpecificTokenRegex, "i")
+        } else {
+            return /[$_a-zA-Z0-9]/i
+        }
     }
 
     public getSignatureHelpTriggerCharacters(language: string): string[] {


### PR DESCRIPTION
Still not sure on the config option name, and if we should expect the user to put [ ] around the regex.

Noticed this in #982, where in the screenshot @bryphe put up, the elements were not being correctly highlighted.

This fixes the token regex to allow for more fine grained setup, but there is still a further issue of what to do in the case of sub-classes or duplicated class names. Since we just highlight in neovim, if we had `property` and `property-longer`, both would be highlighted despite being different things. This can be seen by "Finding all references" on `Configuration` in `Configuration.ts`, and seeing how both `Configuration` and `IConfiguration` and more are highlighted, when they are independent of each other.