### PR TITLE
Set `autoUpdate.enabled` to `false` by default

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -21,7 +21,7 @@ const BaseConfiguration: IConfigurationValues = {
     activate: noop,
     deactivate: noop,
 
-    "autoUpdate.enabled": true,
+    "autoUpdate.enabled": false,
 
     "debug.fixedSize": null,
     "debug.neovimPath": null,


### PR DESCRIPTION
The current auto-update functionality is a no-op anyway (we can't even provide updates if we wanted, until the app is code signed). Some users would prefer not to have this on by default.

I've started to think about 'upsell' features - features that are only available to backers/sponsors/contributors - and auto-update might fit that. I'll put together a more formal plan in an issue for feedback.