### PR TITLE
Enable auto-closing pairs by default

### DIFF
--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -127,7 +127,7 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
 
     editorManager.activeEditor.onBufferEnter.subscribe((newBuffer) => {
 
-        if (!configuration.getValue("experimental.autoClosingPairs.enabled")) {
+        if (!configuration.getValue("autoClosingPairs.enabled")) {
             Log.verbose("[Auto Closing Pairs] Not enabled.")
             return
         }
@@ -169,6 +169,6 @@ const getAutoClosingPairs = (configuration: Configuration, language: string): IA
     if (languagePairs) {
         return languagePairs
     } else {
-        return configuration.getValue("experimental.autoClosingPairs.default") || []
+        return configuration.getValue("autoClosingPairs.default") || []
     }
 }

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -32,13 +32,6 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.fakeLag.languageServer": null,
     "debug.fakeLag.neovimInput": null,
 
-    "experimental.autoClosingPairs.enabled": false,
-    "experimental.autoClosingPairs.default": [
-        { "open": "{", "close": "}" },
-        { "open": "[", "close": "]" },
-        { "open": "(", "close": ")" },
-    ],
-
     "experimental.editor.textMateHighlighting.enabled": false,
     "experimental.editor.textMateHighlighting.maxLines": 2000,
 
@@ -49,6 +42,13 @@ const BaseConfiguration: IConfigurationValues = {
     // "experimental.neovim.transport": Platform.isWindows() ? "pipe" : "stdio",
 
     "experimental.sidebar.enabled": false,
+
+    "autoClosingPairs.enabled": true,
+    "autoClosingPairs.default": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+    ],
 
     "oni.audio.bellUrl": null,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -39,12 +39,7 @@ export interface IConfigurationValues {
     "debug.fakeLag.languageServer": number | null
     "debug.fakeLag.neovimInput": number | null
 
-    // Experimental feature flags
-    // - autoClosingPairs
-    "experimental.autoClosingPairs.enabled": boolean
-    "experimental.autoClosingPairs.default": any
-
-    // - textMateHighlighting
+        // - textMateHighlighting
     "experimental.editor.textMateHighlighting.enabled": boolean
     // If a file has more lines than this value, syntax highlighting will be disabled
     "experimental.editor.textMateHighlighting.maxLines": number
@@ -55,6 +50,9 @@ export interface IConfigurationValues {
     // Valid values are "stdio" and "pipe"
     "experimental.neovim.transport": string
     "experimental.editor.typingPrediction": boolean
+
+    "autoClosingPairs.enabled": boolean
+    "autoClosingPairs.default": any
 
     // Production settings
 

--- a/test/ci/AutoClosingPairs.config.js
+++ b/test/ci/AutoClosingPairs.config.js
@@ -1,7 +1,0 @@
-// For more information on customizing Oni,
-// check out our wiki page:
-// https://github.com/onivim/oni/wiki/Configuration
-
-module.exports = {
-    "experimental.autoClosingPairs.enabled": true,
-};

--- a/test/ci/AutoClosingPairsTest.ts
+++ b/test/ci/AutoClosingPairsTest.ts
@@ -49,7 +49,3 @@ export const test = async (oni: any) => {
 
     assert.deepEqual(lines, expectedResult, "Verify lines are as expected")
 }
-
-export const settings = {
-    configPath: "AutoClosingPairs.config.js",
-}


### PR DESCRIPTION
- Removes experimental flag for auto-closing pairs, now on-by-default.
- Documentation updated to describe configuration settings: https://github.com/onivim/oni/wiki/Language-Support#auto-closing-pairs