### PR TITLE
Performance: Remove git branch check on buffer changed

### DIFF
--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -74,9 +74,6 @@ const activate = Oni => {
     Oni.editors.activeEditor.onBufferEnter.subscribe(
       async evt => await updateBranchIndicator(evt)
     );
-    Oni.editors.activeEditor.onBufferChanged.subscribe(
-      async buf => await updateBranchIndicator(buf)
-    );
   } catch (e) {
     console.warn('[Oni.plugin.git] ERROR', e);
   }


### PR DESCRIPTION
__Issue:__ We are checking branch status on every buffer changed event (every keypress),  which, even though kicking off the git process is async, still has non-trivial overhead:

![perf-regression-git](https://user-images.githubusercontent.com/13532591/33865371-54e6b064-dea6-11e7-8cd6-b0477eebdaf2.png)

It appears that the git spawn can take a significant amount of time - we want to ideally keep operations well under 16ms to hit 60ms, but because this exceeds that, it can cause jerkiness in rendering and responsiveness.

@Akin909 - was there a reason the `onBufferEnter` event wasn't sufficient, and we needed to hook the change event? If there is a case we need it, I'm wondering if there is a less noisy way for us to get the update? 