### PR TITLE
Fix #1039: Typing predictions mid-line

### DIFF
--- a/browser/src/Services/TypingPredictionManager.ts
+++ b/browser/src/Services/TypingPredictionManager.ts
@@ -93,6 +93,12 @@ export class TypingPredictionManager {
 
         const id = this._column + this._predictions.length + 1
 
+        const newCharacterCell = this._latestScreenState.getCell(id, this._line)
+
+        if (newCharacterCell && newCharacterCell.character) {
+            return
+        }
+
         this._predictions = [
             ...this._predictions,
             { id, character },

--- a/browser/src/Services/TypingPredictionManager.ts
+++ b/browser/src/Services/TypingPredictionManager.ts
@@ -8,8 +8,6 @@ import { Event, IEvent } from "oni-types"
 
 import { IScreen } from "./../neovim"
 
-export type TypingPredictionId = number
-
 export interface IPredictedCharacter {
     character: string
     id: number
@@ -34,6 +32,8 @@ export class TypingPredictionManager {
     private _line: number = null
     private _column: number = null
 
+    private _latestScreenState: IScreen = null
+
     public get onPredictionsChanged(): IEvent<ITypingPrediction> {
         return this._predictionsChanged
     }
@@ -47,6 +47,8 @@ export class TypingPredictionManager {
     }
 
     public setCursorPosition(screen: IScreen): void {
+        this._latestScreenState = screen
+
         const line = screen.cursorRow
         const column = screen.cursorColumn
 
@@ -83,9 +85,9 @@ export class TypingPredictionManager {
         }
     }
 
-    public addPrediction(character: string): TypingPredictionId | null {
+    public addPrediction(character: string): void {
 
-        if (!this._enabled) {
+        if (!this._enabled || !this._latestScreenState) {
             return null
         }
 
@@ -97,8 +99,6 @@ export class TypingPredictionManager {
         ]
 
         this._notifyPredictionsChanged()
-
-        return id
     }
 
     public clearAllPredictions(): void {

--- a/browser/test/Mocks/neovim.ts
+++ b/browser/test/Mocks/neovim.ts
@@ -69,7 +69,7 @@ export class MockScreen implements Neovim.IScreen {
 
         const updatedRow = {
             ...row,
-            [x]: cell
+            [x]: cell,
         }
 
         this._cells[y] = updatedRow

--- a/browser/test/Mocks/neovim.ts
+++ b/browser/test/Mocks/neovim.ts
@@ -14,6 +14,8 @@ export class MockScreen implements Neovim.IScreen {
     public cursorColumn: number = 0
     public cursorRow: number = 0
 
+    private _cells: { [row: number]: { [col: number]: Neovim.ICell }} = { }
+
     public get currentBackgroundColor(): string {
         return null
     }
@@ -52,7 +54,25 @@ export class MockScreen implements Neovim.IScreen {
     }
 
     public getCell(x: number, y: number): Neovim.ICell {
-         return null
+        const row = this._cells[y]
+
+        if (!row) {
+            return null
+        }
+
+        const cell = row[x]
+        return cell || null
+    }
+
+    public setCell(x: number, y: number, cell: Neovim.ICell): void {
+        const row = this._cells[y] || { }
+
+        const updatedRow = {
+            ...row,
+            [x]: cell
+        }
+
+        this._cells[y] = updatedRow
     }
 
     public getScrollRegion(): Neovim.IScrollRegion {

--- a/browser/test/Services/TypingPredictionManagerTests.ts
+++ b/browser/test/Services/TypingPredictionManagerTests.ts
@@ -4,6 +4,8 @@
 
 import * as assert from "assert"
 
+import * as Neovim from "./../../src/neovim"
+
 import { ITypingPrediction, TypingPredictionManager } from "./../../src/Services/TypingPredictionManager"
 import { MockScreen } from "./../Mocks/neovim"
 
@@ -41,5 +43,36 @@ describe("TypingPredictionManager", () => {
         assert.strictEqual(lastResult.predictedCursorColumn, 2, "Verify predictedCursorColumn is correct")
         assert.strictEqual(lastResult.predictedCharacters.length, 1, "Verify there is exactly one prediction in lastResult")
         assert.deepEqual(lastResult.predictedCharacters[0].character, "a", "Verify predicted character is correct")
+    })
+
+    it("#1039 - Doesn't add a prediction if it overlaps with an existing character on the screen", () => {
+        mockScreen.cursorRow = 1
+        mockScreen.cursorColumn = 1
+        typingPredictionManager.setCursorPosition(mockScreen)
+
+        // Set a character at the third position, so that we can test the case where there
+        // is a single prediction, and a rejected prediction (because there is a character already on the cell)
+
+        const cell: Neovim.ICell = {
+            character: "T",
+            characterWidth: 1,
+        }
+
+        mockScreen.setCell(3 /* x: column*/, 1 /* y: row */, cell)
+
+        let callCount = 0
+        let lastResult: ITypingPrediction = null
+
+        typingPredictionManager.onPredictionsChanged.subscribe((pd) => {
+            callCount++
+            lastResult = pd
+        })
+
+        typingPredictionManager.addPrediction("a") // First prediction should succeed
+        typingPredictionManager.addPrediction("b") // Second prediction doesn't succeed
+
+        assert.strictEqual(callCount, 1, "Verify only a single call to the prediction handler was made")
+        assert.strictEqual(lastResult.predictedCharacters.length, 1, "Verify there is exactly one prediction in last result")
+        assert.strictEqual(lastResult.predictedCharacters[0].character, "a", "Verify it was the first character entered that got predicted")
     })
 })


### PR DESCRIPTION
__Issue:__ Typing predictions mid-line could be jarring

__Fix:__ Don't use predictions when it would overlap a character, for now.

Longer-term, we could look at re-rendering or pushing the whole line out, but this is a reasonable starting point IMO.