### PR TITLE
Feature: Enable typing prediction by default

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -449,7 +449,7 @@ export class NeovimEditor extends Editor implements IEditor {
 
         this._typingPredictionManager.clearAllPredictions()
 
-        if (newMode === "insert" && configuration.getValue("experimental.editor.typingPrediction")) {
+        if (newMode === "insert" && configuration.getValue("editor.typingPrediction")) {
             this._typingPredictionManager.enable()
         } else {
             this._typingPredictionManager.disable()

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -35,8 +35,6 @@ const BaseConfiguration: IConfigurationValues = {
     "experimental.editor.textMateHighlighting.enabled": false,
     "experimental.editor.textMateHighlighting.maxLines": 2000,
 
-    "editor.typingPrediction": false,
-
     "experimental.neovim.transport": "stdio",
     // TODO: Enable pipe transport for Windows
     // "experimental.neovim.transport": Platform.isWindows() ? "pipe" : "stdio",
@@ -83,6 +81,8 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.linePadding": 2,
 
     "editor.quickOpen.execCommand": null,
+
+    "editor.typingPrediction": true,
 
     "editor.scrollBar.visible": true,
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -35,7 +35,7 @@ const BaseConfiguration: IConfigurationValues = {
     "experimental.editor.textMateHighlighting.enabled": false,
     "experimental.editor.textMateHighlighting.maxLines": 2000,
 
-    "experimental.editor.typingPrediction": false,
+    "editor.typingPrediction": false,
 
     "experimental.neovim.transport": "stdio",
     // TODO: Enable pipe transport for Windows

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -49,7 +49,6 @@ export interface IConfigurationValues {
     // The transport to use for Neovim
     // Valid values are "stdio" and "pipe"
     "experimental.neovim.transport": string
-    "experimental.editor.typingPrediction": boolean
 
     "autoClosingPairs.enabled": boolean
     "autoClosingPairs.default": any
@@ -150,6 +149,10 @@ export interface IConfigurationValues {
     // IE, Windows:
     // "editor.quickOpen.execCommand": "dir /s /b"
     "editor.quickOpen.execCommand": string | null
+
+    // Typing prediction is Oni's implementation of
+    // 'zero-latency' mode typing, and increases responsiveness.
+    "editor.typingPrediction": boolean
 
     "editor.fullScreenOnStart": boolean
     "editor.maximizeScreenOnStart": boolean


### PR DESCRIPTION
This promotes the `editor.typingPrediction` from an experimental feature to an on-by-default feature. This gives improved responsiveness when typing in insert mode.

To get an idea of the difference, you can turn on the `debug.showTypingPrediction` flag, which will highlight predicted characters:
![predicted-typing](https://user-images.githubusercontent.com/13532591/32843246-2450cec6-c9d4-11e7-85a4-b35dc2813b71.gif)

Each of those characters highlighted in red are 'predicted' and would've had a delay in responsiveness otherwise. More info in #946 

The prediction should be completely transparent to the user, but if there are artifacts, it can be disabled via setting `editor.typingPrediction` to `false`.
