### PR TITLE
Add new window option

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { app, BrowserWindow, ipcMain, Menu, webContents } from "electron"
 
 import * as Log from "./Log"
-import { buildMenu } from "./menu"
+import { buildDockMenu, buildMenu } from "./menu"
 import { makeSingleInstance } from "./ProcessLifecycle"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
@@ -57,7 +57,7 @@ if (!isDevelopment && !isDebug) {
     })
 }
 
-function createWindow(commandLineArguments, workingDirectory) {
+export function createWindow(commandLineArguments, workingDirectory) {
     Log.info(`Creating window with arguments: ${commandLineArguments} and working directory: ${workingDirectory}`)
 
     const webPreferences = {
@@ -129,11 +129,9 @@ function updateMenu(mainWindow, loadInit) {
     const menu = buildMenu(mainWindow, loadInit)
     if (process.platform === "darwin") {
         // all osx windows share the same menu
-        const dockMenu = Menu.buildFromTemplate([
-            { label: "New Window", click() { console.log("New Window") } }
-        ])
-        mainWindow.dock.setMenu(dockMenu)
         Menu.setApplicationMenu(menu)
+        const dockMenu = buildDockMenu(mainWindow, loadInit)
+        app.dock.setMenu(dockMenu)
     } else {
         // on windows and linux, set menu per window
         mainWindow.setMenu(menu)

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -129,6 +129,10 @@ function updateMenu(mainWindow, loadInit) {
     const menu = buildMenu(mainWindow, loadInit)
     if (process.platform === "darwin") {
         // all osx windows share the same menu
+        const dockMenu = Menu.buildFromTemplate([
+            { label: "New Window", click() { console.log("New Window") } }
+        ])
+        mainWindow.dock.setMenu(dockMenu)
         Menu.setApplicationMenu(menu)
     } else {
         // on windows and linux, set menu per window

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -1,6 +1,19 @@
 import * as os from "os"
 
 import { app, dialog, Menu, shell } from "electron"
+import { createWindow } from "./main"
+
+export const buildDockMenu = (mainWindow, loadInit) => {
+    const menu = []
+    menu.push({
+        label: "New Window",
+        click() {
+            createWindow([], process.cwd())
+        },
+    })
+
+    return Menu.buildFromTemplate(menu)
+}
 
 export const buildMenu = (mainWindow, loadInit) => {
     const menu = []
@@ -93,6 +106,15 @@ export const buildMenu = (mainWindow, loadInit) => {
                 label: "Split Open…",
                 click(item, focusedWindow) {
                     dialog.showOpenDialog(mainWindow, { properties: ["openFile"] }, (files) => executeVimCommandForFiles(":sp", files))
+                },
+            },
+            {
+                type: "separator",
+            },
+            {
+                label: "New Window",
+                click() {
+                    createWindow([], process.cwd())
                 },
             },
             {


### PR DESCRIPTION
@bryphe following the discussion in #1100 and the link you posted I had a go at adding the functionality of opening a new window to the top menu bar (and to the dock for mac os). Tbh I was little concerned that implementing this would be more involved, i.e. managing the state of multiple windows etc. but it all seems to work fine (which I believe is largely due to your foresight in handling focusing of instances etc. in `main.ts`).

Things that it currently lacks that I imagine might become issues down the line are 
1. *mappability* 
2. an easy way to focus instances
3. cmd-Q and I imagine its alternate OS equivalents kills all windows, subjectively I would have expected each to be deleted one at a time - *looking into this*

Tbh I personally think those are both nice to haves and the menu or clicking each instance works well, and mac os, linux and i'd imagine windows all have several window manager programs, but perhaps thoughts for the future