### PR TITLE
Fix #1064 - Large files crash in Oni

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -82,6 +82,10 @@ export class Buffer implements Oni.Buffer {
             end = this._lineCount
         }
 
+        if (end - start > 2500) {
+            Log.warn("getLines called with over 2500 lines, this may cause instability.")
+        }
+
         const lines = await this._neovimInstance.request<any>("nvim_buf_get_lines", [parseInt(this._id, 10), start, end, false])
         return lines
     }

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -305,17 +305,8 @@ export class NeovimEditor extends Editor implements IEditor {
             }
         })
 
-        const openFiles = async (files: string[], action: string) => {
-
-            await this._neovimInstance.callFunction("OniOpenFile", [action, files[0]])
-
-            for (let i = 1; i < files.length; i++) {
-                this._neovimInstance.command("exec \"" + action + " " + normalizePath(files[i]) + "\"")
-            }
-        }
-
         ipcRenderer.on("open-files", (_evt: any, message: string, files: string[]) => {
-            openFiles(files, message)
+            this._openFiles(files, message)
         })
 
         // enable opening a file via drag-drop
@@ -381,7 +372,6 @@ export class NeovimEditor extends Editor implements IEditor {
 
     public async init(filesToOpen: string[]): Promise<void> {
         const startOptions: INeovimStartOptions = {
-            args: filesToOpen,
             runtimePaths: pluginManager.getAllRuntimePaths(),
             transport: configuration.getValue("experimental.neovim.transport"),
         }
@@ -404,6 +394,10 @@ export class NeovimEditor extends Editor implements IEditor {
 
         if (this._themeManager.activeTheme && this._themeManager.activeTheme.baseVimTheme) {
             await this._neovimInstance.command(":color " + this._themeManager.activeTheme.baseVimTheme)
+        }
+
+        if (filesToOpen && filesToOpen.length > 0) {
+            await this._openFiles(filesToOpen, ":tabnew")
         }
 
         this._hasLoaded = true
@@ -444,6 +438,15 @@ export class NeovimEditor extends Editor implements IEditor {
             onTabClose={onTabClose}
             onTabSelect={onTabSelect} />
     }
+
+    private async _openFiles(files: string[], action: string): Promise<void> {
+        await this._neovimInstance.callFunction("OniOpenFile", [action, files[0]])
+
+        for (let i = 1; i < files.length; i++) {
+            await this._neovimInstance.command("exec \"" + action + " " + normalizePath(files[i]) + "\"")
+        }
+    }
+
 
     private _onModeChanged(newMode: string): void {
 

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -447,7 +447,6 @@ export class NeovimEditor extends Editor implements IEditor {
         }
     }
 
-
     private _onModeChanged(newMode: string): void {
 
         this._typingPredictionManager.clearAllPredictions()

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -99,19 +99,19 @@ const BaseConfiguration: IConfigurationValues = {
 
     "editor.tokenColors": [{
         scope: "variable.object",
-        settings: "Special",
+        settings: "Identifier",
     }, {
         scope: "variable.other.constant",
         settings: "Constant",
     }, {
         scope: "variable.language",
-        settings: "Special",
+        settings: "Identifier",
     }, {
         scope: "variable.parameter",
-        settings: "Special",
+        settings: "Identifier",
     }, {
         scope: "variable.other",
-        settings: "Special",
+        settings: "Identifier",
     }, {
         scope: "support.function",
         settings: "Function",

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -33,11 +33,12 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.fakeLag.neovimInput": null,
 
     "experimental.editor.textMateHighlighting.enabled": false,
-    "experimental.editor.textMateHighlighting.maxLines": 2000,
 
     "experimental.neovim.transport": "stdio",
     // TODO: Enable pipe transport for Windows
     // "experimental.neovim.transport": Platform.isWindows() ? "pipe" : "stdio",
+
+    "editor.maxLinesForLanguageServices": 2500,
 
     "experimental.sidebar.enabled": false,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -41,8 +41,6 @@ export interface IConfigurationValues {
 
         // - textMateHighlighting
     "experimental.editor.textMateHighlighting.enabled": boolean
-    // If a file has more lines than this value, syntax highlighting will be disabled
-    "experimental.editor.textMateHighlighting.maxLines": number
 
     "experimental.sidebar.enabled": boolean
 
@@ -127,6 +125,10 @@ export interface IConfigurationValues {
 
     // Additional padding between lines
     "editor.linePadding": number
+
+    // Maximum supported file size (by lines)
+    // to include language services/completion/syntax highlight/etc
+    "editor.maxLinesForLanguageServices": 2500,
 
     // If true (default), the buffer scroll bar will be visible
     "editor.scrollBar.visible": boolean

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -60,6 +60,7 @@ export class LanguageManager {
             const currentBuffer = editorManager.activeEditor.activeBuffer
 
             if (currentBuffer.lineCount > configuration.getValue("editor.maxLinesForLanguageServices")) {
+                this._statusBar.setStatus(LanguageClientState.NotAvailable)
                 Log.info("[LanguageManager] Not sending 'didOpen' because file line count exceeds limit.")
                 return
             }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -61,13 +61,6 @@ export interface INeovimCompletionInfo {
     col: number
 }
 
-// Limit for the number of lines to handle buffer updates
-// If the file is too large, it ends up being too much traffic
-// between Neovim <-> Oni <-> Language Servers - so
-// set a hard limit. In the future, if need be, this could be
-// moved to a configuration setting.
-export const MAX_LINES_FOR_BUFFER_UPDATE = 5000
-
 export type NeovimEventHandler = (...args: any[]) => void
 
 export interface INeovimInstance {
@@ -374,7 +367,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
                         // set title after attaching listeners so we can get the initial title
                         await this.command("set title")
-                        await this.callFunction("OniConnect", [])
 
                         this._initComplete = true
                     },
@@ -648,7 +640,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     private async _onFullBufferUpdate(context: EventContext, startRange: number, endRange: number): Promise<void> {
-        if (endRange > MAX_LINES_FOR_BUFFER_UPDATE) {
+        if (endRange > this._config.getValue("editor.maxLinesForLanguageServices"))
             return
         }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -640,7 +640,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     private async _onFullBufferUpdate(context: EventContext, startRange: number, endRange: number): Promise<void> {
-        if (endRange > this._config.getValue("editor.maxLinesForLanguageServices"))
+        if (endRange > this._config.getValue("editor.maxLinesForLanguageServices")) {
             return
         }
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -20,13 +20,11 @@ const remapPathToUnpackedAsar = (originalPath: string) => {
 export type MsgPackTransport = "stdio" | "pipe"
 
 export interface INeovimStartOptions {
-    args: string[]
     runtimePaths?: string[]
     transport?: MsgPackTransport
 }
 
 const DefaultStartOptions: INeovimStartOptions = {
-    args: [],
     runtimePaths: [],
     transport: "stdio",
 }
@@ -53,7 +51,6 @@ const getSessionFromProcess = async (neovimProcess: ChildProcess, transport: Msg
 export const startNeovim = async (options: INeovimStartOptions = DefaultStartOptions): Promise<Session> => {
 
     const runtimePaths = options.runtimePaths || []
-    const args = options.args || []
 
     const noopInitVimPath = remapPathToUnpackedAsar(path.join(__dirname, "vim", "noop.vim"))
 
@@ -89,7 +86,6 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
 
     const argsToPass = initVimArg
         .concat(["--cmd", `let &rtp.=',${joinedRuntimePaths}'`, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
-        .concat(args)
 
     const nvimProc = await spawnProcess(nvimProcessPath, argsToPass, {})
 

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -128,7 +128,6 @@ class SharedNeovimInstance implements SharedNeovimInstance {
 
     public async start(): Promise<void> {
         const startOptions: INeovimStartOptions = {
-            args: [],
             runtimePaths: pluginManager.getAllRuntimePaths(),
         }
 

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -14,6 +14,7 @@ const CiTests = [
     "AutoClosingPairsTest",
     "AutoCompletionTest-CSS",
     "AutoCompletionTest-TypeScript",
+    "LargeFileTest",
     "QuickOpenTest",
     "StatusBar-Mode",
     "NoInstalledNeovim",

--- a/test/ci/LargeFileTest.ts
+++ b/test/ci/LargeFileTest.ts
@@ -1,0 +1,42 @@
+/**
+ * Test for opening a large file
+ *
+ * Regression test for #1064
+ */
+
+import { getTemporaryFilePath, navigateToFile } from "./Common"
+
+export const test = async (oni: any) => {
+
+    const filePath = createLargeTestFile()
+    navigateToFile(filePath, oni)
+
+    await oni.automation.sendKeys("G")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 99999, 30000)
+
+    await oni.automation.sendKeys(":50000<CR>")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 49999, 30000)
+
+    await oni.automation.sendKeys("gg")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 0, 30000)
+}
+
+
+import * as fs from "fs"
+import * as os from "os"
+
+const createLargeTestFile = (): string => {
+    const filePath = getTemporaryFilePath("js")
+    const line = "window.alert('hello world from a very very very very extremely large javascript file'); // testing testing testing to make the line very long"
+
+    const lineCount = 100 * 1000
+
+    const lines = []
+    for (let i = 0; i < lineCount; i++) {
+        lines.push(line + os.EOL)
+    }
+
+    fs.writeFileSync(filePath, lines)
+    return filePath
+}
+

--- a/test/ci/LargeFileTest.ts
+++ b/test/ci/LargeFileTest.ts
@@ -21,7 +21,6 @@ export const test = async (oni: any) => {
     await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 0, 30000)
 }
 
-
 import * as fs from "fs"
 import * as os from "os"
 
@@ -39,4 +38,3 @@ const createLargeTestFile = (): string => {
     fs.writeFileSync(filePath, lines)
     return filePath
 }
-

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -116,14 +116,6 @@ endif
 return context
 endfunction
 
-function OniConnect()
-    " Force BufEnter and buffer update events to be dispatched on connection
-    " Otherwise, there can be race conditions where the buffer is loaded
-    " prior to the UI attaching. See #122
-    call OniNotifyEvent("BufEnter")
-    call OniNotifyBufferUpdate()
-endfunction
-
 function OniNotifyYank(yankEvent)
     call OniNotify(["oni_yank", a:yankEvent])
 endfunction


### PR DESCRIPTION
__Issue:__ When trying to open a large file, the Neovim process would crash, and show our generic error message (which is confusing...).

__Defect:__ When we open a file of a supported type for our language service, we try and read the full content to send with the `textDocument/didOpen` message. This was blocked in the `NeovimInstance` on the buffer update side,  but not in other places where we may directly call `getLines`.

__Fix:__ Don't engage the language service or start `textDocument/didOpen` if the file line length goes past a configurable value (`editor.maxLinesForLanguageServices`). In addition, add a regression test, and a warning in the `getLines` method as defensive fixes to make it easier to catch this in the future.