### PR TITLE
Fix #1076 - Hide titlebar on OSX in fullscreen

### DIFF
--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -25,6 +25,14 @@ export interface ISetHasFocusAction {
     }
 }
 
+export interface IEnterFullScreenAction {
+    type: "ENTER_FULL_SCREEN",
+}
+
+export interface ILeaveFullScreenAction {
+    type: "LEAVE_FULL_SCREEN",
+}
+
 export interface ISetLoadingCompleteAction {
     type: "SET_LOADING_COMPLETE",
 }
@@ -250,6 +258,8 @@ export type SimpleAction =
     IBufferEnterAction |
     IBufferSaveAction |
     IBufferUpdateAction |
+    IEnterFullScreenAction |
+    ILeaveFullScreenAction |
     ISetColorsAction |
     ISetCursorPositionAction |
     ISetImeActive |

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -21,12 +21,12 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
     }
 
     switch (a.type) {
-        case "ENTER_FULL_SCREEN": 
+        case "ENTER_FULL_SCREEN":
             return {
                 ...s,
                 isFullScreen: true,
             }
-        case "LEAVE_FULL_SCREEN": 
+        case "LEAVE_FULL_SCREEN":
             return {
                 ...s,
                 isFullScreen: false,

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -21,6 +21,16 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
     }
 
     switch (a.type) {
+        case "ENTER_FULL_SCREEN": 
+            return {
+                ...s,
+                isFullScreen: true,
+            }
+        case "LEAVE_FULL_SCREEN": 
+            return {
+                ...s,
+                isFullScreen: false,
+            }
         case "SET_HAS_FOCUS":
             return {
                 ...s,

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -44,6 +44,7 @@ export interface IState {
     fontFamily: string
     fontSize: string
     hasFocus: boolean
+    isFullScreen: boolean
     mode: string
     definition: null | IDefinition
     cursorLineOpacity: number
@@ -204,6 +205,7 @@ export const createDefaultState = (): IState => ({
     cursorColumnOpacity: 0,
     neovimError: false,
     isLoaded: false,
+    isFullScreen: false,
 
     configuration: {} as IConfigurationValues,
 

--- a/browser/src/UI/components/WindowTitle.tsx
+++ b/browser/src/UI/components/WindowTitle.tsx
@@ -46,7 +46,7 @@ export interface IWindowTitleProps {
 
 export const mapStateToProps = (state: State.IState, props: IWindowTitleProps): IWindowTitleViewProps => {
     return {
-        ...props,
+        visible: props.visible && !state.isFullScreen,
         title: state.windowTitle,
         backgroundColor: state.colors["title.background"],
         foregroundColor: state.colors["title.foreground"],

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -8,6 +8,8 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
+import { remote } from "electron"
+
 import { Provider } from "react-redux"
 import { bindActionCreators } from "redux"
 import thunk from "redux-thunk"
@@ -46,6 +48,15 @@ export const Actions: typeof ActionCreators = bindActionCreators(ActionCreators 
 export const Selectors = {
     getActiveDefinition: () => getActiveDefinition(store.getState() as any),
 }
+
+const browserWindow = remote.getCurrentWindow()
+browserWindow.on("enter-full-screen", () => {
+    store.dispatch({type: "ENTER_FULL_SCREEN"})
+})
+
+browserWindow.on("leave-full-screen", () => {
+    store.dispatch({type: "LEAVE_FULL_SCREEN"})
+})
 
 export const activate = (): void => {
     render(defaultState)


### PR DESCRIPTION
Most apps in OSX hide their titlebar when they go fullscreen. When we implemented our 'custom' title bar, we did not include this behavior - the titlebar was always shown.

To fix this, we keep track of the full screen state, and use that to decide whether or not to render the title bar.