### PR TITLE
Fix #372: Add metrics for startup performance, and parallelize paths

### DIFF
--- a/browser/src/Performance.ts
+++ b/browser/src/Performance.ts
@@ -20,9 +20,9 @@ export function mark(markerName: string): void {
 }
 
 export const startMeasure = (measurementName: string): void => {
-    console.time(measurementName)
+    console.time(measurementName) // tslint:disable-line
 }
 
 export const endMeasure = (measurementName: string): void => {
-    console.timeEnd(measurementName)
+    console.timeEnd(measurementName) // tslint:disable-line
 }

--- a/browser/src/Performance.ts
+++ b/browser/src/Performance.ts
@@ -18,3 +18,11 @@ export function mark(markerName: string): void {
 
     console.log(`[PERFORMANCE] ${markerName}: ${performance.now()}`) // tslint:disable-line no-console
 }
+
+export const startMeasure = (measurementName: string): void => {
+    console.time(measurementName)
+}
+
+export const endMeasure = (measurementName: string): void => {
+    console.timeEnd(measurementName)
+}


### PR DESCRIPTION
- Add measurements to startup path, to quantify startup time per component
- Parallelize some paths that were trivial - saved around ~500ms for me