### PR TITLE
#747 - Alternate QuickOpen filter

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -82,6 +82,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.linePadding": 2,
 
     "editor.quickOpen.execCommand": null,
+    "editor.quickOpen.filterStrategy": "fuse",
 
     "editor.typingPrediction": true,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -152,6 +152,12 @@ export interface IConfigurationValues {
     // "editor.quickOpen.execCommand": "dir /s /b"
     "editor.quickOpen.execCommand": string | null
 
+    // The filter strategy to use for processing results
+    // Options:
+    // - 'fuse' - use the fusejs strategy
+    // - 'regex' - use a regex based strategy
+    "editor.quickOpen.filterStrategy": string
+
     // Typing prediction is Oni's implementation of
     // 'zero-latency' mode typing, and increases responsiveness.
     "editor.typingPrediction": boolean

--- a/browser/src/Services/ContextMenu/ContextMenu.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenu.tsx
@@ -22,7 +22,9 @@ import { createStore } from "./../../Redux"
 import * as UI from "./../../UI"
 import { ContextMenuContainer } from "./ContextMenuComponent"
 
+// TODO: Remove filtering from the context menu responsibility
 const reducer = createReducer<types.CompletionItem, types.CompletionItem>()
+const noopFilter = (opts: types.CompletionItem[], searchText: string): types.CompletionItem[] => opts
 
 export const contextMenuStore = createStore("CONTEXT-MENU", reducer, State.createDefaultState(), [thunk])
 export const contextMenuActions: typeof ActionCreators = bindActionCreators(ActionCreators as any, contextMenuStore.dispatch)
@@ -141,6 +143,7 @@ export class ContextMenu {
 
         contextMenuActions.showPopupMenu(this._id, {
             ...colors,
+            filterFunction: noopFilter,
             onSelectedItemChanged: (item: any) => this._onSelectedItemChanged.dispatch(item),
             onSelectItem: (idx: number) => this._onItemSelectedHandler(idx),
             onHide: () => this._onHidden(),

--- a/browser/src/Services/ContextMenu/ContextMenu.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenu.tsx
@@ -22,20 +22,7 @@ import { createStore } from "./../../Redux"
 import * as UI from "./../../UI"
 import { ContextMenuContainer } from "./ContextMenuComponent"
 
-// TODO: Remove filtering from the context menu responsibility
-const reducer = createReducer<types.CompletionItem, types.CompletionItem>((opts, searchText) => {
-
-    if (!searchText) {
-        return opts
-    }
-
-    const filterRegEx = new RegExp("^" + searchText.split("").join(".*") + ".*")
-
-    return opts.filter((f) => {
-        const textToFilterOn = f.filterText || f.label
-        return textToFilterOn.match(filterRegEx)
-    })
-})
+const reducer = createReducer<types.CompletionItem, types.CompletionItem>()
 
 export const contextMenuStore = createStore("CONTEXT-MENU", reducer, State.createDefaultState(), [thunk])
 export const contextMenuActions: typeof ActionCreators = bindActionCreators(ActionCreators as any, contextMenuStore.dispatch)

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -65,7 +65,7 @@ export class Menu {
     private _onItemSelected = new Event<any>()
     private _onFilterTextChanged = new Event<string>()
     private _onHide = new Event<void>()
-    private _filterFunction = MenuFilter.filterMenuOptions
+    private _filterFunction = MenuFilter.regexFilter
 
     public get onHide(): IEvent<void> {
         return this._onHide

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -11,6 +11,7 @@ import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 
 import * as ActionCreators from "./MenuActionCreators"
+import * as MenuFilter from "./MenuFilter"
 import { createReducer } from "./MenuReducer"
 import * as State from "./MenuState"
 
@@ -64,6 +65,7 @@ export class Menu {
     private _onItemSelected = new Event<any>()
     private _onFilterTextChanged = new Event<string>()
     private _onHide = new Event<void>()
+    private _filterFunction = MenuFilter.filterMenuOptions
 
     public get onHide(): IEvent<void> {
         return this._onHide
@@ -97,9 +99,14 @@ export class Menu {
         menuActions.setMenuItems(this._id, items)
     }
 
+    public setFilterFunction(filterFunc: (items: Oni.Menu.MenuOption[], searchString: string) => IMenuOptionWithHighlights[]) {
+        this._filterFunction = filterFunc
+    }
+
     public show(): void {
 
         menuActions.showPopupMenu(this._id, {
+            filterFunction: this._filterFunction,
             onSelectItem: (idx: number) => this._onItemSelectedHandler(idx),
             onHide: () => this._onHide.dispatch(),
             onFilterTextChanged: (newText) => this._onFilterTextChanged.dispatch(newText),

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -16,8 +16,8 @@ import { createReducer } from "./MenuReducer"
 import * as State from "./MenuState"
 
 export interface IMenuOptionWithHighlights extends Oni.Menu.MenuOption {
-    labelHighlights: number[][],
-    detailHighlights: number[][]
+    labelHighlights: number[]
+    detailHighlights: number[]
 }
 
 export type MenuState = State.IMenus<Oni.Menu.MenuOption, IMenuOptionWithHighlights>

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -65,7 +65,7 @@ export class Menu {
     private _onItemSelected = new Event<any>()
     private _onFilterTextChanged = new Event<string>()
     private _onHide = new Event<void>()
-    private _filterFunction = MenuFilter.regexFilter
+    private _filterFunction = MenuFilter.fuseFilter
 
     public get onHide(): IEvent<void> {
         return this._onHide

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -11,7 +11,6 @@ import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 
 import * as ActionCreators from "./MenuActionCreators"
-import { filterMenuOptions } from "./MenuFilter"
 import { createReducer } from "./MenuReducer"
 import * as State from "./MenuState"
 
@@ -22,7 +21,7 @@ export interface IMenuOptionWithHighlights extends Oni.Menu.MenuOption {
 
 export type MenuState = State.IMenus<Oni.Menu.MenuOption, IMenuOptionWithHighlights>
 
-const reducer = createReducer<Oni.Menu.MenuOption, IMenuOptionWithHighlights>(filterMenuOptions)
+const reducer = createReducer<Oni.Menu.MenuOption, IMenuOptionWithHighlights>()
 
 export const menuStore = createStore<MenuState>(reducer, State.createDefaultState<Oni.Menu.MenuOption, IMenuOptionWithHighlights>(), applyMiddleware(thunk))
 

--- a/browser/src/Services/Menu/MenuActions.ts
+++ b/browser/src/Services/Menu/MenuActions.ts
@@ -8,6 +8,7 @@ export interface IMenuOptions {
     foregroundColor?: string
     backgroundColor?: string
     highlightColor?: string
+    filterFunction?: (items: any[], searchString: string) => any[]
     onSelectedItemChanged?: (newItem: any) => void
     onSelectItem?: (idx: number) => void
     onHide?: () => void

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -154,9 +154,9 @@ export interface IMenuItemProps {
     isSelected: boolean
     filterText: string
     label: string
-    labelHighlights: number[][]
+    labelHighlights: number[]
     detail: string
-    detailHighlights: number[][]
+    detailHighlights: number[]
     pinned: boolean
     onClick: () => void
 }

--- a/browser/src/Services/Menu/MenuFilter.ts
+++ b/browser/src/Services/Menu/MenuFilter.ts
@@ -116,10 +116,24 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
             pinned: f.item.pinned,
             label: f.item.label,
             detail: f.item.detail,
-            labelHighlights,
-            detailHighlights,
+            labelHighlights: convertArrayOfPairsToIndices(labelHighlights),
+            detailHighlights: convertArrayOfPairsToIndices(detailHighlights),
         }
     })
 
     return highlightOptions
+}
+
+const convertArrayOfPairsToIndices = (pairs: number[][]): number[] => {
+    const ret: number[] = []
+
+    pairs.forEach((p) => {
+        const [startIndex, endIndex] = p
+
+        for(let i = startIndex; i <= endIndex; i++) {
+            ret.push(i)
+        }
+    })
+
+    return ret
 }

--- a/browser/src/Services/Menu/MenuFilter.ts
+++ b/browser/src/Services/Menu/MenuFilter.ts
@@ -130,7 +130,7 @@ const convertArrayOfPairsToIndices = (pairs: number[][]): number[] => {
     pairs.forEach((p) => {
         const [startIndex, endIndex] = p
 
-        for(let i = startIndex; i <= endIndex; i++) {
+        for (let i = startIndex; i <= endIndex; i++) {
             ret.push(i)
         }
     })

--- a/browser/src/Services/Menu/MenuFilter.ts
+++ b/browser/src/Services/Menu/MenuFilter.ts
@@ -13,9 +13,7 @@ import { configuration } from "./../../Services/Configuration"
 
 import { IMenuOptionWithHighlights } from "./Menu"
 
-import { createLetterCountDictionary, LetterCountDictionary } from "./../../UI/components/HighlightText"
-
-const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
+export const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
 
     // TODO: Technically, this makes the reducer 'impure',
     // which is not ideal - need to refactor eventually.
@@ -39,62 +37,6 @@ const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
             return true
         }
     }
-}
-
-export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string): IMenuOptionWithHighlights[] => {
-    if (!searchString) {
-        const opt = options.map((o) => {
-            return {
-                ...o,
-                detailHighlights: [],
-                labelHighlights: [],
-            }
-        })
-
-        return sortBy(opt, (o) => o.pinned ? 0 : 1)
-    }
-
-    const filterRegExp = new RegExp(".*" + searchString.split("").join(".*") + ".*")
-
-    const filteredOptions = options.filter((f) => {
-        const textToFilterOn = f.detail + f.label
-        return textToFilterOn.match(filterRegExp)
-    })
-
-    const ret = filteredOptions.map((fo) => {
-        const letterCountDictionary = createLetterCountDictionary(searchString)
-
-        const detailHighlights = getHighlightsFromString(fo.detail, letterCountDictionary)
-        const labelHighlights = getHighlightsFromString(fo.label, letterCountDictionary)
-
-        return {
-            ...fo,
-            detailHighlights,
-            labelHighlights,
-        }
-    })
-
-    return ret
-}
-
-export const getHighlightsFromString = (text: string, letterCountDictionary: LetterCountDictionary): number[] => {
-
-    if (!text) {
-        return []
-    }
-
-    const ret: number[] = []
-
-    for (let i = 0; i < text.length; i++) {
-        const letter = text[i]
-        const idx = i
-        if (letterCountDictionary[letter] && letterCountDictionary[letter] > 0) {
-            ret.push(idx)
-            letterCountDictionary[letter]--
-        }
-    }
-
-    return ret
 }
 
 export const fuseFilter = (options: Oni.Menu.MenuOption[], searchString: string): IMenuOptionWithHighlights[] => {

--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -28,7 +28,7 @@ export function createReducer<T, FilteredT extends T>() {
             case "SHOW_MENU":
                 const options3 = a.payload.items || []
                 const filterText = a.payload.filter || ""
-                const filterFunc = (a.payload.options && a.payload.options.filterFunction) ? a.payload.options.filterFunction : MenuFilter.filterMenuOptions
+                const filterFunc = (a.payload.options && a.payload.options.filterFunction) ? a.payload.options.filterFunction : MenuFilter.fuseFilter
                 const filteredOptions3 = filterFunc(options3, filterText)
                 return {
                     ...a.payload.options,

--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -5,11 +5,11 @@
  */
 
 import * as Actions from "./MenuActions"
+import * as MenuFilter from "./MenuFilter"
 import * as State from "./MenuState"
 
-export type MenuFilterFunction<T, FilteredT extends T> = (options: T[], searchString: string) => FilteredT[]
 
-export function createReducer<T, FilteredT extends T>(filterFunc: MenuFilterFunction<T, FilteredT>) {
+export function createReducer<T, FilteredT extends T>() {
 
     const reducer = (s: State.IMenus<T, FilteredT>, a: Actions.MenuAction): State.IMenus<T, FilteredT> => {
         return {
@@ -28,52 +28,59 @@ export function createReducer<T, FilteredT extends T>(filterFunc: MenuFilterFunc
             case "SHOW_MENU":
                 const options3 = a.payload.items || []
                 const filterText = a.payload.filter || ""
+                const filterFunc = (a.payload.options && a.payload.options.filterFunction) ? a.payload.options.filterFunction : MenuFilter.filterMenuOptions
                 const filteredOptions3 = filterFunc(options3, filterText)
                 return {
                     ...a.payload.options,
                     id: a.payload.id,
                     filter: filterText,
+                    filterFunction: filterFunc,
                     filteredOptions: filteredOptions3,
                     options: options3,
                     selectedIndex: 0,
                     isLoading: false,
                 }
-            case "SET_DETAILED_MENU_ITEM":
-                if (!s || !s.options) {
-                    return s
-                }
-
-                if (!a.payload.detailedItem) {
-                    return s
-                }
-
-                const options = s.options.map((entry) => {
-                    // TODO: Decide on canonical interface for menu options
-                    if ((entry as any).label === a.payload.detailedItem.label) {
-                        return a.payload.detailedItem
-                    } else {
-                        return entry
+            case "SET_DETAILED_MENU_ITEM": 
+                {
+                    if (!s || !s.options) {
+                        return s
                     }
-                })
 
-                const filteredOptions2 = filterFunc(options, s.filter)
-                return {
-                    ...s,
-                    options,
-                    filteredOptions: filteredOptions2,
+                    if (!a.payload.detailedItem) {
+                        return s
+                    }
+
+                    const options = s.options.map((entry) => {
+                        // TODO: Decide on canonical interface for menu options
+                        if ((entry as any).label === a.payload.detailedItem.label) {
+                            return a.payload.detailedItem
+                        } else {
+                            return entry
+                        }
+                    })
+
+                    const filterFunc = s.filterFunction
+                    const filteredOptions2 = filterFunc(options, s.filter)
+                    return {
+                        ...s,
+                        options,
+                        filteredOptions: filteredOptions2,
+                    }
                 }
-
             case "SET_MENU_ITEMS":
-                if (!s || s.id !== a.payload.id) {
-                    return s
-                }
+                {
+                    if (!s || s.id !== a.payload.id) {
+                        return s
+                    }
 
-                const filteredOptions = filterFunc(a.payload.items, s.filter)
+                    const filterFunc = s.filterFunction
+                    const filteredOptions = filterFunc(a.payload.items, s.filter)
 
-                return {
-                    ...s,
-                    options: a.payload.items,
-                    filteredOptions,
+                    return {
+                        ...s,
+                        options: a.payload.items,
+                        filteredOptions,
+                    }
                 }
             case "SET_MENU_LOADING":
                 if (!s || s.id !== a.payload.id) {
@@ -93,15 +100,18 @@ export function createReducer<T, FilteredT extends T>(filterFunc: MenuFilterFunc
                 return {...s,
                         selectedIndex: s.selectedIndex > 0 ? s.selectedIndex - 1 : size - 1}
             case "FILTER_MENU":
-                if (!s) {
-                    return s
+                {
+                    if (!s) {
+                        return s
+                    }
+
+                    const filterFunc = s.filterFunction
+                    const filteredOptionsSorted = filterFunc(s.options, a.payload.filter)
+
+                    return {...s,
+                            filter: a.payload.filter,
+                            filteredOptions: filteredOptionsSorted}
                 }
-
-                const filteredOptionsSorted = filterFunc(s.options, a.payload.filter)
-
-                return {...s,
-                        filter: a.payload.filter,
-                        filteredOptions: filteredOptionsSorted}
             default:
                 return s
         }

--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -8,7 +8,6 @@ import * as Actions from "./MenuActions"
 import * as MenuFilter from "./MenuFilter"
 import * as State from "./MenuState"
 
-
 export function createReducer<T, FilteredT extends T>() {
 
     const reducer = (s: State.IMenus<T, FilteredT>, a: Actions.MenuAction): State.IMenus<T, FilteredT> => {
@@ -26,21 +25,23 @@ export function createReducer<T, FilteredT extends T>() {
         switch (a.type) {
 
             case "SHOW_MENU":
-                const options3 = a.payload.items || []
-                const filterText = a.payload.filter || ""
-                const filterFunc = (a.payload.options && a.payload.options.filterFunction) ? a.payload.options.filterFunction : MenuFilter.fuseFilter
-                const filteredOptions3 = filterFunc(options3, filterText)
-                return {
-                    ...a.payload.options,
-                    id: a.payload.id,
-                    filter: filterText,
-                    filterFunction: filterFunc,
-                    filteredOptions: filteredOptions3,
-                    options: options3,
-                    selectedIndex: 0,
-                    isLoading: false,
+                {
+                    const options3 = a.payload.items || []
+                    const filterText = a.payload.filter || ""
+                    const filterFunc = (a.payload.options && a.payload.options.filterFunction) ? a.payload.options.filterFunction : MenuFilter.fuseFilter
+                    const filteredOptions3 = filterFunc(options3, filterText)
+                    return {
+                        ...a.payload.options,
+                        id: a.payload.id,
+                        filter: filterText,
+                        filterFunction: filterFunc,
+                        filteredOptions: filteredOptions3,
+                        options: options3,
+                        selectedIndex: 0,
+                        isLoading: false,
+                    }
                 }
-            case "SET_DETAILED_MENU_ITEM": 
+            case "SET_DETAILED_MENU_ITEM":
                 {
                     if (!s || !s.options) {
                         return s

--- a/browser/src/Services/Menu/MenuState.ts
+++ b/browser/src/Services/Menu/MenuState.ts
@@ -22,6 +22,8 @@ export interface IMenu<T, FilteredT> {
     borderColor: string
     highlightColor: string
 
+    filterFunction: (items: T[], searchString: string) => FilteredT[]
+
     onFilterTextChanged: (newText: string) => void
     onSelectedItemChanged: (newItem: FilteredT) => void
     onSelectItem: (idx: number) => void

--- a/browser/src/Services/Menu/index.ts
+++ b/browser/src/Services/Menu/index.ts
@@ -1,2 +1,3 @@
 export * from "./Menu"
 export * from "./MenuComponent"
+export * from "./MenuFilter"

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -15,12 +15,12 @@ import { INeovimInstance } from "./../../neovim"
 import { commandManager } from "./../CommandManager"
 import { configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
-import { Menu, menuManager, fuseFilter } from "./../Menu"
+import { fuseFilter, Menu, menuManager } from "./../Menu"
 
 import { FinderProcess } from "./FinderProcess"
 import { QuickOpenItem, QuickOpenType } from "./QuickOpenItem"
-import * as RipGrep from "./RipGrep"
 import { regexFilter } from "./RegExFilter"
+import * as RipGrep from "./RipGrep"
 
 export class QuickOpen {
     private _finderProcess: FinderProcess

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -15,11 +15,12 @@ import { INeovimInstance } from "./../../neovim"
 import { commandManager } from "./../CommandManager"
 import { configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
-import { Menu, menuManager } from "./../Menu"
+import { Menu, menuManager, fuseFilter } from "./../Menu"
 
 import { FinderProcess } from "./FinderProcess"
 import { QuickOpenItem, QuickOpenType } from "./QuickOpenItem"
 import * as RipGrep from "./RipGrep"
+import { regexFilter } from "./RegExFilter"
 
 export class QuickOpen {
     private _finderProcess: FinderProcess
@@ -77,7 +78,13 @@ export class QuickOpen {
         this._loadedItems = []
 
         const overriddenCommand = configuration.getValue("editor.quickOpen.execCommand")
-        // const exclude = config.getValue("oni.exclude")
+
+        const filterStrategy = configuration.getValue("editor.quickOpen.filterStrategy")
+
+        const useRegExFilter = filterStrategy === "regex"
+
+        const filterFunction = useRegExFilter ? regexFilter : fuseFilter
+        this._menu.setFilterFunction(filterFunction)
 
         //  If in exec directory or home, show bookmarks to change cwd to
         if (this._isInstallDirectoryOrHome()) {

--- a/browser/src/Services/QuickOpen/RegExFilter.ts
+++ b/browser/src/Services/QuickOpen/RegExFilter.ts
@@ -77,4 +77,3 @@ export const getHighlightsFromString = (text: string, letterCountDictionary: Let
 
     return ret
 }
-

--- a/browser/src/Services/QuickOpen/RegExFilter.ts
+++ b/browser/src/Services/QuickOpen/RegExFilter.ts
@@ -1,0 +1,80 @@
+/**
+ * MenuFilter.ts
+ *
+ * Implements filtering logic for the menu
+ */
+
+import * as sortBy from "lodash/sortBy"
+
+import * as Oni from "oni-api"
+
+import { IMenuOptionWithHighlights, shouldFilterbeCaseSensitive } from "./../Menu"
+
+import { createLetterCountDictionary, LetterCountDictionary } from "./../../UI/components/HighlightText"
+
+export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string): IMenuOptionWithHighlights[] => {
+    if (!searchString) {
+        const opt = options.map((o) => {
+            return {
+                ...o,
+                detailHighlights: [],
+                labelHighlights: [],
+            }
+        })
+
+        return sortBy(opt, (o) => o.pinned ? 0 : 1)
+    }
+
+    const isCaseSensitive = shouldFilterbeCaseSensitive(searchString)
+
+    if (!isCaseSensitive) {
+        searchString = searchString.toLowerCase()
+    }
+
+    const filterRegExp = new RegExp(".*" + searchString.split("").join(".*") + ".*")
+
+    const filteredOptions = options.filter((f) => {
+        let textToFilterOn = f.detail + f.label
+
+        if (!isCaseSensitive) {
+            textToFilterOn = textToFilterOn.toLowerCase()
+        }
+
+        return textToFilterOn.match(filterRegExp)
+    })
+
+    const ret = filteredOptions.map((fo) => {
+        const letterCountDictionary = createLetterCountDictionary(searchString)
+
+        const detailHighlights = getHighlightsFromString(fo.detail, letterCountDictionary)
+        const labelHighlights = getHighlightsFromString(fo.label, letterCountDictionary)
+
+        return {
+            ...fo,
+            detailHighlights,
+            labelHighlights,
+        }
+    })
+
+    return ret
+}
+
+export const getHighlightsFromString = (text: string, letterCountDictionary: LetterCountDictionary): number[] => {
+    if (!text) {
+        return []
+    }
+
+    const ret: number[] = []
+
+    for (let i = 0; i < text.length; i++) {
+        const letter = text[i]
+        const idx = i
+        if (letterCountDictionary[letter] && letterCountDictionary[letter] > 0) {
+            ret.push(idx)
+            letterCountDictionary[letter]--
+        }
+    }
+
+    return ret
+}
+

--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -63,7 +63,9 @@ function shouldHighlightIndex(index: number, highlights: number[]): boolean {
     return highlights.indexOf(index) >= 0
 }
 
-export function createLetterCountDictionary(text: string): any {
+export type LetterCountDictionary = { [letter: string]: number }
+
+export function createLetterCountDictionary(text: string): LetterCountDictionary {
     const array: string[] = text.split("")
     return array.reduce((previousValue: any, currentValue: string) => {
         const cur = previousValue[currentValue] || 0

--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -33,7 +33,7 @@ export class HighlightText extends React.PureComponent<IHighlightTextProps, {}> 
 
 export interface IHighlightTextByIndexProps {
     highlightClassName: string
-    highlightIndices: number[][]
+    highlightIndices: number[]
     text: string
     className: string
 }
@@ -59,15 +59,8 @@ export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIn
 
 }
 
-function shouldHighlightIndex(index: number, highlights: number[][]): boolean {
-    let matchFound = false
-    for (const startEnd of highlights) {
-        if (startEnd[0] <= index && index <= startEnd[1]) {
-            matchFound = true
-            break
-        }
-    }
-    return matchFound
+function shouldHighlightIndex(index: number, highlights: number[]): boolean {
+    return highlights.indexOf(index) >= 0
 }
 
 export function createLetterCountDictionary(text: string): any {

--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -63,7 +63,7 @@ function shouldHighlightIndex(index: number, highlights: number[]): boolean {
     return highlights.indexOf(index) >= 0
 }
 
-export type LetterCountDictionary = { [letter: string]: number }
+export interface LetterCountDictionary { [letter: string]: number }
 
 export function createLetterCountDictionary(text: string): LetterCountDictionary {
     const array: string[] = text.split("")


### PR DESCRIPTION
__Issue:__ The default strategy we use for filtering in QuickOpen uses `fuse.js`, and calculates a combined match from the label/detail. This can give sometimes unintuitive results.

__Fix:__ Expose an alternate `'regex'` strategy, which use a simple regex for fuzzy matching. Will be interesting to get feedback on how this strategy compares. It might be that the regex strategy is better for quickopen, whereas fuse might be better for the command palette