### PR TITLE
[blocker] Switch to styled-components

### DIFF
--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -9,12 +9,16 @@ import { MenuContainer } from "./../Services/Menu"
 import * as WindowManager from "./../Services/WindowManager"
 
 import { Background } from "./components/Background"
+import { ThemeProvider } from "./components/common"
 import { Loading } from "./components/Loading"
 import StatusBar from "./components/StatusBar"
 import { WindowSplits } from "./components/WindowSplits"
 import { WindowTitle } from "./components/WindowTitle"
 
+import { IThemeColors } from "../Services/Themes/ThemeManager"
+
 interface IRootComponentProps {
+    theme: IThemeColors
     windowManager: WindowManager.WindowManager
 }
 
@@ -23,30 +27,32 @@ const titleBarVisible = Platform.isMac()
 export class RootComponent extends React.PureComponent<IRootComponentProps, {}> {
 
     public render() {
-        return <div className="stack disable-mouse" onKeyDownCapture={(evt) => this._onRootKeyDown(evt)}>
-            <div className="stack">
-                <Background />
-            </div>
-            <div className="stack">
-                <div className="container vertical full">
-                    <div className="container fixed">
-                        <WindowTitle visible={titleBarVisible} />
-                    </div>
-                    <div className="container full">
-                        <div className="stack">
-                            <WindowSplits windowManager={this.props.windowManager} />
+        return <ThemeProvider theme={this.props.theme}>
+          <div className="stack disable-mouse" onKeyDownCapture={(evt) => this._onRootKeyDown(evt)}>
+                <div className="stack">
+                    <Background />
+                </div>
+                <div className="stack">
+                    <div className="container vertical full">
+                        <div className="container fixed">
+                            <WindowTitle visible={titleBarVisible} />
                         </div>
-                        <div className="stack layer">
-                            <MenuContainer />
+                        <div className="container full">
+                            <div className="stack">
+                                <WindowSplits windowManager={this.props.windowManager} />
+                            </div>
+                            <div className="stack layer">
+                                <MenuContainer />
+                            </div>
                         </div>
-                    </div>
-                    <div className="container fixed layer">
-                        <StatusBar />
+                        <div className="container fixed layer">
+                            <StatusBar />
+                        </div>
                     </div>
                 </div>
+                <Loading/>
             </div>
-            <Loading/>
-        </div>
+        </ThemeProvider>
     }
 
     private _onRootKeyDown(evt: React.KeyboardEvent<HTMLElement>): void {
@@ -59,3 +65,4 @@ export class RootComponent extends React.PureComponent<IRootComponentProps, {}> 
         }
     }
 }
+

--- a/browser/src/UI/components/ActiveWindow.tsx
+++ b/browser/src/UI/components/ActiveWindow.tsx
@@ -5,8 +5,9 @@
  * active window in Neovim.
  */
 
-import * as React from "react"
 import { connect } from "react-redux"
+import styled from "styled-components"
+import { withProps } from "./common"
 
 import * as Selectors from "./../Selectors"
 import * as State from "./../State"
@@ -18,24 +19,13 @@ export interface IActiveWindowProps {
     pixelHeight: number
 }
 
-export class ActiveWindow extends React.PureComponent<IActiveWindowProps, {}> {
-    public render(): JSX.Element {
-
-        const px = (str: number): string => `${str}px`
-
-        const style: React.CSSProperties = {
-            position: "absolute",
-            left: px(this.props.pixelX),
-            top: px(this.props.pixelY),
-            width: px(this.props.pixelWidth),
-            height: px(this.props.pixelHeight),
-        }
-
-        return <div style={style}>
-            {this.props.children}
-        </div>
-    }
-}
+const ActiveWindow = withProps<IActiveWindowProps>(styled.div)`
+    position: "absolute",
+    left: ${props => props.pixelX},
+    top: ${props => props.pixelY},
+    width: ${props => props.pixelWidth},
+    height: ${props => props.pixelHeight},
+    `
 
 const mapStateToProps = (state: State.IState): IActiveWindowProps => {
     const dimensions = Selectors.getActiveWindowPixelDimensions(state)

--- a/browser/src/UI/components/Arrow.tsx
+++ b/browser/src/UI/components/Arrow.tsx
@@ -4,9 +4,8 @@
  * Simple 'up' or 'down' arrow component
  */
 
-require("./Arrow.less") // tslint:disable-line no-var-requires
-
-import * as React from "react"
+import styled from "styled-components"
+import { withProps } from "./common"
 
 export enum ArrowDirection {
     Up = 0,
@@ -21,59 +20,73 @@ export interface IArrowProps {
     direction: ArrowDirection
 }
 
-export const Arrow = (props: IArrowProps): JSX.Element => {
+const transparentBorder = (props: IArrowProps) => `${props.size * 0.8}px solid transparent`
+const solidBorder = (props: IArrowProps) => `${props.size}px solid ${props.color}`
 
-    const transparentBorder = `${props.size * 0.8}px solid transparent`
-    const solidBorder = `${props.size}px solid ${props.color}`
-
-    const upArrowStyle = {
+function arrowCSS(props: IArrowProps): string {
+  switch (props.direction) {
+  case ArrowDirection.Up:
+      return `
         width: "0px",
         height: "0px",
-        borderLeft: transparentBorder,
-        borderRight: transparentBorder,
-        borderBottom: solidBorder,
-    }
-
-    const downArrowStyle = {
+        borderLeft: ${transparentBorder},
+        borderRight: ${transparentBorder},
+        borderTop: ${solidBorder},
+        animation-name: appear-up;
+        `
+  case ArrowDirection.Down:
+      return `
         width: "0px",
         height: "0px",
-        borderLeft: transparentBorder,
-        borderRight: transparentBorder,
-        borderTop: solidBorder,
-    }
-
-    const leftArrowStyle = {
+        borderLeft: ${transparentBorder},
+        borderRight: ${transparentBorder},
+        borderTop: ${solidBorder},
+        animation-name: appear-down;
+        `
+  case ArrowDirection.Left:
+      return `
         width: "0px",
         height: "0px",
-        borderTop: transparentBorder,
-        borderRight: solidBorder,
-        borderBottom: transparentBorder,
-    }
-
-    const rightArrowStyle = {
+        borderTop: ${transparentBorder},
+        borderRight: ${solidBorder},
+        borderBottom: ${transparentBorder},
+        animation-name: appear-left;
+        `
+  case ArrowDirection.Right:
+      return `
         width: "0px",
         height: "0px",
-        borderTop: transparentBorder,
-        borderLeft: solidBorder,
-        borderBottom: transparentBorder,
-    }
-
-    let style: any = upArrowStyle
-    let className = "arrow"
-
-    if (props.direction === ArrowDirection.Down) {
-        style = downArrowStyle
-        className = "arrow down"
-    } else if (props.direction === ArrowDirection.Up) {
-        style = upArrowStyle
-        className = "arrow up"
-    } else if (props.direction === ArrowDirection.Left) {
-        style = leftArrowStyle
-        className = "arrow left"
-    } else if (props.direction === ArrowDirection.Right) {
-        style = rightArrowStyle
-        className = "arrow right"
-    }
-
-    return <div className={className} style={style}></div>
+        border-top: ${transparentBorder},
+        border-left: ${solidBorder},
+        border-bottom: ${transparentBorder},
+        animtation-name: appear-right
+        `
+  default:
+      return ``
+  }
 }
+
+export const Arrow = withProps<IArrowProps>(styled.div)`
+    animation-duration: 0.3s;
+    animation-delay: 0.2s;
+    opacity: 0;
+    animation-fill-mode: forwards;
+    ${ arrowCSS }
+    @keyframes appear-down {
+        from {transform: translateY(-4px); opacity: 0;}
+        to {transform: translateY(0px);opacity: 1;}
+    }
+    @keyframes appear-up {
+        from {transform: translateY(4px); opacity: 0;}
+        to {transform: translateY(0px);opacity: 1;}
+    }
+    @keyframes appear-left {
+        from {transform: translateX(4px); opacity: 0;}
+        to {transform: translateX(0px);opacity: 1;}
+    }
+    @keyframes appear-right {
+        from {transform: translateX(-4px); opacity: 0;}
+        to {transform: translateX(0px);opacity: 1;}
+    }
+    `
+

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -1,7 +1,11 @@
+
 import * as React from "react"
 
 import { connect } from "react-redux"
 import * as State from "./../State"
+
+import styled from "styled-components"
+import { withProps } from "./common"
 
 export interface IBackgroundProps {
     backgroundColor: string
@@ -10,33 +14,28 @@ export interface IBackgroundProps {
     backgroundOpacity: number
 }
 
-export class BackgroundView extends React.PureComponent<IBackgroundProps, {}> {
-    public render(): JSX.Element {
-        const coverStyle = {
-            backgroundColor: this.props.backgroundColor,
-            opacity: this.props.backgroundOpacity,
-        }
+export const BackgroundImageView = withProps<IBackgroundProps>(styled.div)`
+    background-image: url("${props => props.backgroundImageUrl}");
+    background-size: ${props => props.backgroundImageSize || "cover"};
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    `
 
-        return <div>
-            <BackgroundImageView {...this.props} />
-            <div className="background-cover" style={coverStyle}></div>
-        </div>
-    }
-}
+export const BackgroundColorView = withProps<IBackgroundProps>(styled.div)`
+    background-color: ${props => props.backgroundColor};
+    opacity: ${props => props.backgroundOpacity};
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    `
 
-export const BackgroundImageView = (props: IBackgroundProps) => {
-
-    if (props.backgroundImageUrl) {
-        const imageStyle = {
-            backgroundImage: "url(" + props.backgroundImageUrl + ")",
-            backgroundSize: props.backgroundImageSize || "cover",
-        }
-
-        return <div className="background-image" style={imageStyle}></div>
-    } else {
-        return null
-    }
-}
+export const BackgroundView = (props: IBackgroundProps) => (
+    <div>
+        {props.backgroundImageUrl ? <BackgroundImageView {...props} /> : null}
+        <BackgroundColorView {...props} />
+    </div>
+)
 
 const mapStateToProps = (state: State.IState): IBackgroundProps => {
     const conf = state.configuration

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
-require("./BufferScrollBar.less") // tslint:disable-line no-var-requires
+import styled from "styled-components"
+import { bufferScrollBarSize, withProps } from "./common"
 
 export interface IBufferScrollBarProps {
     bufferSize: number
@@ -17,47 +18,55 @@ export interface IScrollBarMarker {
     color: string
 }
 
-export class BufferScrollBar extends React.PureComponent<IBufferScrollBarProps, {}> {
+const BufferScrollBarWindow = withProps<IBufferScrollBarProps>(styled.div)`
+    position: absolute;
+    width: ${bufferScrollBarSize};
+    height: ${props => ((props.windowBottomLine - props.windowTopLine + 1) / props.bufferSize) * props.height}px;
+    height: ${props => ((props.windowTopLine - 1) / props.bufferSize) * props.height}px;
+    background-color: rgba(200, 200, 200, 0.2);
+    border-top:1px solid rgba(255, 255, 255, 0.1);
+    border-bottom:1px solid rgba(255, 255, 255, 0.1);
+    `
 
-    constructor(props: any) {
-        super(props)
+const Marker = withProps<{ height: number, bufferSize: number, line: number }>(styled.div)`
+    position: absolute;
+    top: ${props => (props.line / props.bufferSize) * props.height}px;
+    height: 2px;
+    background-color: ${props => props.color};
+    width: 100%;
+    `
+
+const StyledBufferScrollBar = styled.div`
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    right: 0px;
+    background-color: rgba(0, 0, 0, 0.2);
+    width: ${bufferScrollBarSize};
+    border-bottom: 1px solid black;
+    `
+
+export const BufferScrollBar = (props: IBufferScrollBarProps) => {
+
+    if (!props.visible) {
+        return null
     }
 
-    public render(): JSX.Element {
+    const markers = props.markers || []
 
-        if (!this.props.visible) {
-            return null
-        }
+    const markerElements = markers.map((m) => (
+      <Marker
+        key={m.line.toString() + m.color}
+        height={props.height}
+        bufferSize={props.bufferSize}
+        color={m.color}
+        line={m.line} />
+    ))
 
-        const windowHeight = ((this.props.windowBottomLine - this.props.windowTopLine + 1) / this.props.bufferSize) * this.props.height
-        const windowTop = ((this.props.windowTopLine - 1) / this.props.bufferSize) * this.props.height
-
-        const windowStyle: React.CSSProperties  = {
-            top: windowTop + "px",
-            height: windowHeight + "px",
-        }
-
-        const markers = this.props.markers || []
-
-        const markerElements = markers.map((m) => {
-            const line = m.line
-            const pos = (line / this.props.bufferSize) * this.props.height
-            const size = "2px"
-
-            const markerStyle: React.CSSProperties = {
-                position: "absolute",
-                top: pos + "px",
-                height: size,
-                backgroundColor: m.color,
-                width: "100%",
-            }
-
-            return <div style={markerStyle} key={m.line.toString() + m.color}/>
-        })
-
-        return <div className="scroll-bar-container">
-                <div className="scroll-window" style={windowStyle}></div>
-                {markerElements}
-            </div>
-    }
+    return (
+      <StyledBufferScrollBar>
+            <BufferScrollBarWindow {...props} />
+            {markerElements}
+        </StyledBufferScrollBar>
+    )
 }

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -3,6 +3,9 @@ import { connect } from "react-redux"
 import * as Selectors from "./../Selectors"
 import * as State from "./../State"
 
+import styled from "styled-components"
+import { withProps } from "./common"
+
 export interface ICursorLineRendererProps {
     x: number
     y: number
@@ -17,28 +20,21 @@ export interface ICursorLineProps {
     lineType: string
 }
 
-class CursorLineRenderer extends React.PureComponent<ICursorLineRendererProps, {}> {
+const StyledCursorLine = withProps<ICursorLineRendererProps>(styled.div)`
+      position: "absolute",
+      left: ${props => props.x}px; /* Window Start */
+      top: ${props => props.y}px; /* Same as cursor */
+      width: ${props => props.width}px; /* Window width */
+      height: ${props => props.height ? props.height : "0"}px; /* Same as cursor */
+      background-color: ${props => props.color};
+      opacity: ${props => props.opacity};
+      `
 
-    public render(): null |  JSX.Element {
-        if (!this.props.visible) {
-            return null
-        }
-
-        const width = this.props.width
-
-        const cursorStyle: React.CSSProperties = {
-            position: "absolute",
-            left: this.props.x.toString() + "px", // Window Start
-            top: this.props.y.toString() + "px", // Same as cursor
-            width: width.toString() + "px", // Window width
-
-            height: this.props.height ? this.props.height.toString() + "px" : "0px", // Same as cursor
-            backgroundColor: this.props.color,
-            opacity: this.props.opacity,
-        }
-
-        return <div style={cursorStyle} className="cursorLine"></div>
+const CursorLineRenderer  = (props: ICursorLineRendererProps) => {
+    if (!props.visible) {
+        return null
     }
+    return <StyledCursorLine {...props} />
 }
 
 const emptyProps: ICursorLineRendererProps = {

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -10,6 +10,9 @@ import { connect } from "react-redux"
 
 import * as Oni from "oni-api"
 
+import styled from "styled-components"
+import { withProps } from "./common"
+
 import { IState } from "./../State"
 
 import { Arrow, ArrowDirection } from "./Arrow"
@@ -17,6 +20,21 @@ import { Arrow, ArrowDirection } from "./Arrow"
 export enum OpenDirection {
     Up = 1,
     Down = 2,
+}
+
+/**
+ * Helper function that fixes an item horizontally to its first positioned parent.
+ */
+function vfix(top: boolean = true) {
+  return top
+    ? `
+      position: absolute;
+      top: 0;
+      `
+    : `
+      position: absolute;
+      bottom: 0;
+      `
 }
 
 export interface ICursorPositionerProps {
@@ -121,56 +139,54 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
         const adjustedX = this.state.adjustedX
         const adjustedY = this.state.shouldOpenDownward ? this.props.y + this.props.lineHeight * 2.5 : this.props.y
 
-        const containerStyle: React.CSSProperties = {
-            position: "absolute",
-            top: adjustedY.toString() + "px",
-            left: "0px",
-            width: this.props.containerWidth.toString() + "px",
-            visibility: this.state.isMeasured ? "visible" : "hidden", // Wait until we've measured the bounds to show..
+        interface OuterProps extends React.Props<HTMLDivElement> {
+            children: React.ReactNode
+            y: number
+            width: number
+            visible: boolean
         }
 
-        const openFromBottomStyle: React.CSSProperties = {
-            position: "absolute",
-            bottom: "0px",
-        }
+        const Outer = withProps<OuterProps, HTMLDivElement>(styled.div)`
+            position: absolute;
+            top: ${props => props.y}px;
+            left: 0px;
+            width: ${props => props.width}px;
+            visibility: ${props => props.visible ? "visible" : "hidden"}; /* For waiting until we've measured the bounds to show. */
+            `
 
-        const openFromTopStyle: React.CSSProperties = {
-            position: "absolute",
-            top: "0px",
-        }
+        const CustomArrow = styled(Arrow)`
+            ${vfix(!this.state.shouldOpenDownward)}
+            left: ${this.props.x + this.props.fontPixelWidth / 2}px;
+            visibility: ${this.props.hideArrow ? "hidden" : "visible"};
+            `
 
-        const childStyle = this.state.shouldOpenDownward ? openFromTopStyle : openFromBottomStyle
-        const arrowStyle = this.state.shouldOpenDownward ? openFromBottomStyle : openFromTopStyle
+        const Inner = styled.div`
+            ${vfix(this.state.shouldOpenDownward)}
+            ${this.state.isMeasured
+              ? `
+                left: ${this.state.isFullWidth ? "8px" : Math.abs(adjustedX) + "px"};
+                right: ${this.state.isFullWidth ? "8px" : ""};
+                max-width: "95%";
+                `
+                : ``}
+            `
 
-        const arrowStyleWithAdjustments = {
-            ...arrowStyle,
-            left: (this.props.x + this.props.fontPixelWidth / 2).toString() + "px",
-            visibility: this.props.hideArrow ? "hidden" : "visible",
-        }
-
-        const childStyleWithAdjustments: React.CSSProperties = this.state.isMeasured ? {
-            ...childStyle,
-            left: this.state.isFullWidth ? "8px" : Math.abs(adjustedX).toString() + "px",
-            right: this.state.isFullWidth ? "8px" : null,
-            maxWidth: "95%",
-        } : childStyle
-
-        return <div style={containerStyle} key={this.props.key}>
-            <div style={childStyleWithAdjustments}>
-                <div ref={(elem) => this._element = elem}>
-                    {this.props.children}
-                </div>
-            </div>
-            <div style={arrowStyleWithAdjustments}>
-                <Arrow
-                    direction={this.state.shouldOpenDownward
-                        ? ArrowDirection.Up
-                        : ArrowDirection.Down}
-                    size={5}
-                    color={this.props.beakColor}
-                />
-            </div>
-        </div>
+        return <Outer
+                key={this.props.key}
+                y={adjustedY}
+                width={this.props.containerWidth}
+                visible={this.state.isMeasured}>
+            <Inner innerRef={(elem: HTMLElement) => this._element = elem}>
+                {this.props.children}
+            </Inner>
+            <CustomArrow
+                direction={this.state.shouldOpenDownward
+                  ? ArrowDirection.Up
+                  : ArrowDirection.Down}
+                size={5}
+                color={this.props.beakColor}
+            />
+        </Outer>
     }
 
     private _measureElement(element: HTMLElement): void {
@@ -198,9 +214,9 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
             let adjustedX = this.props.x
 
             if (!isFullWidth && rightBounds > this.props.containerWidth) {
-                    const offset = rightBounds - this.props.containerWidth + 8
-                    adjustedX = this.props.x - offset
-                }
+                const offset = rightBounds - this.props.containerWidth + 8
+                adjustedX = this.props.x - offset
+            }
 
             this.setState({
                     isFullWidth,

--- a/browser/src/UI/components/Definition.tsx
+++ b/browser/src/UI/components/Definition.tsx
@@ -7,9 +7,9 @@
 import * as React from "react"
 import * as types from "vscode-languageserver-types"
 
-import { BufferToScreen, ScreenToPixel } from "./../Coordinates"
+import styled, { keyframes } from "styled-components"
 
-require("./Definition.less") // tslint:disable-line no-var-requires
+import { BufferToScreen, ScreenToPixel } from "./../Coordinates"
 
 export interface IDefinitionProps {
     range: types.Range
@@ -22,36 +22,47 @@ export interface IDefinitionProps {
     screenToPixel: ScreenToPixel
 }
 
-export class Definition extends React.PureComponent<IDefinitionProps, {}> {
-    public render(): JSX.Element {
-        if (!this.props.range || !this.props.bufferToScreen) {
-            return null
-        }
+const appear = keyframes`
+    from { opacity: 0; transform: translateY(2px); }
+    to { opacity: 0.4; transform: translateY(0px); }
+    `
 
-        const startScreenPosition = this.props.bufferToScreen(this.props.range.start)
-        const endScreenPosition = this.props.bufferToScreen(this.props.range.end)
-
-        if (!startScreenPosition || !endScreenPosition) {
-            return null
-        }
-
-        // TODO: If a range spans multiple lines, break up into multiple screen ranges
-        if (startScreenPosition.screenY !== endScreenPosition.screenY) {
-            return null
-        }
-
-        const startPixelPosition = this.props.screenToPixel(startScreenPosition)
-        const endPixelPosition = this.props.screenToPixel(endScreenPosition)
-
-        const style: React.CSSProperties = {
-            position: "absolute",
-            top: startPixelPosition.pixelY + "px",
-            left: startPixelPosition.pixelX + "px",
-            height: this.props.fontHeightInPixels + "px",
-            width: (endPixelPosition.pixelX - startPixelPosition.pixelX + this.props.fontWidthInPixels) + "px",
-            borderBottom: "1px solid " + this.props.color,
-        }
-
-        return <div className="definition" style={style} />
+export const Definition = (props: IDefinitionProps) => {
+    if (!props.range || !props.bufferToScreen) {
+        return null
     }
+
+    const startScreenPosition = props.bufferToScreen(props.range.start)
+    const endScreenPosition = props.bufferToScreen(props.range.end)
+
+    if (!startScreenPosition || !endScreenPosition) {
+        return null
+    }
+
+    // TODO: If a range spans multiple lines, break up into multiple screen ranges
+    if (startScreenPosition.screenY !== endScreenPosition.screenY) {
+        return null
+    }
+
+    const startPixelPosition = props.screenToPixel(startScreenPosition)
+    const endPixelPosition = props.screenToPixel(endScreenPosition)
+
+    const Underline = styled.div`
+        position: absolute;
+        top: ${startPixelPosition.pixelY}px;
+        left: ${startPixelPosition.pixelX}px;
+        height: ${props.fontHeightInPixels}px;
+        width: ${endPixelPosition.pixelX - startPixelPosition.pixelX + props.fontWidthInPixels}px;
+        border-bottom: 1px solid ${props.color};
+
+        animation-name: ${appear};
+        animation-duration: 0.25s;
+        animation-delay: 0.25s;
+        animation-fill-mode: forwards;
+        animation-timing-function: ease-in;
+        opacity: 0;
+        `
+
+    return <Underline />
 }
+

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -7,13 +7,14 @@
 import * as React from "react"
 import * as types from "vscode-languageserver-types"
 
+import styled from "styled-components"
+import { bufferScrollBarSize, withProps } from "./common"
+
 import { getColorFromSeverity } from "./../../Services/Errors"
 
 import { Icon } from "./../Icon"
 
 import { BufferToScreen, ScreenToPixel } from "./../Coordinates"
-
-require("./Error.less") // tslint:disable-line no-var-requires
 
 export interface IErrorsProps {
     errors: types.Diagnostic[]
@@ -46,7 +47,7 @@ export class Errors extends React.PureComponent<IErrorsProps, {}> {
 
             const screenY = screenLine
             const pixelPosition = this.props.screenToPixel({screenX: 0, screenY })
-            const isActive = this.props.cursorLine - 1 === e.range.start.line
+            const isActive = this.props.cursorLine === e.range.start.line
             const pixelY = pixelPosition.pixelY - (padding / 2)
 
             return <ErrorMarker isActive={isActive}
@@ -98,22 +99,22 @@ export interface IErrorMarkerProps {
     color: string
 }
 
-export class ErrorMarker extends React.PureComponent<IErrorMarkerProps, {}> {
+export const ErrorMarker = (props: IErrorMarkerProps) => {
 
-    public render(): JSX.Element {
+    const Wrapper = styled.div`
+        position: absolute;
+        top: ${props.y}px;
+        right: ${bufferScrollBarSize};
+        opacity: 0.5;
+        display: flex;
+        justify-content: flex-end;
+        background-color: rgb(80, 80, 80);
+        ${props.isActive ? `opacity: 0.8;` : ``}
+        `
 
-        const iconPositionStyles = {
-            top: this.props.y.toString() + "px",
-        }
-
-        const errorIcon = <div style={iconPositionStyles} className="error-marker">
-            <ErrorIcon color={this.props.color} />
-        </div>
-
-        return <div>
-            {errorIcon}
-        </div>
-    }
+    return <Wrapper>
+        <ErrorIcon color={props.color} />
+    </Wrapper>
 }
 
 export interface IErrorIconProps {
@@ -121,9 +122,13 @@ export interface IErrorIconProps {
 }
 
 export const ErrorIcon = (props: IErrorIconProps) => {
-    return <div className="icon-container" style={{ color: props.color }}>
-        <Icon name="exclamation-circle" />
-    </div>
+
+    const StyledIcon = styled(Icon)`
+        color: ${props.color};
+        padding: 6px;
+        `
+
+    return <StyledIcon name="exclamation-circle" />
 }
 
 export interface IErrorSquiggleProps {
@@ -134,19 +139,12 @@ export interface IErrorSquiggleProps {
     color: string,
 }
 
-export class ErrorSquiggle extends React.PureComponent<IErrorSquiggleProps, {}> {
-    public render(): JSX.Element {
+export const ErrorSquiggle = withProps<IErrorSquiggleProps>(styled.div)`
+    position: absolute;
+    top: ${props => props.y}px;
+    left: ${props => props.x}px;
+    height: ${props => props.height}px;
+    width: ${props => props.width}px;
+    border-bottom: 1px curled ${props => props.color};
+    `
 
-        const { x, y, width, height, color } = this.props
-
-        const style = {
-            top: y.toString() + "px",
-            left: x.toString() + "px",
-            height: height.toString() + "px",
-            width: width.toString() + "px",
-            borderBottom: `1px dashed ${color}`,
-        }
-
-        return <div className="error-squiggle" style={style}></div>
-    }
-}

--- a/browser/src/UI/components/common.ts
+++ b/browser/src/UI/components/common.ts
@@ -1,0 +1,25 @@
+
+import * as styledComponents from "styled-components"
+import { ThemedStyledComponentsModule } from "styled-components" // tslint:disable-line no-duplicate-imports
+import { IThemeColors } from "../../Services/Themes/ThemeManager"
+
+export const bufferScrollBarSize = "7px"
+
+const {
+  default: styled,
+  css,
+  injectGlobal,
+  keyframes,
+  ThemeProvider,
+} = styledComponents as ThemedStyledComponentsModule<any> as ThemedStyledComponentsModule<IThemeColors>
+
+export type StyledFunction<T> = styledComponents.ThemedStyledFunction<T, IThemeColors>
+
+export function withProps<T, U extends HTMLElement = HTMLElement>(
+    styledFunction: StyledFunction<React.HTMLProps<U>>,
+): StyledFunction<T & React.HTMLProps<U>> {
+    return styledFunction
+}
+
+export { css, injectGlobal, keyframes, styled, ThemeProvider }
+export default styled

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -7,6 +7,7 @@
 
 import * as React from "react"
 import * as ReactDOM from "react-dom"
+import { connect } from "react-redux"
 
 import { remote } from "electron"
 
@@ -69,12 +70,16 @@ const updateViewport = () => {
     Actions.setViewport(width, height)
 }
 
-export const render = (_state: State.IState): void => {
+const RootContainer = connect((state: State.IState) => ({
+    theme: state.colors,
+}))(RootComponent)
+
+export const render = (state: State.IState): void => {
     const hostElement = document.getElementById("host")
 
     ReactDOM.render(
         <Provider store={store}>
-            <RootComponent windowManager={windowManager}/>
+            <RootContainer windowManager={windowManager}/>
         </Provider>, hostElement)
 }
 

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "oni-types": "0.0.4",
     "redux-batched-subscribe": "^0.1.6",
     "shell-env": "^0.3.0",
+    "styled-components": "^2.3.0",
     "typescript": "2.6.1",
     "vscode-jsonrpc": "3.5.0",
     "vscode-languageserver": "3.5.0",


### PR DESCRIPTION
So there are starting to get a lot of open pull requests, but if possible, I'd like to get this one merged first when ready. Some tests are failing currently because they do not play nice with the `less` imports. This pull request should not change anything for the end-user, only for the developer by using [styled-components](https://www.styled-components.com/), thereby addressing issue #1132.

There are a few minor side-effects, which I think are beneficial:
 
 - [x] Components have now direct access to `state.colors` through `props.theme` thanks to `ThemeProvider`
 - [x] Error markers now become active on the correct line when setting the cursor to that line
