### PR TITLE
Add react dev tools and hook up redux dev tools

### DIFF
--- a/browser/src/Redux/createStore.ts
+++ b/browser/src/Redux/createStore.ts
@@ -17,7 +17,7 @@ import { RequestAnimationFrameNotifyBatcher } from "./RequestAnimationFrameNotif
 
 export const createStore = <TState>(name: string, reducer: Reducer<TState>, defaultState: TState, optionalMiddleware: Middleware[] = []): Store<TState> => {
 
-    const composeEnhancers = typeof window === 'object' &&
+    const composeEnhancers = typeof window === "object" &&
         window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] ? // tslint:disable-line no-string-literal
         window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({}) : compose // tslint:disable-line no-string-literal
 

--- a/browser/src/Redux/createStore.ts
+++ b/browser/src/Redux/createStore.ts
@@ -17,7 +17,9 @@ import { RequestAnimationFrameNotifyBatcher } from "./RequestAnimationFrameNotif
 
 export const createStore = <TState>(name: string, reducer: Reducer<TState>, defaultState: TState, optionalMiddleware: Middleware[] = []): Store<TState> => {
 
-    const composeEnhancers = (global["window"] && window["__REDUX_DEVTOOLS_EXTENSION__COMPOSE__"]) || compose // tslint:disable-line no-string-literal
+    const composeEnhancers = typeof window === 'object' &&
+        window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] ? // tslint:disable-line no-string-literal
+        window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({}) : compose // tslint:disable-line no-string-literal
 
     const loggingMiddleware: Middleware = createLoggingMiddleware(name)
 

--- a/main/src/installDevTools.ts
+++ b/main/src/installDevTools.ts
@@ -5,13 +5,19 @@
  */
 
 import * as Log from "./Log"
-
-try {
-    const electronDevtoolsInstaller = require("electron-devtools-installer") // tslint:disable-line no-var-requires
-
-    electronDevtoolsInstaller.default(electronDevtoolsInstaller.REDUX_DEVTOOLS)
-        .then((name) => Log.info(`Added extension: ${name}`))
-        .catch((err) => Log.info(`An error occurred: ${err}`))
-} catch (ex) {
-    Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
+(async () => {
+    try {
+        // const electronDevtoolsInstaller = require("electron-devtools-installer") // tslint:disable-line no-var-requires
+        const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, installExtension } = require("electron-devtools-installer")
+        try {
+            const reduxExt = await installExtension(REDUX_DEVTOOLS)
+            Log.info(`Added extension: ${reduxExt}`)
+            const reactExt = await installExtension(REACT_DEVELOPER_TOOLS)
+            Log.info(`Added extension: ${reactExt}`)
+        } catch (e) {
+            Log.info(`An error occurred: ${e}`)
+        }
+    } catch (ex) {
+        Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
 }
+})()

--- a/main/src/installDevTools.ts
+++ b/main/src/installDevTools.ts
@@ -5,20 +5,19 @@
  */
 
 import * as Log from "./Log"
-try {
-    // tslint:disable-next-line no-var-requires
-    const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, default: installExtension } = require("electron-devtools-installer")
-    console.log('RREACT_DEVELOPER_TOOLS: ', REACT_DEVELOPER_TOOLS)
+export default async () => {
     try {
-        Promise.all([
-            installExtension(REDUX_DEVTOOLS),
-            installExtension(REACT_DEVELOPER_TOOLS),
-        ]).then((extensions) =>
-            extensions.forEach(ext => Log.info(`Added extension: ${ext}`)),
-        )
-    } catch (e) {
-        Log.info(`An error occurred: ${e}`)
-    }
-} catch (ex) {
-    Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
+        // const electronDevtoolsInstaller = require("electron-devtools-installer") // tslint:disable-line no-var-requires
+        const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, installExtension } = await import("electron-devtools-installer")
+        try {
+            const reduxExt = await installExtension(REDUX_DEVTOOLS)
+            Log.info(`Added extension: ${reduxExt}`)
+            const reactExt = await installExtension(REACT_DEVELOPER_TOOLS)
+            Log.info(`Added extension: ${reactExt}`)
+        } catch (e) {
+            Log.info(`An error occurred: ${e}`)
+        }
+    } catch (ex) {
+        Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
+}
 }

--- a/main/src/installDevTools.ts
+++ b/main/src/installDevTools.ts
@@ -5,19 +5,20 @@
  */
 
 import * as Log from "./Log"
-(async () => {
+try {
+    // tslint:disable-next-line no-var-requires
+    const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, default: installExtension } = require("electron-devtools-installer")
+    console.log('RREACT_DEVELOPER_TOOLS: ', REACT_DEVELOPER_TOOLS)
     try {
-        // const electronDevtoolsInstaller = require("electron-devtools-installer") // tslint:disable-line no-var-requires
-        const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, installExtension } = require("electron-devtools-installer")
-        try {
-            const reduxExt = await installExtension(REDUX_DEVTOOLS)
-            Log.info(`Added extension: ${reduxExt}`)
-            const reactExt = await installExtension(REACT_DEVELOPER_TOOLS)
-            Log.info(`Added extension: ${reactExt}`)
-        } catch (e) {
-            Log.info(`An error occurred: ${e}`)
-        }
-    } catch (ex) {
-        Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
+        Promise.all([
+            installExtension(REDUX_DEVTOOLS),
+            installExtension(REACT_DEVELOPER_TOOLS),
+        ]).then((extensions) =>
+            extensions.forEach(ext => Log.info(`Added extension: ${ext}`)),
+        )
+    } catch (e) {
+        Log.info(`An error occurred: ${e}`)
+    }
+} catch (ex) {
+    Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
 }
-})()

--- a/main/src/installDevTools.ts
+++ b/main/src/installDevTools.ts
@@ -7,8 +7,7 @@
 import * as Log from "./Log"
 export default async () => {
     try {
-        // const electronDevtoolsInstaller = require("electron-devtools-installer") // tslint:disable-line no-var-requires
-        const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, installExtension } = await import("electron-devtools-installer")
+        const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, default: installExtension } = require("electron-devtools-installer")
         try {
             const reduxExt = await installExtension(REDUX_DEVTOOLS)
             Log.info(`Added extension: ${reduxExt}`)
@@ -19,5 +18,5 @@ export default async () => {
         }
     } catch (ex) {
         Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
-}
+    }
 }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -52,7 +52,8 @@ if (!isDevelopment && !isDebug) {
     // initialization and is ready to create browser windows.
     // Some APIs can only be used after this event occurs.
     app.on("ready", async () => {
-        await import("./installDevTools")
+        const devExtensions = require("./installDevTools")
+        await devExtensions()
         loadFileFromArguments(process.platform, process.argv, process.cwd())
     })
 }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -51,8 +51,8 @@ if (!isDevelopment && !isDebug) {
     // This method will be called when Electron has finished
     // initialization and is ready to create browser windows.
     // Some APIs can only be used after this event occurs.
-    app.on("ready", () => {
-        require("./installDevTools")
+    app.on("ready", async () => {
+        await import("./installDevTools")
         loadFileFromArguments(process.platform, process.argv, process.cwd())
     })
 }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -4,6 +4,7 @@ import { app, BrowserWindow, ipcMain, Menu, webContents } from "electron"
 
 import * as Log from "./Log"
 import { buildDockMenu, buildMenu } from "./menu"
+import addDevExtensions from "./installDevTools"
 import { makeSingleInstance } from "./ProcessLifecycle"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
@@ -52,8 +53,7 @@ if (!isDevelopment && !isDebug) {
     // initialization and is ready to create browser windows.
     // Some APIs can only be used after this event occurs.
     app.on("ready", async () => {
-        const devExtensions = require("./installDevTools")
-        await devExtensions()
+        await addDevExtensions()
         loadFileFromArguments(process.platform, process.argv, process.cwd())
     })
 }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -2,9 +2,9 @@ import * as path from "path"
 
 import { app, BrowserWindow, ipcMain, Menu, webContents } from "electron"
 
+import addDevExtensions from "./installDevTools"
 import * as Log from "./Log"
 import { buildDockMenu, buildMenu } from "./menu"
-import addDevExtensions from "./installDevTools"
 import { makeSingleInstance } from "./ProcessLifecycle"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "css-loader": "0.28.4",
     "electron": "1.8.1",
     "electron-builder": "19.46.4",
-    "electron-devtools-installer": "2.2.0",
+    "electron-devtools-installer": "2.2.1",
     "electron-mocha": "5.0.0",
     "electron-rebuild": "1.6.0",
     "extract-zip": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,9 +1972,9 @@ electron-chromedriver@~1.6.0:
     electron-download "^3.1.0"
     extract-zip "^1.6.0"
 
-electron-devtools-installer@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz#9813e6811afcd69ddca3cae5416db72ea7ecfb6a"
+electron-devtools-installer@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.1.tgz#0beb73ccbf65cbc4d09e706cebda638f839b8c55"
   dependencies:
     "7zip" "0.0.6"
     cross-unzip "0.0.2"


### PR DESCRIPTION
As per conversation on gitter I've added the react dev tools and tweaked the redux dev tools to pick up the store.

An issue I ran into relates to [permissions](https://github.com/MarshallOfSound/electron-devtools-installer/issues/63) whilst using `electron-devtools-installer`, It was reported as closed in another issue but I found that the issue continued to persist for me so I followed the advice in the link. Essentially the react devtools extension *on my mac* possibly on other platforms required me to `chmod 777` the path of the extension, I don't know how much of an issue this maybe for others if it is then it might be worth looking into the standalone app, like [`react-devtools`](https://github.com/facebook/react-devtools/blob/master/packages/react-devtools/README.md) or simply add the advice re chmod to the dev wiki whilst electron-installer work on the issue hopefully