### PR TITLE
Fix #1149 - Handle  shift+space key

### DIFF
--- a/browser/src/Input/Keyboard/Resolvers.ts
+++ b/browser/src/Input/Keyboard/Resolvers.ts
@@ -101,6 +101,10 @@ const isShiftCharacter = (keyMap: IKeyMap, evt: KeyboardEvent): boolean => {
         return false
     }
 
+    if (code === "Space") {
+        return false
+    }
+
     if (mappedKey.withShift === key || mappedKey.withAltGraphShift === key) {
         return true
     } else {

--- a/browser/test/Input/Keyboard/ResolverTests.ts
+++ b/browser/test/Input/Keyboard/ResolverTests.ts
@@ -31,10 +31,10 @@ describe("Resolvers", () => {
                     "Space": {
                         unmodified: " ",
                         withShift: " ",
-                    }
+                    },
                 }
 
-                const metaResolver = createMetaKeyResolver(layout)
+                metaResolver = createMetaKeyResolver(layout)
 
                 const key = shift(createKeyEvent(" ", "Space"))
                 const result = metaResolver(key, key.key)

--- a/browser/test/Input/Keyboard/ResolverTests.ts
+++ b/browser/test/Input/Keyboard/ResolverTests.ts
@@ -25,6 +25,23 @@ describe("Resolvers", () => {
     describe("metaResolver", () => {
         let metaResolver: KeyResolver
 
+        describe("*", () => {
+            it("Handles <s- > (shift+space)", () => {
+                const layout = {
+                    "Space": {
+                        unmodified: " ",
+                        withShift: " ",
+                    }
+                }
+
+                const metaResolver = createMetaKeyResolver(layout)
+
+                const key = shift(createKeyEvent(" ", "Space"))
+                const result = metaResolver(key, key.key)
+                assert.equal(result, "<s- >")
+            })
+        })
+
         describe("english", () => {
             beforeEach(() => {
                 metaResolver = createMetaKeyResolver(englishLayout)


### PR DESCRIPTION
__Issue:__ The `shift+space` key is being sent to neovim as ` `, not `<s-space>` as would be expected.

__Defect__: The keyboard layout/mapping we leverage shows ` ` as being the result character from shift+space key, and in that case we ignore the `shift` and just send a space to neovim. This works fine for alphabetical characters - for example, if we see a `P` which is `shift+p`, we know to ignore the shift key, and just send `P` - but that doesn't make sense in the case of space.

__Fix__: Special case the ' ' key here.