### PR TITLE
Pass in name parameter to redux devtools

### DIFF
--- a/browser/src/Redux/createStore.ts
+++ b/browser/src/Redux/createStore.ts
@@ -19,7 +19,7 @@ export const createStore = <TState>(name: string, reducer: Reducer<TState>, defa
 
     const composeEnhancers = typeof window === "object" &&
         window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] ? // tslint:disable-line no-string-literal
-        window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({}) : compose // tslint:disable-line no-string-literal
+        window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({ name }) : compose // tslint:disable-line no-string-literal
 
     const loggingMiddleware: Middleware = createLoggingMiddleware(name)
 


### PR DESCRIPTION
Thanks to @Akin909 , we now have the redux-devtools integrated! 💯 

We have multiple state stores, and the default name makes it hard to differentiate them - this just passes in the `name` parameter so that we can see them in the dropdown:
![image](https://user-images.githubusercontent.com/13532591/34137555-77d56a78-e420-11e7-94a8-175221e00e19.png)
