### PR TITLE
Wire up Autoread.

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -306,6 +306,10 @@ export class NeovimEditor extends Editor implements IEditor {
 
         browserWindow.on("focus", () => {
             this._neovimInstance.autoCommands.executeAutoCommand("FocusGained")
+
+            if (_configuration.getValue("vim.setting.autoread")) {
+                this._neovimInstance.command(":checktime")
+            }
         })
 
         this._onConfigChanged(this._configuration.getValues())

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -307,6 +307,9 @@ export class NeovimEditor extends Editor implements IEditor {
         browserWindow.on("focus", () => {
             this._neovimInstance.autoCommands.executeAutoCommand("FocusGained")
 
+            // If the user has autoread enabled, we should run ":checktime" on
+            // focus, as this is needed to get the file to auto-update.
+            // https://github.com/neovim/neovim/issues/1936
             if (_configuration.getValue("vim.setting.autoread")) {
                 this._neovimInstance.command(":checktime")
             }


### PR DESCRIPTION
Following on from discussion in #1081, this allows Oni to call the check time command when the user is using `autoread`.