### PR TITLE
Change the initial window width/height from 600x800 to 800x600

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -28,8 +28,8 @@ let windowState: IWindowState = {
     bounds: {
         x: null,
         y: null,
-        height: 800,
-        width: 600,
+        height: 600,
+        width: 800,
     },
     isMaximized: false,
 }


### PR DESCRIPTION
One thing I didn't notice about #1160 is that it flipped the 'starting state' dimensions of the window - previously, the window was 800 pixels wide by 600 pixels high. However, these were reversed to 600 pixels wide by 800 pixels high. It might just be me since I was used to the 800x600, but the 600x800 looked a bit awkward 😄 This change resets the default back to 800x600.