### PR TITLE
Fix regression in opening files from command line

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -467,6 +467,7 @@ export class NeovimEditor extends Editor implements IEditor {
     }
 
     public async init(filesToOpen: string[]): Promise<void> {
+        Log.info("[NeovimEditor::init] Called with filesToOpen: " + filesToOpen)
         const startOptions: INeovimStartOptions = {
             runtimePaths: pluginManager.getAllRuntimePaths(),
             transport: this._configuration.getValue("experimental.neovim.transport"),

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -80,7 +80,7 @@ if (!isDevelopment && !isDebug) {
     let processArgs = process.argv || []
 
     // If running from spectron, ignore the arguments
-    if (processArgs.filter((f) => f.indexOf("--test-type=webdriver"))) {
+    if (processArgs.find((f) => f.indexOf("--test-type=webdriver") >= 0)) {
         Log.warn("Clearing arguments because running from automation!")
         processArgs = []
     }


### PR DESCRIPTION
__Issue:__ Passing a file as an argument to Oni isn't working. This also breaks Windows shell extensions, since they rely on passing the file as an argument.

__Defect:__ This is a regression from one of the automation stability fixes. The automation passes a bunch of arguments to Oni, and this can cause some timing issues (it will attempt to load additional files, whereas the test case may not expect it). We added a filter so that, if the arguments are from automation, we ignore it - but the filter's logic wasn't correct.

__Fix:__ Correct the logic for filtering automation arguments.