### PR TITLE
Refactoring - Status Bar: Explicit dependencies / initialization

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -24,7 +24,7 @@ import { inputManager } from "./../../Services/InputManager"
 import * as LanguageManager from "./../../Services/Language"
 import { menuManager } from "./../../Services/Menu"
 import { recorder } from "./../../Services/Recorder"
-import { statusBar } from "./../../Services/StatusBar"
+import { getInstance as getStatusBarInstance } from "./../../Services/StatusBar"
 import { windowManager } from "./../../Services/WindowManager"
 import { workspace } from "./../../Services/Workspace"
 
@@ -110,7 +110,7 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
     }
 
     public get statusBar(): OniApi.StatusBar {
-        return statusBar
+        return getStatusBarInstance()
     }
 
     public get ui(): Ui {

--- a/browser/src/Services/Language/LanguageClientStatusBar.tsx
+++ b/browser/src/Services/Language/LanguageClientStatusBar.tsx
@@ -17,7 +17,7 @@ export class LanguageClientStatusBar {
     private _fileType: string
 
     constructor(
-        private _statusBar: Oni.StatusBar
+        private _statusBar: Oni.StatusBar,
     ) {
         this._item = this._statusBar.createItem(0, 0, "oni.status.fileType2")
     }

--- a/browser/src/Services/Language/LanguageClientStatusBar.tsx
+++ b/browser/src/Services/Language/LanguageClientStatusBar.tsx
@@ -11,15 +11,15 @@ import * as Oni from "oni-api"
 
 import { Icon } from "./../../UI/Icon"
 
-import { statusBar } from "./../StatusBar"
-
 export class LanguageClientStatusBar {
 
     private _item: Oni.StatusBarItem
     private _fileType: string
 
-    constructor() {
-        this._item = statusBar.createItem(0, 0, "oni.status.fileType2")
+    constructor(
+        private _statusBar: Oni.StatusBar
+    ) {
+        this._item = this._statusBar.createItem(0, 0, "oni.status.fileType2")
     }
 
     public show(fileType: string): void {

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -36,13 +36,17 @@ export class LanguageManager {
     private _languageServerInfo: { [language: string]: ILanguageClient } = {}
     private _notificationSubscriptions: { [notificationMessage: string]: Event<any> } = {}
     private _requestHandlers: { [request: string]: LanguageClientTypes.RequestHandler } = {}
-    private _statusBar = new LanguageClientStatusBar()
+    private _languageClientStatusBar: LanguageClientStatusBar
     private _currentTrackedFile: string = null
 
     constructor(
         private _configuration: Oni.Configuration,
         private _editorManager: Oni.EditorManager,
+        private _statusBar: Oni.StatusBar,
     ) {
+
+        this._languageClientStatusBar = new LanguageClientStatusBar(this._statusBar)
+
         this._editorManager.allEditors.onBufferEnter.subscribe(async () => this._onBufferEnter())
 
         this._editorManager.allEditors.onBufferLeave.subscribe((bufferInfo: Oni.EditorBufferEventArgs) => {
@@ -274,17 +278,17 @@ export class LanguageManager {
         const { language, filePath } = buffer
 
         if (language) {
-            this._statusBar.show(language)
+            this._languageClientStatusBar.show(language)
 
             if (this._hasLanguageClient(language)) {
-                this._statusBar.setStatus(LanguageClientState.Initializing)
+                this._languageClientStatusBar.setStatus(LanguageClientState.Initializing)
             } else {
-                this._statusBar.setStatus(LanguageClientState.NotAvailable)
+                this._languageClientStatusBar.setStatus(LanguageClientState.NotAvailable)
             }
         }
 
         if (buffer.lineCount > this._configuration.getValue("editor.maxLinesForLanguageServices")) {
-            this._statusBar.setStatus(LanguageClientState.NotAvailable)
+            this._languageClientStatusBar.setStatus(LanguageClientState.NotAvailable)
             Log.info("[LanguageManager] Not sending 'didOpen' because file line count exceeds limit.")
             return
         }
@@ -294,7 +298,7 @@ export class LanguageManager {
             const lines = await this._editorManager.activeEditor.activeBuffer.getLines()
             const text = lines.join(os.EOL)
             const version = this._editorManager.activeEditor.activeBuffer.version
-            this._statusBar.setStatus(LanguageClientState.Active)
+            this._languageClientStatusBar.setStatus(LanguageClientState.Active)
             return Helpers.pathToTextDocumentItemParams(filePath, language, text, version)
         })
     }
@@ -320,7 +324,7 @@ export class LanguageManager {
         switch (protocolMessage) {
             case "textDocument/didOpen":
             case "textDocument/didChange":
-                this._statusBar.setStatus(status)
+                this._languageClientStatusBar.setStatus(status)
                 break
             default:
                 break
@@ -351,8 +355,8 @@ const logDebug = (args: any) => {
 
 let _languageManager: LanguageManager = null
 
-export const activate = (configuration: Oni.Configuration, editorManager: Oni.EditorManager): void => {
-    _languageManager = new LanguageManager(configuration, editorManager)
+export const activate = (configuration: Oni.Configuration, editorManager: Oni.EditorManager, statusBar: Oni.StatusBar): void => {
+    _languageManager = new LanguageManager(configuration, editorManager, statusBar)
 }
 
 export const getInstance = (): LanguageManager => {

--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -21,12 +21,6 @@ export enum StatusBarAlignment {
     Right,
 }
 
-export interface IStatusBarItem {
-    show(): void
-    hide(): void
-    setContents(element: any): void
-}
-
 export class StatusBarItem implements Oni.StatusBarItem {
     private _contents: JSX.Element
     private _visible: boolean = false
@@ -77,7 +71,7 @@ class StatusBar implements Oni.StatusBar {
     private _id: number = 0
 
     constructor(
-        private _configuration: Configuration
+        private _configuration: Configuration,
     ) { }
 
     public getItem(globalId: string): Oni.StatusBarItem {

--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -12,6 +12,8 @@ import "rxjs/add/operator/debounceTime"
 
 import * as Oni from "oni-api"
 
+import { Configuration } from "./Configuration"
+
 import * as Shell from "./../UI/Shell"
 
 export enum StatusBarAlignment {
@@ -74,6 +76,10 @@ export class StatusBarItem implements Oni.StatusBarItem {
 class StatusBar implements Oni.StatusBar {
     private _id: number = 0
 
+    constructor(
+        private _configuration: Configuration
+    ) { }
+
     public getItem(globalId: string): Oni.StatusBarItem {
         return new StatusBarItem(globalId)
     }
@@ -82,8 +88,18 @@ class StatusBar implements Oni.StatusBar {
         this._id++
         const statusBarId = globalId || `${this._id.toString()}`
 
+        // TODO: Use priority
+        this._configuration.getValue("statusbar.priority")
+
         return new StatusBarItem(statusBarId, alignment, priority)
     }
 }
 
-export const statusBar = new StatusBar()
+let _statusBar: StatusBar = null
+export const activate = (configuration: Configuration): void => {
+    _statusBar = new StatusBar(configuration)
+}
+
+export const getInstance = (): StatusBar => {
+    return _statusBar
+}

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -25,6 +25,7 @@ const start = async (args: string[]): Promise<void> => {
     const themesPromise = import("./Services/Themes")
     const iconThemesPromise = import("./Services/IconThemes")
 
+    const statusBarPromise = import("./Services/StatusBar")
     const startEditorsPromise = import("./startEditors")
 
     const sharedNeovimInstancePromise = import("./neovim/SharedNeovimInstance")
@@ -86,8 +87,12 @@ const start = async (args: string[]): Promise<void> => {
 
     const { editorManager } = await editorManagerPromise
 
+    const StatusBar = await statusBarPromise
+    StatusBar.activate(configuration)
+    const statusBar = StatusBar.getInstance()
+
     const LanguageManager = await languageManagerPromise
-    LanguageManager.activate(configuration, editorManager)
+    LanguageManager.activate(configuration, editorManager, statusBar)
     const languageManager = LanguageManager.getInstance()
 
     Performance.startMeasure("Oni.Start.Editors")

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -28,6 +28,16 @@ export class MockConfiguration {
     }
 }
 
+export class MockStatusBar implements Oni.StatusBar {
+    public getItem(globalId: string): Oni.StatusBarItem {
+        return null
+    }
+
+    public createItem(alignment: number, priority: number, globalId: string): Oni.StatusBarItem {
+        return null
+    }
+}
+
 export class MockEditor extends Editor {
 
     private _activeBuffer: MockBuffer = null

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -28,13 +28,32 @@ export class MockConfiguration {
     }
 }
 
+export class MockStatusBarItem implements Oni.StatusBarItem {
+
+    public show(): void {
+        // tslint:disable-line
+    }
+
+    public hide(): void {
+        // tslint:disable-line
+    }
+
+    public setContents(element: JSX.Element): void {
+        // tslint:disable-line
+    }
+
+    public dispose(): void {
+        // tslint:disable-line
+    }
+}
+
 export class MockStatusBar implements Oni.StatusBar {
     public getItem(globalId: string): Oni.StatusBarItem {
-        return null
+        return new MockStatusBarItem()
     }
 
     public createItem(alignment: number, priority: number, globalId: string): Oni.StatusBarItem {
-        return null
+        return new MockStatusBarItem()
     }
 }
 

--- a/browser/test/Services/Language/LanguageManagerTests.ts
+++ b/browser/test/Services/Language/LanguageManagerTests.ts
@@ -59,7 +59,9 @@ describe("LanguageManager", () => {
         mockEditor = new Mocks.MockEditor()
         editorManager.setActiveEditor(mockEditor)
 
-        languageManager = new Language.LanguageManager(mockConfiguration as any, editorManager)
+        const mockStatusBar = new Mocks.MockStatusBar()
+
+        languageManager = new Language.LanguageManager(mockConfiguration as any, editorManager, mockStatusBar)
     })
 
     it("sends didOpen request if language server is registered after enter event", async () => {


### PR DESCRIPTION
This refactors the statusbar to make the initialization timing and dependency injection explicit. A `StatusBar` now gets initialized as part of our startup flow in `browser/src/index.tsx`, and then we use that instance for the Oni API object as well as for the language client (so that it can create the language client status bar).

This also hooks in the `configuration` object, but it's not used yet - just to make it easy to bring in for #1114 