### PR TITLE
Adding key property to tooltip

### DIFF
--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -17,10 +17,11 @@ export interface IToolTipsViewProps {
 }
 
 export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
-
     public render(): JSX.Element {
         const toolTipElements = this.props.toolTips.map((toolTip) => {
-            return <ToolTipView {...toolTip} borderColor={this.props.borderColor} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor}/>
+            const key = toolTip.options.position.pixelX + toolTip.options.position.pixelY
+
+            return <ToolTipView key={key} {...toolTip} borderColor={this.props.borderColor} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor}/>
         })
 
         const style: React.CSSProperties = {

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -19,7 +19,7 @@ export interface IToolTipsViewProps {
 export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
     public render(): JSX.Element {
         const toolTipElements = this.props.toolTips.map((toolTip) => {
-            const key = toolTip.options.position.pixelX + toolTip.options.position.pixelY
+            const key = `X:${toolTip.options.position.pixelX},Y:${toolTip.options.position.pixelY}`
 
             return <ToolTipView key={key} {...toolTip} borderColor={this.props.borderColor} foregroundColor={this.props.foregroundColor} backgroundColor={this.props.backgroundColor}/>
         })


### PR DESCRIPTION
This fixes a error/warning from React that 'key' is required