### PR TITLE
Feature/add focus gained and focus lost hooks

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -35,8 +35,19 @@ import { Completion } from "./../../Services/Completion"
 import { Configuration, IConfigurationValues } from "./../../Services/Configuration"
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 import { Errors } from "./../../Services/Errors"
-import { addInsertModeLanguageFunctionality, LanguageEditorIntegration, LanguageManager } from "./../../Services/Language"
-import { ISyntaxHighlighter, NullSyntaxHighlighter, SyntaxHighlighter } from "./../../Services/SyntaxHighlighting"
+
+import {
+    addInsertModeLanguageFunctionality,
+    LanguageEditorIntegration,
+    LanguageManager,
+} from "./../../Services/Language"
+
+import {
+    ISyntaxHighlighter,
+    NullSyntaxHighlighter,
+    SyntaxHighlighter,
+} from "./../../Services/SyntaxHighlighting"
+
 import { tasks } from "./../../Services/Tasks"
 import { ThemeManager } from "./../../Services/Themes"
 import { TypingPredictionManager } from "./../../Services/TypingPredictionManager"
@@ -167,7 +178,14 @@ export class NeovimEditor extends Editor implements IEditor {
 
         registerBuiltInCommands(commandManager, this._neovimInstance)
 
-        this._commands = new NeovimEditorCommands(commandManager, this._contextMenuManager, this._definition, this._languageIntegration, this._rename, this._symbols)
+        this._commands = new NeovimEditorCommands(
+            commandManager,
+            this._contextMenuManager,
+            this._definition,
+            this._languageIntegration,
+            this._rename,
+            this._symbols,
+        )
 
         const updateViewport = () => {
             const width = document.body.offsetWidth
@@ -224,7 +242,10 @@ export class NeovimEditor extends Editor implements IEditor {
 
             const inactiveIds = tabPageState.inactiveWindows.map((w) => w.windowNumber)
 
-            this._actions.setActiveVimTabPage(tabPageState.tabId, [tabPageState.activeWindow.windowNumber, ...inactiveIds])
+            this._actions.setActiveVimTabPage(
+                tabPageState.tabId,
+                [tabPageState.activeWindow.windowNumber, ...inactiveIds],
+            )
 
             const { activeWindow } = tabPageState
             this._actions.setWindowState(activeWindow.windowNumber,
@@ -339,7 +360,11 @@ export class NeovimEditor extends Editor implements IEditor {
             }
 
             this.notifyBufferChanged(bufferUpdate)
-            this._actions.bufferUpdate(parseInt(bufferUpdate.buffer.id, 10), bufferUpdate.buffer.modified, bufferUpdate.buffer.lineCount)
+            this._actions.bufferUpdate(
+                parseInt(bufferUpdate.buffer.id, 10),
+                bufferUpdate.buffer.modified,
+                bufferUpdate.buffer.lineCount,
+            )
 
             this._syntaxHighlighter.notifyBufferUpdate(bufferUpdate)
         })

--- a/browser/src/Services/Workspace.ts
+++ b/browser/src/Services/Workspace.ts
@@ -24,17 +24,19 @@ import { convertTextDocumentEditsToFileMap } from "./Language/Edits"
 
 export class Workspace implements Oni.Workspace {
     private _onDirectoryChangedEvent = new Event<string>()
-    private _onFocusGainedEvent = new Event<void>()
-    private _onFocusLostEvent = new Event<void>()
+    private _onFocusGainedEvent = new Event<Oni.Buffer>()
+    private _onFocusLostEvent = new Event<Oni.Buffer>()
     private _mainWindow = remote.getCurrentWindow()
+    private _lastActiveBuffer: Oni.Buffer
 
     constructor() {
         this._mainWindow.on("focus", () => {
-            this._onFocusGainedEvent.dispatch()
+            this._onFocusGainedEvent.dispatch(this._lastActiveBuffer)
         })
 
-        this._mainWindow.on("blur", (e: any) => {
-            this._onFocusLostEvent.dispatch()
+        this._mainWindow.on("blur", () => {
+            this._lastActiveBuffer = editorManager.activeEditor.activeBuffer
+            this._onFocusLostEvent.dispatch(this._lastActiveBuffer)
         })
     }
 

--- a/browser/src/Services/Workspace.ts
+++ b/browser/src/Services/Workspace.ts
@@ -5,13 +5,13 @@
  *  - The current / active directory (and 'Open Folder')
  */
 
+import { remote } from "electron"
 import "rxjs/add/observable/defer"
 import "rxjs/add/observable/from"
 import "rxjs/add/operator/concatMap"
 import "rxjs/add/operator/toPromise"
 import { Observable } from "rxjs/Observable"
 import * as types from "vscode-languageserver-types"
-import { remote } from "electron"
 
 import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"

--- a/browser/src/Services/Workspace.ts
+++ b/browser/src/Services/Workspace.ts
@@ -83,11 +83,11 @@ export class Workspace implements Oni.Workspace {
         // Hide modal
     }
 
-    public get onFocusGained(): IEvent<any> {
+    public get onFocusGained(): IEvent<Oni.Buffer> {
         return this._onFocusGainedEvent
     }
 
-    public get onFocusLost(): IEvent<any> {
+    public get onFocusLost(): IEvent<Oni.Buffer> {
         return this._onFocusLostEvent
     }
 }

--- a/browser/src/Services/Workspace.ts
+++ b/browser/src/Services/Workspace.ts
@@ -11,6 +11,7 @@ import "rxjs/add/operator/concatMap"
 import "rxjs/add/operator/toPromise"
 import { Observable } from "rxjs/Observable"
 import * as types from "vscode-languageserver-types"
+import { remote } from "electron"
 
 import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
@@ -23,6 +24,19 @@ import { convertTextDocumentEditsToFileMap } from "./Language/Edits"
 
 export class Workspace implements Oni.Workspace {
     private _onDirectoryChangedEvent = new Event<string>()
+    private _onFocusGainedEvent = new Event<void>()
+    private _onFocusLostEvent = new Event<void>()
+    private _mainWindow = remote.getCurrentWindow()
+
+    constructor() {
+        this._mainWindow.on("focus", () => {
+            this._onFocusGainedEvent.dispatch()
+        })
+
+        this._mainWindow.on("blur", (e: any) => {
+            this._onFocusLostEvent.dispatch()
+        })
+    }
 
     public get onDirectoryChanged(): IEvent<string> {
         return this._onDirectoryChangedEvent
@@ -65,6 +79,14 @@ export class Workspace implements Oni.Workspace {
         Log.verbose("[Workspace] Completed applying edits")
 
         // Hide modal
+    }
+
+    public get onFocusGained(): IEvent<any> {
+        return this._onFocusGainedEvent
+    }
+
+    public get onFocusLost(): IEvent<any> {
+        return this._onFocusLostEvent
     }
 }
 

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -8,7 +8,6 @@ import addDevExtensions from "./installDevTools"
 import * as Log from "./Log"
 import { buildDockMenu, buildMenu } from "./menu"
 import { makeSingleInstance } from "./ProcessLifecycle"
-import { workspace } from "./../../browser/src/Services/Workspace"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
 

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -8,6 +8,7 @@ import addDevExtensions from "./installDevTools"
 import * as Log from "./Log"
 import { buildDockMenu, buildMenu } from "./menu"
 import { makeSingleInstance } from "./ProcessLifecycle"
+import { workspace } from "./../../browser/src/Services/Workspace"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
 

--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -67,18 +67,17 @@ const activate = Oni => {
       }
     };
 
-    if(!isLoaded) {
+    if (!isLoaded) {
       updateBranchIndicator(Oni.editors.activeEditor.activeBuffer);
     }
 
     Oni.editors.activeEditor.onBufferEnter.subscribe(
       async evt => await updateBranchIndicator(evt)
     );
-    const buf = Oni.editors.activeEditor.activeBuffer
-    Oni.editors.workspace.onFocusGained.subscribe(async () => {
-      console.log('Regained Focus');
-      return await updateBranchIndicator(buf);
-    });
+    Oni.workspace.onFocusGained.subscribe(
+      async buffer => await updateBranchIndicator(buffer)
+    );
+
   } catch (e) {
     console.warn('[Oni.plugin.git] ERROR', e);
   }

--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -74,6 +74,11 @@ const activate = Oni => {
     Oni.editors.activeEditor.onBufferEnter.subscribe(
       async evt => await updateBranchIndicator(evt)
     );
+    const buf = Oni.editors.activeEditor.activeBuffer
+    Oni.editors.workspace.onFocusGained.subscribe(async () => {
+      console.log('Regained Focus');
+      return await updateBranchIndicator(buf);
+    });
   } catch (e) {
     console.warn('[Oni.plugin.git] ERROR', e);
   }


### PR DESCRIPTION
This PR adds a `focusGained` and `focusLost` hooks to oni. The events themselves pass in the lastActiveBuffer on focusLost and on focusGained. 

Also subscribed the Oni git plugin to this event so in the case of changing git branch etc outside oni the plugin is correctly updated on returning to oni.

Fixes #1109 