### PR TITLE
bugfix/render-italics-and-bold-text

### DIFF
--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -7,6 +7,7 @@ export interface IFontMeasurement {
 
 export function measureFont(fontFamily: string, fontSize: string, characterToTest = "H") {
     const div = document.createElement("div")
+
     div.style.position = "absolute"
     div.style.left = "10px"
     div.style.top = "10px"
@@ -27,8 +28,7 @@ export function measureFont(fontFamily: string, fontSize: string, characterToTes
     const height = rect.height
 
     document.body.removeChild(div)
-    console.log("isItalicAvailable: ",  isItalicAvailable) // tslint:disable-line
-    console.log("isBoldAvailable: ",  isBoldAvailable) // tslint:disable-line
+
     return {
         width,
         height,
@@ -38,20 +38,14 @@ export function measureFont(fontFamily: string, fontSize: string, characterToTes
 }
 
 export function addDefaultUnitIfNeeded(fontSize: string) {
-
-    const defaultUnit = "px"
-
-    if (isNaN(Number(fontSize))) {
-        return fontSize
-    } else {
-        return fontSize + defaultUnit
-    }
+    const roundFont = `${Math.round(parseFloat(fontSize))}px`
+    return roundFont
 }
 
 export function isStyleAvailable(fontName: string, style: string, fontSize = "12px") {
+    const text = "abcdefghijklmnopqrstuvwxyz0123456789"
     let canvas = document.createElement("canvas")
     const context = canvas.getContext("2d")
-    const text = "abcdefghijklmnopqrstuvwxyz0123456789"
     context.font = `${fontSize} ${fontName}`
     const baselineSize = context.measureText(text).width
     context.font = `${style} ${fontSize} ${fontName}`

--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -5,33 +5,35 @@ export interface IFontMeasurement {
     height: number
 }
 
-export function measureFont(fontFamily: string, fontSize: string, characterToTest?: string) {
-    characterToTest = characterToTest || "H"
+export function measureFont(fontFamily: string, fontSize: string, characterToTest = "H") {
     const div = document.createElement("div")
-
     div.style.position = "absolute"
     div.style.left = "10px"
     div.style.top = "10px"
     div.style.backgroundColor = "red"
     div.style.left = "-1000px"
     div.style.top = "-1000px"
-
     div.textContent = characterToTest
     div.style.fontFamily = `${fontFamily},${FallbackFonts}`
     div.style.fontSize = fontSize
 
+    const isItalicAvailable = isStyleAvailable(fontFamily, "italic", fontSize)
+    const isBoldAvailable = isStyleAvailable(fontFamily, "bold", fontSize)
+
     document.body.appendChild(div)
 
     const rect = div.getBoundingClientRect()
-
     const width = rect.width
     const height = rect.height
 
     document.body.removeChild(div)
-
+    console.log("isItalicAvailable: ",  isItalicAvailable) // tslint:disable-line
+    console.log("isBoldAvailable: ",  isBoldAvailable) // tslint:disable-line
     return {
         width,
         height,
+        isItalicAvailable,
+        isBoldAvailable,
     }
 }
 
@@ -44,4 +46,16 @@ export function addDefaultUnitIfNeeded(fontSize: string) {
     } else {
         return fontSize + defaultUnit
     }
+}
+
+export function isStyleAvailable(fontName: string, style: string, fontSize = "12px") {
+    let canvas = document.createElement("canvas")
+    const context = canvas.getContext("2d")
+    const text = "abcdefghijklmnopqrstuvwxyz0123456789"
+    context.font = `${fontSize} ${fontName}`
+    const baselineSize = context.measureText(text).width
+    context.font = `${style} ${fontSize} ${fontName}`
+    const newSize = context.measureText(text).width
+    canvas = null
+    return newSize === baselineSize
 }

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -289,13 +289,11 @@ export class CanvasRenderer implements INeovimRenderer {
         if (!state.isWhitespace) {
             const lastFontStyle = this._canvasContext.font
             this._canvasContext.fillStyle = foregroundColor
-            if (bold || italic) {
-                if (bold) {
-                    this._canvasContext.font = `bold ${this._canvasContext.font}`
-                }
-                if (italic) {
-                    this._canvasContext.font = `italic ${this._canvasContext.font}`
-                }
+            if (bold) {
+                this._canvasContext.font = `bold ${this._canvasContext.font}`
+            }
+            if (italic) {
+                this._canvasContext.font = `italic ${this._canvasContext.font}`
             }
             this._canvasContext.fillText(text, boundsStartX, y * fontHeightInPixels + linePaddingInPixels / 2)
             this._canvasContext.font = lastFontStyle

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -12,6 +12,9 @@ export interface IRenderState {
     backgroundColor: string
     text: string
     startX: number
+    bold: boolean
+    italic: boolean
+    underline: boolean
     y: number
     width: number
 }
@@ -177,6 +180,9 @@ export class CanvasRenderer implements INeovimRenderer {
             foregroundColor: screenInfo.foregroundColor,
             backgroundColor: screenInfo.backgroundColor,
             text: "",
+            bold: false,
+            italic: false,
+            underline: false,
             startX: span.startX,
             y,
             width: 0,
@@ -203,7 +209,6 @@ export class CanvasRenderer implements INeovimRenderer {
 
     private _getNextRenderState(cell: ICell, x: number, y: number, currentState: IRenderState): IRenderState {
         const isCurrentCellWhiteSpace = isWhiteSpace(cell.character)
-
         if (cell.foregroundColor !== currentState.foregroundColor
             || cell.backgroundColor !== currentState.backgroundColor
             || isCurrentCellWhiteSpace !== currentState.isWhitespace
@@ -213,6 +218,9 @@ export class CanvasRenderer implements INeovimRenderer {
                 foregroundColor: cell.foregroundColor,
                 backgroundColor: cell.backgroundColor,
                 text: cell.character,
+                bold: cell.bold,
+                italic: cell.italic,
+                underline: cell.underline,
                 width: cell.characterWidth,
                 startX: x,
                 y,
@@ -229,6 +237,9 @@ export class CanvasRenderer implements INeovimRenderer {
                 foregroundColor: cell.foregroundColor,
                 backgroundColor: cell.backgroundColor,
                 text: currentState.text + cell.character,
+                bold: cell.bold,
+                italic: cell.italic,
+                underline: cell.underline,
                 width: currentState.width + adjustedCharacterWidth,
                 startX: currentState.startX,
                 y: currentState.y,
@@ -249,7 +260,7 @@ export class CanvasRenderer implements INeovimRenderer {
             return
         }
 
-        const { backgroundColor, foregroundColor, text, startX, y } = state
+        const { backgroundColor, foregroundColor, bold, italic,  /* underline ,*/ text, startX, y } = state
 
         const { fontWidthInPixels, fontHeightInPixels, linePaddingInPixels } = screenInfo
 
@@ -276,8 +287,18 @@ export class CanvasRenderer implements INeovimRenderer {
         }
 
         if (!state.isWhitespace) {
+            const lastFontStyle = this._canvasContext.font
             this._canvasContext.fillStyle = foregroundColor
+            if (bold || italic) {
+                if (bold) {
+                    this._canvasContext.font = `bold ${this._canvasContext.font}`
+                }
+                if (italic) {
+                    this._canvasContext.font = `italic ${this._canvasContext.font}`
+                }
+            }
             this._canvasContext.fillText(text, boundsStartX, y * fontHeightInPixels + linePaddingInPixels / 2)
+            this._canvasContext.font = lastFontStyle
         }
 
         // Commit span dimensions to grid

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -614,7 +614,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     break
                 case "highlight_set":
                     const highlightInfo = a[a.length - 1][0]
-                    console.log('highlightInfo: ', highlightInfo)
+
                     this.emit("action", Actions.setHighlight(
                         !!highlightInfo.bold,
                         !!highlightInfo.italic,

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -446,12 +446,21 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this._fontFamily = fontFamily
         this._fontSize = fontSize
 
-        const { width, height } = measureFont(this._fontFamily, this._fontSize)
+        const { width, height, isBoldAvailable, isItalicAvailable } = measureFont(this._fontFamily, this._fontSize)
 
         this._fontWidthInPixels = width
         this._fontHeightInPixels = height + linePadding
 
-        this.emit("action", Actions.setFont(fontFamily, fontSize, width, height + linePadding, linePadding))
+        this.emit("action", Actions.setFont({
+                fontFamily,
+                fontSize,
+                fontWidthInPixels: width,
+                fontHeightInPixels: height + linePadding,
+                linePaddingInPixels: linePadding,
+                isItalicAvailable,
+                isBoldAvailable,
+            }),
+        )
 
         this.resize(this._lastWidthInPixels, this._lastHeightInPixels)
     }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -614,6 +614,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     break
                 case "highlight_set":
                     const highlightInfo = a[a.length - 1][0]
+                    console.log('highlightInfo: ', highlightInfo)
                     this.emit("action", Actions.setHighlight(
                         !!highlightInfo.bold,
                         !!highlightInfo.italic,

--- a/browser/src/neovim/Screen.ts
+++ b/browser/src/neovim/Screen.ts
@@ -140,11 +140,11 @@ export class NeovimScreen implements IScreen {
     }
 
     public get currentForegroundColor(): string {
-        return this._currentHighlight.foregroundColor ? this._currentHighlight.foregroundColor : this._foregroundColor
+        return this._currentHighlight.foregroundColor || this._foregroundColor
     }
 
     public get currentBackgroundColor(): string {
-        return this._currentHighlight.backgroundColor ? this._currentHighlight.backgroundColor : this._backgroundColor
+        return this._currentHighlight.backgroundColor || this._backgroundColor
     }
 
     public getCell(x: number, y: number): ICell {
@@ -164,8 +164,8 @@ export class NeovimScreen implements IScreen {
                 this._cursorColumn = action.col
                 break
             case Actions.PutAction: {
-                let foregroundColor = this._currentHighlight.foregroundColor ? this._currentHighlight.foregroundColor : this._foregroundColor
-                let backgroundColor = this._currentHighlight.backgroundColor ? this._currentHighlight.backgroundColor : this._backgroundColor
+                let foregroundColor = this._currentHighlight.foregroundColor || this._foregroundColor
+                let backgroundColor = this._currentHighlight.backgroundColor || this._backgroundColor
 
                 if (this._currentHighlight.reverse) {
                     const temp = foregroundColor

--- a/browser/src/neovim/Screen.ts
+++ b/browser/src/neovim/Screen.ts
@@ -14,6 +14,8 @@ export interface IHighlight {
 
     foregroundColor?: string
     backgroundColor?: string
+    isItalicAvailable?: boolean
+    isBoldAvailable?: boolean
 }
 
 export interface IScreen {
@@ -246,6 +248,8 @@ export class NeovimScreen implements IScreen {
                 this._fontWidthInPixels = action.fontWidthInPixels
                 this._fontHeightInPixels = action.fontHeightInPixels
                 this._linePaddingInPixels = action.linePaddingInPixels
+                this._currentHighlight.isItalicAvailable = action.isItalicAvailable
+                this._currentHighlight.isBoldAvailable = action.isBoldAvailable
                 break
             case Actions.CHANGE_MODE:
                 this._mode = action.mode
@@ -257,11 +261,12 @@ export class NeovimScreen implements IScreen {
                 this._foregroundColor = action.color
                 break
             case Actions.SET_HIGHLIGHT:
+                const { isBoldAvailable, isItalicAvailable } = this._currentHighlight
                 this._currentHighlight.foregroundColor = action.foregroundColor
                 this._currentHighlight.backgroundColor = action.backgroundColor
                 this._currentHighlight.reverse = !!action.reverse
-                this._currentHighlight.bold = action.bold
-                this._currentHighlight.italic = action.italic
+                this._currentHighlight.bold = isBoldAvailable ? action.bold : false
+                this._currentHighlight.italic = isItalicAvailable ? action.italic : false
                 this._currentHighlight.undercurl = action.undercurl
                 this._currentHighlight.underline = action.underline
                 break

--- a/browser/src/neovim/Screen.ts
+++ b/browser/src/neovim/Screen.ts
@@ -47,6 +47,9 @@ export interface ICell {
 
     foregroundColor?: string
     backgroundColor?: string
+    italic?: boolean
+    bold?: boolean
+    underline?: boolean
 }
 
 export interface IPixelPosition {
@@ -170,6 +173,8 @@ export class NeovimScreen implements IScreen {
                     backgroundColor = temp
                 }
 
+                const { underline, bold, italic } = this._currentHighlight
+
                 const characters = action.characters
                 const row = this._cursorRow
                 const col = this._cursorColumn
@@ -184,6 +189,9 @@ export class NeovimScreen implements IScreen {
                         backgroundColor,
                         character,
                         characterWidth,
+                        italic,
+                        bold,
+                        underline,
                     })
 
                     for (let c = 1; c < characterWidth; c++) {
@@ -192,6 +200,9 @@ export class NeovimScreen implements IScreen {
                             backgroundColor,
                             character: "",
                             characterWidth: 0,
+                            italic,
+                            bold,
+                            underline,
                         })
                     }
 
@@ -202,8 +213,8 @@ export class NeovimScreen implements IScreen {
                 break
             }
             case Actions.CLEAR_TO_END_OF_LINE: {
-                const foregroundColor = this._currentHighlight.foregroundColor ? this._currentHighlight.foregroundColor : this._foregroundColor
-                const backgroundColor = this._currentHighlight.backgroundColor ? this._currentHighlight.backgroundColor : this._backgroundColor
+                const foregroundColor = this._currentHighlight.foregroundColor || this._foregroundColor
+                const backgroundColor = this._currentHighlight.backgroundColor || this._backgroundColor
 
                 const row = this._cursorRow
                 for (let i = this._cursorColumn; i < this.width; i++) {
@@ -212,6 +223,9 @@ export class NeovimScreen implements IScreen {
                         backgroundColor,
                         character: "",
                         characterWidth: 1,
+                        bold: this._currentHighlight.bold,
+                        italic: this._currentHighlight.italic,
+                        underline: this._currentHighlight.underline,
                     })
                 }
                 break
@@ -246,6 +260,10 @@ export class NeovimScreen implements IScreen {
                 this._currentHighlight.foregroundColor = action.foregroundColor
                 this._currentHighlight.backgroundColor = action.backgroundColor
                 this._currentHighlight.reverse = !!action.reverse
+                this._currentHighlight.bold = action.bold
+                this._currentHighlight.italic = action.italic
+                this._currentHighlight.undercurl = action.undercurl
+                this._currentHighlight.underline = action.underline
                 break
             case Actions.SET_SCROLL_REGION:
                 this._scrollRegion = {

--- a/browser/src/neovim/actions.ts
+++ b/browser/src/neovim/actions.ts
@@ -39,12 +39,24 @@ export interface IKeyboardInputAction extends IAction {
     input: string
 }
 
+interface ISetFontArguments {
+    fontFamily: string
+    fontSize: string
+    fontWidthInPixels: number
+    fontHeightInPixels: number
+    linePaddingInPixels: number
+    isItalicAvailable: boolean
+    isBoldAvailable: boolean
+}
+
 export interface ISetFontAction extends IAction {
     fontFamily: string
     fontSize: string
     fontWidthInPixels: number
     fontHeightInPixels: number
     linePaddingInPixels: number
+    isItalicAvailable: boolean
+    isBoldAvailable: boolean
 }
 
 export interface IScrollAction extends IAction {
@@ -177,7 +189,15 @@ export function changeMode(mode: string): IChangeModeAction {
     }
 }
 
-export function setFont(fontFamily: string, fontSize: string, fontWidthInPixels: number, fontHeightInPixels: number, linePaddingInPixels: number): ISetFontAction {
+export function setFont({
+    fontFamily,
+    fontSize,
+    fontWidthInPixels,
+    fontHeightInPixels,
+    linePaddingInPixels,
+    isItalicAvailable,
+    isBoldAvailable,
+}: ISetFontArguments): ISetFontAction {
     return {
         type: SET_FONT,
         fontFamily,
@@ -185,6 +205,8 @@ export function setFont(fontFamily: string, fontSize: string, fontWidthInPixels:
         fontWidthInPixels,
         fontHeightInPixels,
         linePaddingInPixels,
+        isItalicAvailable,
+        isBoldAvailable,
     }
 }
 

--- a/browser/src/neovim/actions.ts
+++ b/browser/src/neovim/actions.ts
@@ -90,7 +90,15 @@ export function setScrollRegion(top: number, bottom: number, left: number, right
     }
 }
 
-export function setHighlight(bold: boolean, italic: boolean, reverse: boolean, underline: boolean, undercurl: boolean, foregroundColor?: number, backgroundColor?: number): ISetHighlightAction {
+export function setHighlight(
+    bold: boolean,
+    italic: boolean,
+    reverse: boolean,
+    underline: boolean,
+    undercurl: boolean,
+    foregroundColor?: number,
+    backgroundColor?: number,
+): ISetHighlightAction {
     const action: ISetHighlightAction = {
         type: SET_HIGHLIGHT,
         bold,


### PR DESCRIPTION
This PR fixes #878 by adding the metadata re bold and italics from neovim to the cell data and using that when the text is rendered.

Note: I haven't included underline in the final render as that seems to be another beast but theoretically one could use this [SO](https://stackoverflow.com/questions/4627133/is-it-possible-to-draw-text-decoration-underline-etc-with-html5-canvas-text) answer which is a work around for not having a text-decoration style in canvas but wasn't sure whether the underline is wanted or whether it could/would be implemented using something similar to the error squiggles