### PR TITLE
Dependency: Replace 'css-language-server' with 'vscode-css-languageserver-bin'

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -15,7 +15,7 @@ import { ocamlAndReasonConfiguration, ocamlLanguageServerPath } from "./ReasonCo
 
 const noop = () => { } // tslint:disable-line no-empty
 
-const cssLanguageServerPath = path.join(__dirname, "node_modules", "css-language-server", "lib", "cli.js")
+const cssLanguageServerPath = path.join(__dirname, "node_modules", "vscode-css-languageserver-bin", "cssServerMain.js")
 
 const BaseConfiguration: IConfigurationValues = {
     activate: noop,

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
   "license": "MIT",
   "dependencies": {
     "@types/redux-batched-subscribe": "^0.1.2",
-    "css-language-server": "0.0.2",
     "dompurify": "1.0.2",
     "electron-settings": "^3.1.4",
     "find-up": "2.1.0",
@@ -139,6 +138,7 @@
     "shell-env": "^0.3.0",
     "styled-components": "^2.3.0",
     "typescript": "2.6.1",
+    "vscode-css-languageserver-bin": "^1.2.1",
     "vscode-jsonrpc": "3.5.0",
     "vscode-languageserver": "3.5.0",
     "vscode-languageserver-types": "3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,13 +1603,6 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-language-server@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/css-language-server/-/css-language-server-0.0.2.tgz#9cce79c6e97a67b3442a46aaa45788bec9515ed3"
-  dependencies:
-    vscode-css-languageservice "^3.0.0"
-    vscode-languageserver "^3.5.0"
-
 css-loader@0.28.4:
   version "0.28.4"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.4.tgz#6cf3579192ce355e8b38d5f42dd7a1f2ec898d0f"
@@ -6407,9 +6400,16 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vscode-css-languageservice@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-3.0.1.tgz#2fb8f33d959d289289154142e8c22ad501a0139b"
+vscode-css-languageserver-bin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageserver-bin/-/vscode-css-languageserver-bin-1.2.1.tgz#00483a92687f3233e1a9ea6f0c018ea965d9ed3e"
+  dependencies:
+    vscode-css-languageservice "^3.0.3"
+    vscode-languageserver "^3.5.0"
+
+vscode-css-languageservice@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-3.0.3.tgz#02cc4efa5335f5104e0a2f3b6920faaf59db4f7a"
   dependencies:
     vscode-languageserver-types "3.5.0"
     vscode-nls "^2.0.1"


### PR DESCRIPTION
This updates our CSS/LESS/SASS strategy to use `vscode-css-languageserver-bin` instead of `css-language-server`. `vscode-css-languageserver-bin` is more mature and includes diagnostics support:
![image](https://user-images.githubusercontent.com/13532591/34465870-1ebb9740-ee76-11e7-975d-d1f33ab7d632.png)
