### PR TITLE
Regression: Fix missing titlebar on OSX

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -35,6 +35,7 @@ import { Completion } from "./../../Services/Completion"
 import { Configuration, IConfigurationValues } from "./../../Services/Configuration"
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 import { Errors } from "./../../Services/Errors"
+import * as Shell from "./../../UI/Shell"
 
 import {
     addInsertModeLanguageFunctionality,
@@ -269,9 +270,8 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         this._neovimInstance.onTitleChanged.subscribe((newTitle) => {
-            // MUSTFIX
-            // const title = newTitle.replace(" - NVIM", " - ONI")
-            // UI.Actions.setWindowTitle(title)
+            const title = newTitle.replace(" - NVIM", " - ONI")
+            Shell.Actions.setWindowTitle(title)
         })
 
         this._neovimInstance.onLeave.subscribe(() => {

--- a/browser/src/UI/components/WindowTitle.tsx
+++ b/browser/src/UI/components/WindowTitle.tsx
@@ -36,7 +36,7 @@ export class WindowTitleView extends React.PureComponent<IWindowTitleViewProps, 
             WebkitUserSelect: "none",
         }
 
-        return <div style={style}>{this.props.title}</div>
+        return <div id={"oni-titlebar"} style={style}>{this.props.title}</div>
     }
 }
 

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -26,6 +26,10 @@ const WindowsOnlyTests = [
     "PaintPerformanceTest",
 ]
 
+const OSXOnlyTests = [
+    "OSX.WindowTitleTest",
+]
+
 // tslint:disable:no-console
 
 import * as Platform from "./../browser/src/Platform"
@@ -38,7 +42,7 @@ export interface ITestCase {
 
 describe("ci tests", function() { // tslint:disable-line only-arrow-functions
 
-    const tests = Platform.isWindows() ? [...CiTests, ...WindowsOnlyTests] : CiTests
+    const tests = Platform.isWindows() ? [...CiTests, ...WindowsOnlyTests] : Platform.isMac() ? [...CiTests, ...OSXOnlyTests] : CiTests
 
     CiTests.forEach((test) => {
         runInProcTest(path.join(__dirname, "ci"), test)

--- a/test/ci/OSX.WindowTitleTest.ts
+++ b/test/ci/OSX.WindowTitleTest.ts
@@ -1,0 +1,21 @@
+/**
+ * Test script to validate the window title is rendered
+ */
+
+import * as assert from "assert"
+import * as os from "os"
+
+import { createNewFile } from "./Common"
+
+export const test = async (oni: any) => {
+    await oni.automation.waitForEditors()
+
+    // Create a file that doesn't have a language associated with it, to minimize noise
+    await createNewFile("test_file", oni)
+
+    // Validate that the titlebar element eventually shows ONI + the file name
+    await oni.automation.waitFor(() => {
+        const titleBar = document.getElementById("oni-titlebar")
+        return titleBar.textContent.indexOf("ONI") >= 0 && titleBar.textContent.indexOf("test_file") >= 0
+    })
+}


### PR DESCRIPTION
__Issue:__ The titlebar isn't showing up on OSX anymore

__Defect:__ During the refactoring to split the editor / shell stores, the titlebar state wasn't wired up.

__Fix:__ Dispatch the `SET_TITLE` action against the shell store from NeovimEditor. This will have to be refactored a bit once the multiplexing is fully in place, but it's something that can happen later.

Also added a test case in the hopes that it can keep it from regressing again in the future.