### PR TITLE
Dependency: Upgrade to 'oni-api' 0.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
     "ocaml-language-server": "1.0.12",
-    "oni-api": "0.0.22",
+    "oni-api": "0.0.23",
     "oni-neovim-binaries": "0.1.0",
     "oni-ripgrep": "0.0.3",
     "oni-types": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
     "ocaml-language-server": "1.0.12",
-    "oni-api": "0.0.20",
+    "oni-api": "0.0.22",
     "oni-neovim-binaries": "0.1.0",
     "oni-ripgrep": "0.0.3",
     "oni-types": "0.0.4",

--- a/test/ci/AutoClosingPairsTest.ts
+++ b/test/ci/AutoClosingPairsTest.ts
@@ -8,11 +8,13 @@ import * as assert from "assert"
 import * as os from "os"
 import * as path from "path"
 
+import * as Oni from "oni-api"
+
 import { createNewFile } from "./Common"
 
 const delay = 0
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
 
     await createNewFile("js", oni)

--- a/test/ci/AutoCompletionTest-CSS.ts
+++ b/test/ci/AutoCompletionTest-CSS.ts
@@ -4,9 +4,11 @@
 
 import * as assert from "assert"
 
+import * as Oni from "oni-api"
+
 import { createNewFile, getCompletionElement } from "./Common"
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
 
     await createNewFile("css", oni)

--- a/test/ci/AutoCompletionTest-TypeScript.ts
+++ b/test/ci/AutoCompletionTest-TypeScript.ts
@@ -4,9 +4,11 @@
 
 import * as assert from "assert"
 
+import * as Oni from "oni-api"
+
 import { createNewFile, getCompletionElement } from "./Common"
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
 
     await createNewFile("ts", oni)

--- a/test/ci/LargeFileTest.ts
+++ b/test/ci/LargeFileTest.ts
@@ -4,21 +4,23 @@
  * Regression test for #1064
  */
 
+import * as Oni from "oni-api"
+
 import { getTemporaryFilePath, navigateToFile } from "./Common"
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     const filePath = createLargeTestFile()
     await oni.automation.waitForEditors()
 
     navigateToFile(filePath, oni)
 
-    await oni.automation.sendKeys("G")
+    oni.automation.sendKeys("G")
     await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 99999, 30000)
 
-    await oni.automation.sendKeys(":50000<CR>")
+    oni.automation.sendKeys(":50000<CR>")
     await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 49999, 30000)
 
-    await oni.automation.sendKeys("gg")
+    oni.automation.sendKeys("gg")
     await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 0, 30000)
 }
 

--- a/test/ci/NoInstalledNeovim.ts
+++ b/test/ci/NoInstalledNeovim.ts
@@ -8,6 +8,8 @@ import * as assert from "assert"
 import * as os from "os"
 import * as path from "path"
 
+import * as Oni from "oni-api"
+
 const getInstallHelpElement = () => {
 
     const elements = document.body.getElementsByClassName("install-help")
@@ -19,7 +21,7 @@ const getInstallHelpElement = () => {
     }
 }
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     // Wait for install help UX to show
     await oni.automation.waitFor(() => getInstallHelpElement() !== null)
 

--- a/test/ci/PaintPerformanceTest.ts
+++ b/test/ci/PaintPerformanceTest.ts
@@ -7,9 +7,11 @@ import * as os from "os"
 
 import { Rectangle, remote } from "electron"
 
+import * as Oni from "oni-api"
+
 import { createNewFile, getCompletionElement } from "./Common"
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
 
     // Create a file that doesn't have a language associated with it, to minimize noise

--- a/test/ci/StatusBar-Mode.ts
+++ b/test/ci/StatusBar-Mode.ts
@@ -7,9 +7,11 @@
 import * as assert from "assert"
 import * as path from "path"
 
+import * as Oni from "oni-api"
+
 import { getElementByClassName } from "./Common"
 
-export const test = async (oni: any) => {
+export const test = async (oni: Oni.Plugin.Api) => {
     // Wait for completion popup to show
     await oni.automation.waitFor(() => getElementByClassName("mode") !== null)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@0.0.20:
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.20.tgz#8b092b12cda6cda95af10098213ceb5067b3732e"
+oni-api@0.0.22:
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.22.tgz#332066ad02149913f3decdcd6b7e8ae3fb562fe8"
 
 oni-neovim-binaries@0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.22.tgz#332066ad02149913f3decdcd6b7e8ae3fb562fe8"
+oni-api@0.0.23:
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.23.tgz#442b8eb147bc2c3dc78b44cc158d6e3030d9014e"
 
 oni-neovim-binaries@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- Upgrade to `oni-api` 0.0.23

This allows us to strongly-type the API in the CiTests (which is the same as the plugin API), since the automation + additional methods are now available there.