### PR TITLE
Fix #963 - Delete word in 'lightweight' text

### DIFF
--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -15,6 +15,8 @@ import { IMenuOptionWithHighlights, menuStore } from "./Menu"
 import * as ActionCreators from "./MenuActionCreators"
 import * as State from "./MenuState"
 
+import { TextInputView } from "./../../UI/components/LightweightText"
+
 export interface IMenuProps {
     visible: boolean
     selectedIndex: number
@@ -68,16 +70,10 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
 
         return <div className="menu-background enable-mouse">
             <div className="menu" style={menuStyle}>
-                <input type="text"
-                    style={{color: this.props.foregroundColor}}
-                    ref={(inputElement) => {
-                        this._inputElement = inputElement
-                        if (this._inputElement) {
-                            focusManager.pushFocus(this._inputElement)
-                        }
-                    }}
-                    onChange={(evt) => this._onChange(evt)}
-                    />
+                <TextInputView
+                    backgroundColor={this.props.backgroundColor}
+                    foregroundColor={this.props.foregroundColor}
+                    onChange={(evt) => this._onChange(evt)} />
                 <div className="items">
                     {items}
                 </div>

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -71,7 +71,8 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
         return <div className="menu-background enable-mouse">
             <div className="menu" style={menuStyle}>
                 <TextInputView
-                    backgroundColor={this.props.backgroundColor}
+                    overrideDefaultStyle={true}
+                    backgroundColor={null}
                     foregroundColor={this.props.foregroundColor}
                     onChange={(evt) => this._onChange(evt)} />
                 <div className="items">

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -68,6 +68,18 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
         }
     }
 
+    public componentWillUnmount(): void {
+        if (this._element) {
+
+            if (this.props.onComplete) {
+                this.props.onComplete(this._element.value)
+            }
+
+            focusManager.popFocus(this._element)
+            this._element = null
+        }
+    }
+
     private _onKeyDown(keyboardEvent: React.KeyboardEvent<HTMLInputElement>): void {
 
         if (this._element && keyboardEvent.ctrlKey) {
@@ -92,7 +104,7 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
                         const previousValue = this._element.value
                         let idx = previousValue.length - 1
 
-                        while(idx > 0) {
+                        while (idx > 0) {
                             if (!previousValue[idx].match(WordRegex)) {
                                 break
                             }
@@ -107,18 +119,6 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
                     return
 
             }
-        }
-    }
-
-    public componentWillUnmount(): void {
-        if (this._element) {
-
-            if (this.props.onComplete) {
-                this.props.onComplete(this._element.value)
-            }
-
-            focusManager.popFocus(this._element)
-            this._element = null
         }
     }
 }

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -62,12 +62,6 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
             ref={(elem) => this._element = elem} /></div>
     }
 
-    private _onChange(changeEvent: React.ChangeEvent<HTMLInputElement>): void {
-        if (this.props.onChange) {
-            this.props.onChange(changeEvent)
-        }
-    }
-
     public componentWillUnmount(): void {
         if (this._element) {
 
@@ -77,6 +71,12 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
 
             focusManager.popFocus(this._element)
             this._element = null
+        }
+    }
+
+    private _onChange(changeEvent: React.ChangeEvent<HTMLInputElement>): void {
+        if (this.props.onChange) {
+            this.props.onChange(changeEvent)
         }
     }
 

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -7,6 +7,7 @@ import { focusManager } from "./../../Services/FocusManager"
 
 export interface IToolTipsViewProps {
     onComplete?: (result: string) => void
+    onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void
 
     defaultValue?: string
 
@@ -14,6 +15,9 @@ export interface IToolTipsViewProps {
     foregroundColor: string
 
 }
+
+// TODO: Is there a better value for this?
+const WordRegex = /[$_a-zA-Z0-9]/i
 
 export class TextInputView extends React.PureComponent<IToolTipsViewProps, {}> {
 
@@ -43,10 +47,60 @@ export class TextInputView extends React.PureComponent<IToolTipsViewProps, {}> {
         const defaultValue = this.props.defaultValue || ""
 
         return <div style={containerStyle}><input type="text"
-                    style={inputStyle}
-                    placeholder={defaultValue}
-                    onFocus={(evt) => evt.currentTarget.select()}
-                    ref={(elem) => this._element = elem} /></div>
+            style={inputStyle}
+            placeholder={defaultValue}
+            onKeyDown={(evt) => this._onKeyDown(evt)}
+            onChange={(evt) => this._onChange(evt)}
+            onFocus={(evt) => evt.currentTarget.select()}
+            ref={(elem) => this._element = elem} /></div>
+    }
+
+    private _onChange(changeEvent: React.ChangeEvent<HTMLInputElement>): void {
+        if (this.props.onChange) {
+            this.props.onChange(changeEvent)
+        }
+    }
+
+    private _onKeyDown(keyboardEvent: React.KeyboardEvent<HTMLInputElement>): void {
+
+        if (this._element && keyboardEvent.ctrlKey) {
+
+            switch (keyboardEvent.key) {
+                case "u":
+                    {
+                        this._element.value = ""
+                        break
+                    }
+                case "h":
+                    {
+                        const previousValue = this._element.value
+
+                        if (previousValue.length > 0) {
+                            this._element.value = previousValue.substring(0, previousValue.length - 1)
+                        }
+                        break
+                    }
+                case "w":
+                    {
+                        const previousValue = this._element.value
+                        let idx = previousValue.length - 1
+
+                        while(idx > 0) {
+                            if (!previousValue[idx].match(WordRegex)) {
+                                break
+                            }
+
+                            idx--
+                        }
+
+                        this._element.value = previousValue.substring(0, idx)
+                    }
+                    break
+                default:
+                    return
+
+            }
+        }
     }
 
     public componentWillUnmount(): void {

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -5,7 +5,7 @@ import * as State from "./../Shell/ShellState"
 
 import { focusManager } from "./../../Services/FocusManager"
 
-export interface IToolTipsViewProps {
+export interface ITextInputViewProps {
     onComplete?: (result: string) => void
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void
 
@@ -14,12 +14,19 @@ export interface IToolTipsViewProps {
     backgroundColor: string
     foregroundColor: string
 
+    overrideDefaultStyle?: boolean
+
 }
 
 // TODO: Is there a better value for this?
 const WordRegex = /[$_a-zA-Z0-9]/i
+const EmptyStyle: React.CSSProperties = {}
 
-export class TextInputView extends React.PureComponent<IToolTipsViewProps, {}> {
+/**
+ * TextInputView is a lightweight input control, that implements some
+ * common functionality (like focus management, key handling)
+ */
+export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> {
 
     private _element: HTMLInputElement
 
@@ -31,7 +38,7 @@ export class TextInputView extends React.PureComponent<IToolTipsViewProps, {}> {
 
     public render(): JSX.Element {
 
-        const containerStyle: React.CSSProperties = {
+        const containerStyle: React.CSSProperties = this.props.overrideDefaultStyle ? EmptyStyle : {
             padding: "4px",
             border: "1px solid " + this.props.foregroundColor,
         }
@@ -116,7 +123,7 @@ export class TextInputView extends React.PureComponent<IToolTipsViewProps, {}> {
     }
 }
 
-const mapStateToProps = (state: State.IState, originalProps?: Partial<IToolTipsViewProps>) => ({
+const mapStateToProps = (state: State.IState, originalProps?: Partial<ITextInputViewProps>) => ({
     ...originalProps,
     backgroundColor: state.colors["editor.background"],
     foregroundColor: state.colors["editor.foreground"],


### PR DESCRIPTION
__Issue:__ There are a few cases today where we use a vanilla input box instead of vim integration. This includes the rename dialog and quickopen. In these cases, the normal insert-mode muscle memory (`control+h` - delete one character, `control+w` - delete word, `control+u` - delete line) doesn't work as expected.

__Fix:__ Bake in these bindings into the `TextInputView` (lightweight text editor). This isn't perfect, and the `WordRegEx` may need some tweaking. At some point, it would be nice to replace this with a neovim-backed edit experience.