### PR TITLE
Bugfix: Add key to scroll bar container

### DIFF
--- a/browser/src/Editor/NeovimEditor/containers/BufferScrollBarContainer.ts
+++ b/browser/src/Editor/NeovimEditor/containers/BufferScrollBarContainer.ts
@@ -16,6 +16,7 @@ export const getCurrentLine = createSelector(
     })
 
 const NoScrollBar: IBufferScrollBarProps = {
+    windowId: null,
     bufferSize: -1,
     height: -1,
     windowTopLine: -1,
@@ -73,6 +74,7 @@ const mapStateToProps = (state: State.IState): IBufferScrollBarProps => {
     const markers = getMarkers(state)
 
     return {
+        windowId: activeWindow.windowId,
         windowTopLine: activeWindow.topBufferLine,
         windowBottomLine: activeWindow.bottomBufferLine,
         bufferSize,

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components"
 import { bufferScrollBarSize } from "./common"
 
 export interface IBufferScrollBarProps {
+    windowId: number
     bufferSize: number
     height: number
     windowTopLine: number
@@ -75,7 +76,7 @@ export class BufferScrollBar extends React.PureComponent<IBufferScrollBarProps, 
             return <div style={markerStyle} key={m.line.toString() + m.color}/>
         })
 
-        return <ScrollBarContainer>
+        return <ScrollBarContainer key={this.props.windowId}>
                     <ScrollBarWindow style={windowStyle}></ScrollBarWindow>
                     {markerElements}
                 </ScrollBarContainer>


### PR DESCRIPTION
This adds a `key` to the BufferScrollBarContainer. It seems that, without it, errors would collect there (and give warnings in the console).