### PR TITLE
Performance (Perceived): Separate loading / entrance for editor

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -561,6 +561,8 @@ export class NeovimEditor extends Editor implements IEditor {
             await this._openFiles(filesToOpen, ":tabnew")
         }
 
+        this._actions.setLoadingComplete()
+
         this._hasLoaded = true
         this._isFirstRender = true
         this._scheduleRender()

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -324,9 +324,6 @@ export const setHasFocus = (hasFocus: boolean) => {
 }
 
 export const setLoadingComplete = () => {
-
-    document.body.classList.add("loaded")
-
     return {
         type: "SET_LOADING_COMPLETE",
     }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorLoadingOverlay.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorLoadingOverlay.tsx
@@ -1,0 +1,41 @@
+/**
+ * NeovimEditorLoadingOverlay
+ *
+ * Overlay shown over the editor window while initializing (loading Neovim)
+ */
+
+import * as React from "react"
+import { connect } from "react-redux"
+
+import * as State from "./NeovimEditorStore"
+
+import styled from "styled-components"
+import { withProps } from "./../../UI/components/common"
+
+const LoadingSpinnerWrapper = withProps<{}>(styled.div)`
+    background-color: ${props => props.theme["editor.background"]};
+    color: ${props => props.theme["editor.foreground"]};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    opacity: 1;
+    transition: opacity 0.15s ease-in;
+
+    &.loaded {
+        opacity: 0;
+        pointer-events: none;
+    }
+`
+
+export const NeovimEditorLoadingOverlayView = (props: {visible: boolean}): JSX.Element => {
+        const className = props.visible ? "stack layer" : " stack layer loaded"
+
+        return <LoadingSpinnerWrapper className={className} />
+}
+
+export const mapStateToProps = (state: State.IState): { visible: boolean } => {
+    return { visible: !state.isLoaded }
+}
+
+export const NeovimEditorLoadingOverlay = connect(mapStateToProps)(NeovimEditorLoadingOverlayView)

--- a/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
@@ -30,6 +30,11 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
                 ...s,
                 colors: a.payload.colors,
             }
+        case "SET_LOADING_COMPLETE":
+            return {
+                ...s,
+                isLoaded: true,
+            }
         case "SET_NEOVIM_ERROR":
              return { ...s,
                       neovimError: a.payload.neovimError }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
@@ -55,6 +55,7 @@ export interface IState {
     cursorColumnOpacity: number
     configuration: IConfigurationValues
     imeActive: boolean
+    isLoaded: boolean
     viewport: IViewport
     colors: IThemeColors
 
@@ -180,6 +181,7 @@ export const createDefaultState = (): IState => ({
     cursorLineOpacity: 0,
     cursorColumnOpacity: 0,
     neovimError: false,
+    isLoaded: false,
 
     activeVimTabPage: null,
 

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -97,8 +97,8 @@ export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> 
                 <div className="stack layer">
                     <ToolTips />
                 </div>
-                <InstallHelp />
                 <NeovimEditorLoadingOverlay />
+                <InstallHelp />
             </div>
         </div>
     }

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -51,6 +51,22 @@ export interface INeovimSurfaceProps {
     onTabSelect?: (tabId: number) => void
 }
 
+import styled, { keyframes } from "styled-components"
+
+const keys = keyframes`
+    0% { transform: rotateY(0deg); opacity: 0.1; }
+    50% { transform: rotateY(180deg) scale(0.9); opacity: 0.2; }
+    100% { transform: rotateY(360deg); opacity: 0.1; }
+`
+
+const LoadingContainer = styled.div`
+    opacity: 0.4;
+
+    img {
+        animation: ${keys} 2.5s linear infinite;
+    }
+`
+
 export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> {
     public render(): JSX.Element {
         return <div className="container vertical full">
@@ -97,6 +113,11 @@ export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> 
                     <ToolTips />
                 </div>
                 <InstallHelp />
+                <div className="stack layer">
+                    <LoadingContainer>
+                        <img src="images/oni-icon-no-border.svg" style={{width: "128px", height: "128px"}} />
+                    </LoadingContainer>
+                </div>
             </div>
         </div>
     }

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -28,6 +28,7 @@ import { ErrorsContainer } from "./containers/ErrorsContainer"
 import { TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 
 import { NeovimActiveWindowContainer } from "./NeovimActiveWindow"
+import { NeovimEditorLoadingOverlay } from "./NeovimEditorLoadingOverlay"
 import { NeovimInput } from "./NeovimInput"
 import { NeovimLayers } from "./NeovimLayersView"
 import { NeovimRenderer } from "./NeovimRenderer"
@@ -50,22 +51,6 @@ export interface INeovimSurfaceProps {
     onTabClose?: (tabId: number) => void
     onTabSelect?: (tabId: number) => void
 }
-
-import styled, { keyframes } from "styled-components"
-
-const keys = keyframes`
-    0% { transform: rotateY(0deg); opacity: 0.1; }
-    50% { transform: rotateY(180deg) scale(0.9); opacity: 0.2; }
-    100% { transform: rotateY(360deg); opacity: 0.1; }
-`
-
-const LoadingContainer = styled.div`
-    opacity: 0.4;
-
-    img {
-        animation: ${keys} 2.5s linear infinite;
-    }
-`
 
 export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> {
     public render(): JSX.Element {
@@ -113,11 +98,7 @@ export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> 
                     <ToolTips />
                 </div>
                 <InstallHelp />
-                <div className="stack layer">
-                    <LoadingContainer>
-                        <img src="images/oni-icon-no-border.svg" style={{width: "128px", height: "128px"}} />
-                    </LoadingContainer>
-                </div>
+                <NeovimEditorLoadingOverlay />
             </div>
         </div>
     }

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -187,10 +187,11 @@ const BaseConfiguration: IConfigurationValues = {
     "statusbar.fontSize": "0.9em",
     "statusbar.priority": {
         "oni.status.workingDirectory": 0,
-        "oni.status.linenumber": 1,
-        "oni.status.mode": 0,
+        "oni.status.linenumber": 2,
+        "oni.status.gitHubRepo": 0,
+        "oni.status.mode": 1,
         "oni.status.filetype": 1,
-        "oni.status.git": 2,
+        "oni.status.git": 3,
     },
 
     "tabs.mode": "buffers",

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -195,6 +195,7 @@ export interface IConfigurationValues {
         "oni.status.filetype": number,
         "oni.status.workingDirectory": number,
         "oni.status.git": number,
+        "oni.status.gitHubRepo": number,
         "oni.status.linenumber": number,
         "oni.status.mode": number,
     }

--- a/browser/src/UI/components/LoadingSpinner.tsx
+++ b/browser/src/UI/components/LoadingSpinner.tsx
@@ -1,0 +1,32 @@
+/**
+ * NeovimSurface.tsx
+ *
+ * UI layer for the Neovim editor surface
+ */
+
+import * as React from "react"
+
+import styled, { keyframes } from "styled-components"
+
+import { Icon, IconSize } from "./../Icon"
+
+const keys = keyframes`
+    0% { transform: rotateZ(0deg); }
+    100% { transform: rotateZ(359deg); }
+`
+
+const LoadingIconWrapper = styled.div`
+    opacity: 0.1;
+
+    i {
+        animation: ${keys} 1.5s linear infinite;
+    }
+`
+
+export class LoadingSpinner extends React.PureComponent<{}, {}> {
+    public render(): JSX.Element {
+        return <LoadingIconWrapper>
+            <Icon name="circle-o-notch" size={IconSize.FourX} />
+        </LoadingIconWrapper>
+    }
+}

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -1,4 +1,3 @@
-import * as electron from "electron"
 import styled from "styled-components"
 
 import * as keys from "lodash/keys"
@@ -132,20 +131,10 @@ export class StatusBar extends React.PureComponent<StatusBarProps, { isLoaded: b
                     <StatusResize direction="center" />
                     <StatusResize direction="flex-end">
                         {rightItems.map(item => <ItemWithWidth {...item} key={item.id} />)}
-                        <StatusBarComponent onClick={this._openGithub}>
-                            <span>
-                                <i className="fa fa-github" />
-                            </span>
-                        </StatusBarComponent>
                     </StatusResize>
                 </StatusBarInner>
             </StatusBarContainer>
         )
-    }
-
-    private _openGithub(): void {
-        // TODO: Open this in an internal window once that capability is available
-        electron.shell.openExternal("https://www.github.com/onivim/oni")
     }
 }
 

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components"
+import styled, { keyframes } from "styled-components"
 
 import * as keys from "lodash/keys"
 import * as React from "react"
@@ -16,7 +16,6 @@ interface StatusBarStyleProps {
     fontSize: string
     fontFamily: string
     className?: string
-    loaded?: boolean
 }
 
 export interface StatusBarProps extends StatusBarStyleProps {
@@ -48,7 +47,13 @@ interface IStatusComponent {
     maxWidth?: string
 }
 
+const enterKeyframes = keyframes`
+    0% { transform: translateY(4px); opacity: 0; }
+    100% { transform: translateY(0px); opacity: 1; }
+`
+
 const StatusBarComponent = withProps<IStatusComponent>(styled.div)`
+    animation: ${enterKeyframes} 0.2s ease-in;
     white-space: nowrap;
     padding-left: 8px;
     padding-right: 8px;
@@ -70,8 +75,6 @@ const StatusBarContainer = withProps<StatusBarStyleProps>(styled.div)`
     color: ${({ theme }) => theme.foreground};
     box-shadow: 0 -8px 20px 0 rgba(0, 0, 0, 0.2);
     pointer-events: auto;
-    transform: ${({ loaded }) => loaded ? `translateY(0px)` : `translateY(4px)`};
-    transition: transform 0.25s ease;
     height: 2em;
     width: 100%;
     position: relative;
@@ -94,15 +97,7 @@ const StatusBarInner = styled.div`
     justify-content: space-between;
 `
 
-export class StatusBar extends React.PureComponent<StatusBarProps, { isLoaded: boolean }> {
-    public state = {
-        isLoaded: false,
-    }
-
-    public componentDidMount() {
-        this.setState({ isLoaded: true })
-    }
-
+export class StatusBar extends React.PureComponent<StatusBarProps, {}> {
     public render() {
         if (!this.props.enabled) {
             return null
@@ -123,7 +118,7 @@ export class StatusBar extends React.PureComponent<StatusBarProps, { isLoaded: b
         }
 
         return (
-            <StatusBarContainer {...statusBarProps} loaded={this.state.isLoaded}>
+            <StatusBarContainer {...statusBarProps}>
                 <StatusBarInner>
                     <StatusResize direction="flex-start">
                         {leftItems.map(item => <ItemWithWidth {...item} key={item.id} />)}

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -102,6 +102,8 @@ const start = async (args: string[]): Promise<void> => {
     const CSS = await cssPromise
     CSS.activate()
 
+    Shell.Actions.setLoadingComplete()
+
     const Diagnostics = await diagnosticsPromise
     const diagnostics = Diagnostics.getInstance()
 
@@ -128,8 +130,6 @@ const start = async (args: string[]): Promise<void> => {
     const AutoClosingPairs = await autoClosingPairsPromise
     AutoClosingPairs.activate(configuration, editorManager, inputManager, languageManager)
     Performance.endMeasure("Oni.Start.Activate")
-
-    Shell.Actions.setLoadingComplete()
 
     checkForUpdates()
 

--- a/vim/core/oni-core-statusbar/index.js
+++ b/vim/core/oni-core-statusbar/index.js
@@ -10,10 +10,12 @@ const activate = (Oni) => {
     const mode = ids.find(id => id.includes('mode'));
     const linenumber = ids.find(id => id.includes('linenumber'));
     const dir = ids.find(id => id.includes('workingDir'));
+    const gitHubRepo = ids.find(id => id.includes('gitHubRepo'));
 
     const workingDirectoryItem = Oni.statusBar.createItem(0, dir)
     const lineNumberItem = Oni.statusBar.createItem(1, linenumber)
     const modeItem = Oni.statusBar.createItem(1, mode)
+    const gitHubRepoItem = Oni.statusBar.createItem(1, gitHubRepo)
 
     const setMode = (mode) => {
         const getBackgroundColorForMode = (m) => {
@@ -87,6 +89,20 @@ const activate = (Oni) => {
         workingDirectoryItem.setContents(element)
     }
 
+    const setGitHubRepo = () => {
+        const openGitHubRepoCommand = () => {
+            Oni.commands.executeCommand("browser.openUrl", "https://github.com/onivim/oni")
+        }
+
+        const gitHubIcon = Oni.ui.createIcon({
+          name: 'github',
+          size: Oni.ui.iconSize.Default,
+        });
+
+        const element = React.createElement("div", { onClick: openGitHubRepoCommand }, gitHubIcon)
+        gitHubRepoItem.setContents(element)
+    }
+
     Oni.editors.activeEditor.onModeChanged.subscribe((newMode) => {
         setMode(newMode)
     })
@@ -103,10 +119,12 @@ const activate = (Oni) => {
     setLineNumber(1, 1)
     setWorkingDirectory(null)
     setWorkingDirectory(process.cwd())
+    setGitHubRepo()
 
     modeItem.show()
     lineNumberItem.show()
     workingDirectoryItem.show()
+    gitHubRepoItem.show()
 }
 
 module.exports = {

--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -22,8 +22,7 @@ const activate = Oni => {
         return;
       }
       const filePath = evt.filePath || evt.bufferFullPath;
-      const items = Oni.configuration.getValue('statusbar.priority');
-      const gitId = Object.keys(items).find(id => id.includes('git'));
+      const gitId = 'oni.status.git'
       const gitBranchIndicator = Oni.statusBar.createItem(1, gitId);
 
       isLoaded = true;


### PR DESCRIPTION
Today, we show a loading 'overlay' (a blank screen) on top of the entire shell over the course of loading. 
We remove that overlay at the end of the `Oni.Start.Editors` sequence - after all the neovim instances have been spun up and fully initialized.

This means we don't show anything in the UI until we get to here:
![image](https://user-images.githubusercontent.com/13532591/34616293-b1a2fb74-f1ec-11e7-9852-f8db780c2c63.png)

This is by-design, because the first render of the canvas is rocky, since we see the colorscheme switch.

However, other parts of the UI are already rendered at this point - like the statusbar (and sidebar, later!). So we can pull the curtain up for those elements, and then have a separate overlay for the `NeovimEditor`. In effect, we're dividing the entrance into two stages:
![image](https://user-images.githubusercontent.com/13532591/34616372-ea16ec04-f1ec-11e7-9c25-294845e3b6c8.png)

In the first arrow, we'll uncover the shell, so that we can see progress there (animate in statusbar, sidebar, etc).

In the second arrow, we'll uncover the editor pane (with a slight entrance animation).

Even though the absolute time to render is no different, it _feels_ better, because you see progress in the UI state, and the subtle animations help reinforce this.