### PR TITLE
Automation: Use spectron to get console logs

### DIFF
--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -86,7 +86,6 @@ export class Automation implements OniApi.Automation.Api {
 
         const testPath2 = testPath
 
-        const loggingRedirector = new LoggingRedirector()
         Log.enableVerboseLogging()
         try {
             Log.info("[AUTOMATION] Starting test: " + testPath)
@@ -103,13 +102,6 @@ export class Automation implements OniApi.Automation.Api {
             this._reportResult(false, ex)
         } finally {
             this._reportWindowSize()
-            const logs = loggingRedirector.getAllLogs()
-
-            const logsElement = this._createElement("automated-test-logs", this._getOrCreateTestContainer("automated-test-container"))
-
-            logsElement.textContent = JSON.stringify(logs)
-
-            loggingRedirector.dispose()
         }
     }
 
@@ -158,45 +150,3 @@ export class Automation implements OniApi.Automation.Api {
 }
 
 export const automation = new Automation()
-
-class LoggingRedirector {
-
-    private _logs: string[] = []
-
-    private _oldInfo: any
-    private _oldWarn: any
-    private _oldError: any
-
-    constructor() {
-        this._oldInfo = console.log
-        this._oldWarn = console.warn
-        this._oldError = console.error
-
-        console.log = this._redirect("INFO", this._oldInfo)
-        console.warn = this._redirect("WARN", this._oldWarn)
-        console.error = this._redirect("ERROR", this._oldError)
-    }
-
-    public getAllLogs(): string[] {
-        return this._logs
-    }
-
-    public dispose(): void {
-        this._logs = null
-
-        console.log = this._oldInfo
-        console.warn = this._oldWarn
-        console.error = this._oldError
-
-        this._oldInfo = null
-        this._oldWarn = null
-        this._oldError = null
-    }
-
-    private _redirect(type: string, oldFunction: any): any {
-        return (...args: any[]) => {
-            this._logs.push("[" + type + "][" + new Date().getTime() + "]: " + JSON.stringify(args))
-            oldFunction(args)
-        }
-    }
-}

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -90,18 +90,13 @@ export const runInProcTest = (rootPath: string, testName: string, timeout: numbe
 
             const writeLogs = (logs: any[]): void => {
                 logs.forEach((log) => {
-                    console.log(`[${log.level}][${log.source}] ${log.message}`)
+                    console.log(`[${log.level}] ${log.message}`)
                 })
             }
 
             const rendererLogs: any[] = await oni.client.getRenderProcessLogs()
             console.log("---LOGS (Renderer): ")
             writeLogs(rendererLogs)
-            console.log("---")
-
-            const mainLogs: any[] = await oni.client.getMainProcessLogs()
-            console.log("---LOGS (Main): ")
-            writeLogs(mainLogs)
             console.log("---")
 
             const result = JSON.parse(resultText)

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -88,12 +88,20 @@ export const runInProcTest = (rootPath: string, testName: string, timeout: numbe
 
             console.log("Retrieving logs...")
 
-            await oni.client.waitForExist(".automated-test-logs")
-            const clientLogs = await oni.client.getText(".automated-test-logs")
-            console.log("---LOGS (During run): ")
+            const writeLogs = (logs: any[]): void => {
+                logs.forEach((log) => {
+                    console.log(`[${log.level}][${log.source}] ${log.message}`)
+                })
+            }
 
-            const logs = JSON.parse(clientLogs).forEach((log) => console.log(log))
+            const rendererLogs: any[] = await oni.client.getRenderProcessLogs()
+            console.log("---LOGS (Renderer): ")
+            writeLogs(rendererLogs)
+            console.log("---")
 
+            const mainLogs: any[] = await oni.client.getMainProcessLogs()
+            console.log("---LOGS (Main): ")
+            writeLogs(mainLogs)
             console.log("---")
 
             const result = JSON.parse(resultText)


### PR DESCRIPTION
__Issue:__ In some cases, when the test fails in OSX on Travis, we get no console logs at all from the renderer process (although it is running, as it passes the check for the `.editor` element).

__Fix:__ Use spectron's getRenderProcessLogs, as it is more robust / reliable than our strategy of redirecting the logs and writing to an element.