### PR TITLE
Feature/hide app shortcut on macOS

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -29,6 +29,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<m-t>", "language.symbols.workspace", () => !menu.isMenuOpen())
         input.bind("<s-m-t>", "language.symbols.document")
         input.bind("<m-m>", "oni.editor.minimize")
+        input.bind("<m-h>", "oni.editor.hide")
 
         if (config.getValue("editor.clipboard.enabled")) {
             input.bind("<m-c>", "editor.clipboard.yank", isVisualMode)

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -8,7 +8,7 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 
-import { clipboard, remote } from "electron"
+import { clipboard, remote, app } from "electron"
 
 import * as Oni from "oni-api"
 
@@ -50,7 +50,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, neovimIn
 
         new CallbackCommand("oni.editor.minimize", "Minimize Window", "Minimize the current window", () => remote.getCurrentWindow().minimize()),
 
-        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () => remote.getCurrentWindow().hide()),
+        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () => app.hide()),
 
         // Language service
         // TODO: Deprecate

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -8,7 +8,7 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 
-import { clipboard, remote, app } from "electron"
+import { clipboard, remote } from "electron"
 
 import * as Oni from "oni-api"
 
@@ -50,7 +50,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, neovimIn
 
         new CallbackCommand("oni.editor.minimize", "Minimize Window", "Minimize the current window", () => remote.getCurrentWindow().minimize()),
 
-        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () => app.hide()),
+        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () => remote.app.hide()),
 
         // Language service
         // TODO: Deprecate

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -50,6 +50,8 @@ export const registerBuiltInCommands = (commandManager: CommandManager, neovimIn
 
         new CallbackCommand("oni.editor.minimize", "Minimize Window", "Minimize the current window", () => remote.getCurrentWindow().minimize()),
 
+        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () => remote.getCurrentWindow().hide()),
+
         // Language service
         // TODO: Deprecate
         new CallbackCommand("oni.editor.findAllReferences", null, null, () => findAllReferences()),

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -195,6 +195,12 @@ app.on("window-all-closed", () => {
 app.on("activate", () => {
     // On OS X it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
+    const currentWindow: BrowserWindow = windows[windows.length - 1]
+
+    if (currentWindow) {
+        currentWindow.show()
+    }
+
     if (windows.length === 0) {
         createWindow([], process.cwd())
     }

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -12,6 +12,13 @@ export const buildDockMenu = (mainWindow, loadInit) => {
         },
     })
 
+    menu.push({
+        label: "Hide Window",
+        click(item, focusedWindow) {
+            focusedWindow.hide()
+        },
+    })
+
     return Menu.buildFromTemplate(menu)
 }
 
@@ -117,6 +124,12 @@ export const buildMenu = (mainWindow, loadInit) => {
                 label: "New Window",
                 click() {
                     createWindow([], process.cwd())
+                },
+            },
+            {
+                label: "Hide Window",
+                click(item, focusedWindow) {
+                    focusedWindow.hide()
                 },
             },
             {

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -12,13 +12,6 @@ export const buildDockMenu = (mainWindow, loadInit) => {
         },
     })
 
-    menu.push({
-        label: "Hide Window",
-        click(item, focusedWindow) {
-            focusedWindow.hide()
-        },
-    })
-
     return Menu.buildFromTemplate(menu)
 }
 


### PR DESCRIPTION
Add `Cmd-H` shortcut to hide oni window as well as a menu option fixes #1196 
 
@bryphe  whilst working on this I observed that when hitting the close button on oni the window is closed but the app remains open in a sense (which I believe we discussed previously is default mac behaviour) however on activate when then icon is clicked for example **after** closing with the button a new oni window is created, as part of this I realised that the close button could function as a hide button so that the reference to the window still exists and it can be reused on activate. This would also theoretically fix #1193 which I imagine is occuring because though the app is running there is no window to reference