### PR TITLE
Add tests for markdown preview

### DIFF
--- a/browser/src/Performance.ts
+++ b/browser/src/Performance.ts
@@ -1,28 +1,35 @@
 
+export interface IPerformance {
+    mark(markerName: string): void
+    startMeasure(measurementName: string): void
+    endMeasure(measurementName: string): void
+}
 /**
  * Thin wrapper around browser performance API
  */
-export function mark(markerName: string): void {
-    if (typeof window === "undefined") {
-        return
+export class Performance implements IPerformance {
+    public mark(markerName: string): void {
+        if (typeof window === "undefined") {
+            return
+        }
+
+        if (process.env.NODE_ENV === "production") {
+            return
+        }
+
+        performance.mark(markerName)
+
+        const anyConsole: any = console
+        anyConsole.timeStamp(markerName)
+
+        console.log(`[PERFORMANCE] ${markerName}: ${performance.now()}`) // tslint:disable-line no-console
     }
 
-    if (process.env.NODE_ENV === "production") {
-        return
+    public startMeasure(measurementName: string): void {
+        console.time(measurementName) // tslint:disable-line
     }
 
-    performance.mark(markerName)
-
-    const anyConsole: any = console
-    anyConsole.timeStamp(markerName)
-
-    console.log(`[PERFORMANCE] ${markerName}: ${performance.now()}`) // tslint:disable-line no-console
-}
-
-export const startMeasure = (measurementName: string): void => {
-    console.time(measurementName) // tslint:disable-line
-}
-
-export const endMeasure = (measurementName: string): void => {
-    console.timeEnd(measurementName) // tslint:disable-line
+    public endMeasure(measurementName: string): void {
+        console.timeEnd(measurementName) // tslint:disable-line
+    }
 }

--- a/browser/src/Plugins/Api/Capabilities.ts
+++ b/browser/src/Plugins/Api/Capabilities.ts
@@ -36,6 +36,7 @@ export interface IThemeContribution {
 export interface IPluginMetadata {
     name: string
     main: string
+    test: string
     engines: any
     contributes: IContributions
 }

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from "events"
 
 import * as OniApi from "oni-api"
 
-import * as Process from "./Process"
+import { Process, processManager } from "./Process"
 import { Services } from "./Services"
 import { Ui } from "./Ui"
 
@@ -52,6 +52,7 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
     private _ui: Ui
     private _services: Services
     private _colors: Colors
+    private _process: Process
 
     public get automation(): OniApi.Automation.Api {
         return automation
@@ -106,7 +107,7 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
     }
 
     public get process(): OniApi.Process {
-        return Process
+        return processManager
     }
 
     public get statusBar(): OniApi.StatusBar {
@@ -133,19 +134,21 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
         return helpers
     }
 
-    constructor() {
+    constructor(
+    ) {
         super()
         this._colors = getColors()
 
         this._dependencies = new Dependencies()
         this._ui = new Ui(react)
         this._services = new Services()
+        this._process = processManager
     }
 
     public async execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): Promise<ChildProcess.ChildProcess> {
         Log.warn("WARNING: `OniApi.execNodeScript` is deprecated. Please use `OniApi.process.execNodeScript` instead")
 
-        return await Process.execNodeScript(scriptPath, args, options, callback)
+        return await this._process.execNodeScript(scriptPath, args, options, callback)
     }
 
     /**
@@ -155,6 +158,6 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
 
         Log.warn("WARNING: `OniApi.spawnNodeScript` is deprecated. Please use `OniApi.process.spawnNodeScript` instead")
 
-        return await Process.spawnNodeScript(scriptPath, args, options)
+        return await this._process.spawnNodeScript(scriptPath, args, options)
     }
 }

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -1,88 +1,99 @@
 import * as ChildProcess from "child_process"
+import * as OniApi from "oni-api"
 
 import * as Log from "./../../Log"
 import * as Platform from "./../../Platform"
-import { configuration } from "./../../Services/Configuration"
+import { Configuration, configuration } from "./../../Services/Configuration"
 
-const getPathSeparator = () => {
-    return Platform.isWindows() ? ";" : ":"
-}
+export class Process implements OniApi.Process {
 
-const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[]): string => {
-    if (!pathsToAdd || !pathsToAdd.length) {
-        return currentPath
+    constructor(
+        private _configuration: Configuration,
+    ) {
     }
 
-    const separator = getPathSeparator()
-
-    const joinedPathsToAdd = pathsToAdd.join(separator)
-
-    return currentPath + separator + joinedPathsToAdd
-}
-
-const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
-    let existingPath: string
-
-    try {
-        const shellEnv = await import("shell-env")
-        const shellEnvironment = await shellEnv()
-        process.env = { ...process.env, ...shellEnvironment }
-        existingPath = process.env.Path || process.env.PATH
-    } catch (e) {
-        existingPath = process.env.Path || process.env.PATH
+    private getPathSeparator(): string {
+        return Platform.isWindows() ? ";" : ":"
     }
 
-    const requiredOptions = {
-        env: {
-            ...process.env,
-            ...originalSpawnOptions.env,
-        },
+    private mergePathEnvironmentVariable(currentPath: string, pathsToAdd: string[]): string {
+        if (!pathsToAdd || !pathsToAdd.length) {
+            return currentPath
+        }
+
+        const separator = this.getPathSeparator()
+
+        const joinedPathsToAdd = pathsToAdd.join(separator)
+
+        return currentPath + separator + joinedPathsToAdd
     }
 
-    requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))
+    private async mergeSpawnOptions(originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> {
+        let existingPath: string
 
-    return {
-        ...originalSpawnOptions,
-        ...requiredOptions,
+        try {
+            const shellEnv = await import("shell-env")
+            const shellEnvironment = await shellEnv()
+            process.env = { ...process.env, ...shellEnvironment }
+            existingPath = process.env.Path || process.env.PATH
+        } catch (e) {
+            existingPath = process.env.Path || process.env.PATH
+        }
+
+        const requiredOptions = {
+            env: {
+                ...process.env,
+                ...originalSpawnOptions.env,
+            },
+        }
+
+        requiredOptions.env.PATH = this.mergePathEnvironmentVariable(existingPath, this._configuration.getValue("environment.additionalPaths"))
+
+        return {
+            ...originalSpawnOptions,
+            ...requiredOptions,
+        }
+    }
+
+    /**
+     * API surface area responsible for handling process-related tasks
+     * (spawning processes, managing running process, etc)
+     */
+    public async execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): Promise<ChildProcess.ChildProcess> {
+        const spawnOptions = await this.mergeSpawnOptions(options)
+        spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
+
+        const execOptions = [process.execPath, scriptPath].concat(args)
+        const execString = execOptions.map((s) => `"${s}"`).join(" ")
+
+        return ChildProcess.exec(execString, spawnOptions, callback)
+    }
+
+    /**
+     * Wrapper around `child_process.exec` to run using electron as opposed to node
+     */
+    public async spawnNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> {
+        const spawnOptions = await this.mergeSpawnOptions(options)
+        spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
+
+        const allArgs = [scriptPath].concat(args)
+
+        return ChildProcess.spawn(process.execPath, allArgs, spawnOptions)
+    }
+
+    /**
+     * Spawn process - wrapper around `child_process.spawn`
+     */
+    public async spawnProcess(startCommand: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> {
+        const spawnOptions = await this.mergeSpawnOptions(options)
+
+        const proc = ChildProcess.spawn(startCommand, args, spawnOptions)
+        proc.on("error", (err: Error) => {
+            Log.error(err)
+        })
+
+        return proc
     }
 }
 
-/**
- * API surface area responsible for handling process-related tasks
- * (spawning processes, managing running process, etc)
- */
-export const execNodeScript = async (scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): Promise<ChildProcess.ChildProcess> => {
-    const spawnOptions = await mergeSpawnOptions(options)
-    spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
-
-    const execOptions = [process.execPath, scriptPath].concat(args)
-    const execString = execOptions.map((s) => `"${s}"`).join(" ")
-
-    return ChildProcess.exec(execString, spawnOptions, callback)
-}
-
-/**
- * Wrapper around `child_process.exec` to run using electron as opposed to node
- */
-export const spawnNodeScript = async (scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> => {
-    const spawnOptions = await mergeSpawnOptions(options)
-    spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
-
-    const allArgs = [scriptPath].concat(args)
-
-    return ChildProcess.spawn(process.execPath, allArgs, spawnOptions)
-}
-
-/**
- * Spawn process - wrapper around `child_process.spawn`
- */
-export const spawnProcess = async (startCommand: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> => {
-    const spawnOptions = await mergeSpawnOptions(options)
-
-    const proc = ChildProcess.spawn(startCommand, args, spawnOptions)
-    proc.on("error", (err: Error) => {
-        Log.error(err)
-    })
-
-    return proc
-    }
+export const processManager = new Process(configuration)

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -4,30 +4,36 @@ import * as path from "path"
 
 import * as Oni from "oni-api"
 
-import { configuration } from "./../Services/Configuration"
+import { Configuration, configuration } from "./../Services/Configuration"
 
 import { AnonymousPlugin } from "./AnonymousPlugin"
 import { Plugin } from "./Plugin"
 
-const corePluginsRoot = path.join(__dirname, "vim", "core")
-const defaultPluginsRoot = path.join(__dirname, "vim", "default")
-const extensionsRoot = path.join(__dirname, "extensions")
-
 export class PluginManager extends EventEmitter {
-    private _config = configuration
     private _rootPluginPaths: string[] = []
     private _plugins: Plugin[] = []
     private _anonymousPlugin: AnonymousPlugin
+
+    constructor(
+        private _config: Configuration,
+        private _basePath: string,
+    ) {
+        super()
+    }
 
     public get plugins(): Plugin[] {
         return this._plugins
     }
 
     public discoverPlugins(): void {
+        const corePluginsRoot = path.join(this._basePath, "vim", "core")
         this._rootPluginPaths.push(corePluginsRoot)
+
+        const extensionsRoot = path.join(this._basePath, "extensions")
         this._rootPluginPaths.push(extensionsRoot)
 
         if (this._config.getValue("oni.useDefaultConfig")) {
+            const defaultPluginsRoot = path.join(this._basePath, "vim", "default")
             this._rootPluginPaths.push(defaultPluginsRoot)
             this._rootPluginPaths.push(path.join(defaultPluginsRoot, "bundle"))
         }
@@ -70,7 +76,7 @@ export class PluginManager extends EventEmitter {
     }
 }
 
-export const pluginManager = new PluginManager()
+export const pluginManager = new PluginManager(configuration, __dirname)
 
 function getDirectories(rootPath: string): string[] {
     if (!fs.existsSync(rootPath)) {

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -1,6 +1,6 @@
 import { Grid } from "./../Grid"
 import { ICell, IScreen } from "./../neovim"
-import * as Performance from "./../Performance"
+import { Performance } from "./../Performance"
 import { INeovimRenderer } from "./INeovimRenderer"
 import { getSpansToEdit, IPosition, ISpan } from "./Span"
 
@@ -54,6 +54,8 @@ export class CanvasRenderer implements INeovimRenderer {
     private _lastRenderGrid: Grid<ICell> = new Grid<ICell>()
     private _grid: Grid<ISpan> = new Grid<ISpan>()
     private _devicePixelRatio: number
+
+    private _performance = new Performance()
 
     public start(element: HTMLDivElement): void {
         this._editorElement = element
@@ -109,7 +111,7 @@ export class CanvasRenderer implements INeovimRenderer {
     }
 
     public _draw(screenInfo: IScreen, modifiedCells: IPosition[]): void {
-        Performance.mark("CanvasRenderer.update.start")
+        this._performance.mark("CanvasRenderer.update.start")
 
         this._canvasContext.font = screenInfo.fontSize + " " + screenInfo.fontFamily
         this._canvasContext.textBaseline = "top"
@@ -168,7 +170,7 @@ export class CanvasRenderer implements INeovimRenderer {
             })
         }
 
-        Performance.mark("CanvasRenderer.update.end")
+        this._performance.mark("CanvasRenderer.update.end")
     }
 
     private _renderSpan(span: ISpan, y: number, screenInfo: IScreen): void {

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -10,9 +10,9 @@ import * as OniApi from "oni-api"
 
 import * as Utility from "./../Utility"
 
-import { configuration } from "./Configuration"
-import { editorManager } from "./EditorManager"
-import { inputManager } from "./InputManager"
+import { Configuration, configuration } from "./Configuration"
+import { EditorManager, editorManager } from "./EditorManager"
+import { InputManager, inputManager } from "./InputManager"
 
 import * as Log from "./../Log"
 import * as Shell from "./../UI/Shell"
@@ -26,12 +26,19 @@ import { Oni } from "./../Plugins/Api/Oni"
 
 export class Automation implements OniApi.Automation.Api {
 
+    constructor(
+        private _configuration: Configuration,
+        private _editorManager: EditorManager,
+        private _inputManager: InputManager,
+    ) {
+    }
+
     public sendKeys(keys: string): void {
         Log.info("[AUTOMATION] Sending keys: " + keys)
 
-        if (!inputManager.handleKey(keys)) {
+        if (!this._inputManager.handleKey(keys)) {
             Log.info("[AUTOMATION] InputManager did not handle key: " + keys)
-            const anyEditor: any = editorManager.activeEditor as any
+            const anyEditor: any = this._editorManager.activeEditor as any
             anyEditor._onKeyDown(keys)
         }
     }
@@ -76,7 +83,7 @@ export class Automation implements OniApi.Automation.Api {
         Log.info("[AUTOMATION] Startup complete!")
 
         Log.info("[AUTOMATION] Waiting for neovim to attach...")
-        await this.waitFor(() => editorManager.activeEditor.neovim && (editorManager.activeEditor as any).neovim.isInitialized, 30000)
+        await this.waitFor(() => this._editorManager.activeEditor.neovim && (this._editorManager.activeEditor as any).neovim.isInitialized, 30000)
         Log.info("[AUTOMATION] Neovim attached!")
     }
 
@@ -90,7 +97,7 @@ export class Automation implements OniApi.Automation.Api {
         Log.enableVerboseLogging()
         try {
             Log.info("[AUTOMATION] Starting test: " + testPath)
-            Log.info("[AUTOMATION] Configuration path: " + configuration.userJsConfig)
+            Log.info("[AUTOMATION] Configuration path: " + this._configuration.userJsConfig)
             const testCase: any = Utility.nodeRequire(testPath2)
             const oni = new Oni()
 
@@ -157,7 +164,7 @@ export class Automation implements OniApi.Automation.Api {
     }
 }
 
-export const automation = new Automation()
+export const automation = new Automation(configuration, editorManager, inputManager)
 
 class LoggingRedirector {
 

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -8,7 +8,7 @@ import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 import { applyDefaultKeyBindings } from "./../../Input/KeyBindings"
 import * as Log from "./../../Log"
-import * as Performance from "./../../Performance"
+import { IPerformance, Performance } from "./../../Performance"
 import * as Platform from "./../../Platform"
 import { diff } from "./../../Utility"
 
@@ -23,6 +23,11 @@ export class Configuration implements Oni.Configuration {
     private _configEverHadValue: boolean = false
 
     private _setValues: { [configValue: string]: any } = { }
+
+    constructor(
+        private _performance: IPerformance,
+    ) {
+    }
 
     public get userJsConfig(): string {
 
@@ -40,7 +45,7 @@ export class Configuration implements Oni.Configuration {
     }
 
     public start(): void {
-        Performance.mark("Config.load.start")
+        this._performance.mark("Config.load.start")
 
         this.applyConfig()
 
@@ -64,7 +69,7 @@ export class Configuration implements Oni.Configuration {
             }
         })
 
-        Performance.mark("Config.load.end")
+        this._performance.mark("Config.load.end")
     }
 
     public hasValue(configValue: keyof IConfigurationValues): boolean {
@@ -198,4 +203,4 @@ export class Configuration implements Oni.Configuration {
     }
 }
 
-export const configuration = new Configuration()
+export const configuration = new Configuration(new Performance())

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -218,7 +218,7 @@ const LinuxConfigOverrides: Partial<IConfigurationValues> = {
 
 const PlatformConfigOverride = Platform.isWindows() ? WindowsConfigOverrides : Platform.isLinux() ? LinuxConfigOverrides : MacConfigOverrides
 
-export const DefaultConfiguration = {
+export const DefaultConfiguration: IConfigurationValues = {
     ...BaseConfiguration,
     ...PlatformConfigOverride,
 }

--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -1,7 +1,7 @@
 
 import * as Oni from "oni-api"
 
-import { commandManager } from "./CommandManager"
+import { CommandManager, commandManager } from "./CommandManager"
 
 export type ActionFunction = () => boolean
 
@@ -21,6 +21,11 @@ export interface KeyBindingMap {
 export class InputManager implements Oni.InputManager {
 
     private _boundKeys: KeyBindingMap = {}
+
+    constructor(
+        private _commandManager: CommandManager,
+    ) {
+    }
 
     /**
      * API Methods
@@ -91,7 +96,7 @@ export class InputManager implements Oni.InputManager {
 
             const action = binding.action
             if (typeof action === "string") {
-                const result = commandManager.executeCommand(action, null)
+                const result = this._commandManager.executeCommand(action, null)
 
                 if (result !== false) {
                     return true
@@ -109,4 +114,4 @@ export class InputManager implements Oni.InputManager {
     }
 }
 
-export const inputManager = new InputManager()
+export const inputManager = new InputManager(commandManager)

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -24,7 +24,7 @@ import { LanguageClientLogger } from "./../../Plugins/Api/LanguageClient/Languag
 
 import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
-import * as Process from "./../../Plugins/Api/Process"
+import { processManager } from "./../../Plugins/Api/Process"
 
 import { IServerCapabilities } from "./ServerCapabilities"
 
@@ -113,10 +113,10 @@ export class LanguageClientProcess {
 
         if (this._serverOptions.command) {
             Log.info(`[LanguageClientProcess]: Starting process via '${this._serverOptions.command}'`)
-            this._process = await Process.spawnProcess(this._serverOptions.command, args, options)
+            this._process = await processManager.spawnProcess(this._serverOptions.command, args, options)
         } else if (this._serverOptions.module) {
             Log.info(`[LanguageClientProcess]: Starting process via node script '${this._serverOptions.module}'`)
-            this._process = await Process.spawnNodeScript(this._serverOptions.module, args, options)
+            this._process = await processManager.spawnNodeScript(this._serverOptions.module, args, options)
         } else {
             throw new Error("A command or module must be specified to start the server")
         }

--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -71,7 +71,7 @@ export class StatusBarItem implements Oni.StatusBarItem {
     }
 }
 
-class StatusBar implements Oni.StatusBar {
+export class StatusBar implements Oni.StatusBar {
     private _id: number = 0
 
     public getItem(globalId: string): Oni.StatusBarItem {

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -16,7 +16,7 @@ import * as flatten from "lodash/flatten"
 
 import * as Oni from "oni-api"
 
-import { Menu, menuManager } from "./../Services/Menu"
+import { Menu, MenuManager, menuManager } from "./../Services/Menu"
 
 export interface ITask {
     name: string
@@ -38,6 +38,12 @@ export class Tasks extends EventEmitter {
 
     private _providers: ITaskProvider[] = []
 
+    constructor(
+        private _menuManager: MenuManager,
+    ) {
+        super()
+    }
+
     // TODO: This should be refactored, as it is simply
     // a timing dependency on when the object is created versus when
     // it is shown.
@@ -57,7 +63,7 @@ export class Tasks extends EventEmitter {
                             }
                         })
 
-            this._menu = menuManager.create()
+            this._menu = this._menuManager.create()
             this._menu.onItemSelected.subscribe((selection: any) => this._onItemSelected(selection))
             this._menu.show()
             this._menu.setItems(options)
@@ -89,4 +95,4 @@ export class Tasks extends EventEmitter {
     }
 }
 
-export const tasks = new Tasks()
+export const tasks = new Tasks(menuManager)

--- a/browser/src/Services/Workspace.ts
+++ b/browser/src/Services/Workspace.ts
@@ -18,11 +18,16 @@ import { Event, IEvent } from "oni-types"
 import * as Log from "./../Log"
 import * as Helpers from "./../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
-import { editorManager } from "./EditorManager"
+import { EditorManager, editorManager } from "./EditorManager"
 import { convertTextDocumentEditsToFileMap } from "./Language/Edits"
 
 export class Workspace implements Oni.Workspace {
     private _onDirectoryChangedEvent = new Event<string>()
+
+    constructor(
+        private _editorManager: EditorManager,
+    ) {
+    }
 
     public get onDirectoryChanged(): IEvent<string> {
         return this._onDirectoryChangedEvent
@@ -43,7 +48,7 @@ export class Workspace implements Oni.Workspace {
         const files = Object.keys(editsToUse)
 
         // TODO: Show modal to grab input
-        // await editorManager.activeEditor.openFiles(files)
+        // await this._editorManager.activeEditor.openFiles(files)
 
         const deferredEdits = await files.map((fileUri: string) => {
             return Observable.defer(async () => {
@@ -51,7 +56,7 @@ export class Workspace implements Oni.Workspace {
                 const fileName = Helpers.unwrapFileUriPath(fileUri)
                 // TODO: Sort changes?
                 Log.verbose("[Workspace] Opening file: " + fileName)
-                const buf = await editorManager.activeEditor.openFile(fileName)
+                const buf = await this._editorManager.activeEditor.openFile(fileName)
                 Log.verbose("[Workspace] Got buffer for file: " + buf.filePath + " and id: " + buf.id)
                 await buf.applyTextEdits(changes)
                 Log.verbose("[Workspace] Applied " + changes.length + " edits to buffer")
@@ -68,4 +73,4 @@ export class Workspace implements Oni.Workspace {
     }
 }
 
-export const workspace = new Workspace()
+export const workspace = new Workspace(editorManager)

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -3,7 +3,7 @@ import * as net from "net"
 import * as path from "path"
 
 import * as Platform from "./../Platform"
-import { spawnProcess } from "./../Plugins/Api/Process"
+import { processManager } from "./../Plugins/Api/Process"
 import { configuration } from "./../Services/Configuration"
 
 import { Session } from "./Session"
@@ -87,7 +87,7 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
     const argsToPass = initVimArg
         .concat(["--cmd", `let &rtp.=',${joinedRuntimePaths}'`, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
 
-    const nvimProc = await spawnProcess(nvimProcessPath, argsToPass, {})
+    const nvimProc = await processManager.spawnProcess(nvimProcessPath, argsToPass, {})
 
     console.log(`Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
 

--- a/browser/test/Input/InputManagerTests.ts
+++ b/browser/test/Input/InputManagerTests.ts
@@ -1,12 +1,13 @@
 import * as assert from "assert"
 
 import { InputManager } from "./../../src/Services/InputManager"
+import { CommandManager } from "./../../src/Services/CommandManager"
 
 describe("InputManager", () => {
     describe("bind", () => {
         it("adds a key handler", () => {
 
-            const im = new InputManager()
+            const im = new InputManager(new CommandManager())
 
             let count = 0
             im.bind("<c-a>", () => { count++; return true })
@@ -19,7 +20,7 @@ describe("InputManager", () => {
         })
 
         it("removes key handler when calling dispose", () => {
-            const im = new InputManager()
+            const im = new InputManager(new CommandManager())
 
             let count = 0
             const dispose = im.bind("<c-a>", () => { count++; return true })
@@ -32,7 +33,7 @@ describe("InputManager", () => {
         })
 
         it("dispose key handler is robust if unbindAll was called first", () => {
-            const im = new InputManager()
+            const im = new InputManager(new CommandManager())
 
             let count = 0
             const dispose = im.bind("{", () => { count++; return true })

--- a/browser/test/Mocks/Performance.ts
+++ b/browser/test/Mocks/Performance.ts
@@ -1,0 +1,19 @@
+/**
+ * Mocks/Performance.ts
+ *
+ * Implementations of test mocks and doubles,
+ * for Oni's IPerformance interface.
+ */
+
+import { IPerformance } from "./../../src/Performance"
+
+export class MockPerformance implements IPerformance {
+    public mark(markerName: string): void {
+    }
+
+    public startMeasure(measurementName: string): void {
+    }
+
+    public endMeasure(measurementName: string): void {
+    }
+}

--- a/browser/test/Mocks/oni.ts
+++ b/browser/test/Mocks/oni.ts
@@ -1,0 +1,133 @@
+/**
+ * Mocks/oni.ts
+ *
+ * Implementations of test mocks and doubles,
+ * for Oni's API interface.
+ */
+
+import { EventEmitter } from "events"
+import * as OniApi from "oni-api"
+
+import { Automation } from "./../../src/Services/Automation"
+import { Colors } from "./../../src/Services/Colors"
+import { CommandManager } from "./../../src/Services/CommandManager"
+import { Configuration } from "./../../src/Services/Configuration"
+import { DiagnosticsDataSource } from "./../../src/Services/Diagnostics"
+import { EditorManager } from "./../../src/Services/EditorManager"
+import { InputManager } from "./../../src/Services/InputManager"
+import { ThemeManager } from "./../../src/Services/Themes/ThemeManager"
+import { MenuManager } from "./../../src/Services/Menu"
+import { Process } from "./../../src/Plugins/Api/Process"
+import { StatusBar } from "./../../src/Services/StatusBar"
+import { Workspace } from "./../../src/Services/Workspace"
+import { WindowManager } from "./../../src/Services/WindowManager"
+
+import { MockPerformance } from "./Performance"
+
+export class OniMock extends EventEmitter implements OniApi.Plugin.Api {
+    private _configuration: Configuration
+    private _commandManager: CommandManager
+    private _editorManager: EditorManager
+    private _statusBar: StatusBar
+    private _windowManager: WindowManager
+    private _menuManager: MenuManager
+    private _diagnosticsDataSource: DiagnosticsDataSource
+    private _colors: Colors
+    private _inputManager: InputManager
+    private _processManager: Process
+    private _workspace: Workspace
+    private _automation: Automation
+
+    constructor() {
+        super()
+
+        const performance = new MockPerformance()
+        const themeManager = new ThemeManager()
+        const configuration = new Configuration(performance)
+        configuration.start()
+        const commandManager = new CommandManager()
+        const editorManager = new EditorManager()
+        const statusBar = new StatusBar()
+        const windowManager = new WindowManager()
+        const menuManager = new MenuManager()
+        const diagnosticsDataSource = new DiagnosticsDataSource()
+        const colors = new Colors(configuration, themeManager)
+        const inputManager = new InputManager(commandManager)
+        const processManager = new Process(configuration)
+        const workspace = new Workspace(editorManager)
+        const automation = new Automation(configuration, editorManager, inputManager)
+
+        this._automation = automation
+        this._colors = colors
+        this._commandManager = commandManager
+        this._configuration = configuration
+        this._diagnosticsDataSource = diagnosticsDataSource
+        this._editorManager = editorManager
+        this._inputManager = inputManager
+        this._menuManager = menuManager
+        this._processManager = processManager
+        this._statusBar = statusBar
+        this._workspace = workspace
+        this._windowManager = windowManager
+    }
+
+    public get automation(): OniApi.Automation.Api {
+        return this._automation
+    }
+
+    public get colors(): OniApi.IColors {
+        return this._colors
+    }
+
+    public get commands(): OniApi.Commands {
+        return this._commandManager
+    }
+
+    public get configuration(): OniApi.Configuration {
+        return this._configuration
+    }
+
+    public get contextMenu(): any {
+        return null
+    }
+
+    public get diagnostics(): OniApi.Plugin.Diagnostics.Api {
+        return this._diagnosticsDataSource
+    }
+
+    public get editors(): OniApi.EditorManager {
+        return this._editorManager
+    }
+
+    public get input(): OniApi.InputManager {
+        return this._inputManager
+    }
+
+    public get language(): any {
+        return null
+    }
+
+    public get log(): OniApi.Log {
+        return null
+    }
+
+    public get menu(): any {
+        return this._menuManager
+    }
+
+    public get process(): OniApi.Process {
+        return this._processManager
+    }
+
+    public get statusBar(): OniApi.StatusBar {
+        return this._statusBar
+    }
+
+    public get workspace(): OniApi.Workspace {
+        return this._workspace
+    }
+
+    public get windows(): OniApi.IWindowManager {
+        return this._windowManager
+    }
+}

--- a/browser/test/PluginsTests.ts
+++ b/browser/test/PluginsTests.ts
@@ -1,0 +1,20 @@
+import * as path from "path"
+
+import { PluginManager } from "./../src/Plugins/PluginManager"
+import { Configuration } from "./../src/Services/Configuration"
+
+import { MockPerformance } from "./Mocks/Performance"
+
+const config = new Configuration(new MockPerformance())
+config.start()
+
+const pluginManager = new PluginManager(config, path.join(__dirname, '..', '..', '..'))
+pluginManager.discoverPlugins()
+
+for (let plugin of pluginManager.plugins) {
+    if (plugin.hasTest()) {
+        describe(`PLUGIN ${plugin.name}`, () => {
+            plugin.test()
+        })
+    }
+}

--- a/extensions/oni-plugin-markdown-preview/package.json
+++ b/extensions/oni-plugin-markdown-preview/package.json
@@ -2,6 +2,7 @@
   "name": "oni-plugin-markdown-preview",
   "version": "0.0.1",
   "main": "lib/index.js",
+  "test": "lib/test.js",
   "engines": {
     "oni": "^0.0.1"
   },

--- a/extensions/oni-plugin-markdown-preview/src/index.tsx
+++ b/extensions/oni-plugin-markdown-preview/src/index.tsx
@@ -1,4 +1,4 @@
-import { Event, EventCallback, IDisposable, IEvent } from "oni-types"
+import { EventCallback, IDisposable, IEvent } from "oni-types"
 
 import * as dompurify from "dompurify"
 import * as marked from "marked"

--- a/extensions/oni-plugin-markdown-preview/src/test.ts
+++ b/extensions/oni-plugin-markdown-preview/src/test.ts
@@ -1,0 +1,233 @@
+//import * as assert from "assert"
+
+import * as MarkdownPreview from "./index"
+
+import * as OniApi from "oni-api"
+
+export const test = (oni: OniApi.Plugin.Api): void => {
+    it("no error", () => {
+        //
+    })
+    //throw Error("This is my test")
+    //MarkdownPreview.activate(oni)
+}
+
+/*
+describe("MarkdownPreview", () => {
+    describe("activate", () => {
+        it("returns empty if the string doesn't have whitespace", () => {
+            const result = AutoClosingPairs.getWhiteSpacePrefix("test")
+            assert.strictEqual(result, "")
+        })
+
+        it("returns tab", () => {
+            const result = AutoClosingPairs.getWhiteSpacePrefix("\ttest")
+            assert.strictEqual(result, "\t")
+        })
+
+        it("returns spaces", () => {
+            const result = AutoClosingPairs.getWhiteSpacePrefix("  test")
+            assert.strictEqual(result, "  ")
+        })
+    })
+})
+*/
+
+
+
+/*
+describe(`PLUGIN ${plugin._oniPluginMetadata.name}`, () => {
+    it("getCell returns correct value", () => {
+        const grid = new Grid<string>()
+
+        grid.setCell(1, 1, "a")
+
+        assert.strictEqual(grid.getCell(0, 0), null)
+        assert.strictEqual(grid.getCell(1, 1), "a")
+    })
+
+    it("width and height are 0 by default", () => {
+        const grid = new Grid<void>()
+
+        assert.strictEqual(grid.width, 0)
+        assert.strictEqual(grid.height, 0)
+    })
+
+    describe("shift", () => {
+        it("shift(0) does not shift", () => {
+            const val = [
+                [1, 2],
+                [3, 4],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+            startGrid.shiftRows(0)
+            assertGridValues(startGrid, val)
+        })
+
+        it("shift(1) shifts upwards", () => {
+            const val = [
+                [1, 2],
+                [3, 4],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+            startGrid.shiftRows(1)
+
+            const expectedOutput = [
+                [3, 4],
+                [null, null],
+            ]
+            assertGridValues(startGrid, expectedOutput)
+        })
+
+        it("shift(-1) shifts downwards", () => {
+            const val = [
+                [1, 2],
+                [3, 4],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+            startGrid.shiftRows(-1)
+
+            const expectedOutput = [
+                [null, null],
+                [1, 2],
+            ]
+            assertGridValues(startGrid, expectedOutput)
+        })
+    })
+
+    describe("setRegion", () => {
+        it("sets value", () => {
+
+            const val = [
+                [1, 2],
+                [3, 4],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+
+            startGrid.setRegion(0, 0, 2, 2, 5)
+
+            const expectedVal = [
+                [5, 5],
+                [5, 5],
+            ]
+
+            assertGridValues(startGrid, expectedVal)
+        })
+
+        it("sets null correctly", () => {
+            const val = [
+                [1, 2, 3],
+                [3, 4, 5],
+                [6, 7, 8],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+
+            startGrid.setRegion(0, 0, 2, 2, null)
+
+            const expectedOuput = [
+                [null, null, 3],
+                [null, null, 5],
+                [6, 7, 8],
+            ]
+
+            assertGridValues(startGrid, expectedOuput)
+        })
+    })
+
+    describe("cloneRegion", () => {
+        it("returns new grid for single item", () => {
+            const val = [
+                [1, 2],
+                [3, 4],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+
+            const topLeftGrid = startGrid.cloneRegion(0, 0, 1, 1)
+            assert.strictEqual(topLeftGrid.width, 1)
+            assert.strictEqual(topLeftGrid.height, 1)
+            assert.strictEqual(topLeftGrid.getCell(0, 0), 1)
+
+            const bottomRightGrid = startGrid.cloneRegion(1, 1, 1, 1)
+            assert.strictEqual(bottomRightGrid.width, 1)
+            assert.strictEqual(bottomRightGrid.height, 1)
+            assert.strictEqual(bottomRightGrid.getCell(0, 0), 4)
+        })
+
+        it("returns square subsection", () => {
+            const val = [
+                [1, 2, 3],
+                [3, 4, 5],
+                [6, 7, 8],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+
+            const topLeftGrid = startGrid.cloneRegion(0, 0, 2, 2)
+            assert.strictEqual(topLeftGrid.width, 2)
+            assert.strictEqual(topLeftGrid.height, 2)
+
+            const expectedOutput = [
+                [1, 2],
+                [3, 4],
+            ]
+
+            assertGridValues(topLeftGrid, expectedOutput)
+        })
+
+        it("handles null & undefined correctly", () => {
+            const val = [
+                [null, undefined, 3],
+                [0, 1, 5],
+                [6, 7, 8],
+            ]
+
+            const startGrid = createGridFromNestedArray(val)
+            const outGrid = startGrid.cloneRegion(0, 0, 2, 2)
+
+            const expectedOutput = [
+                [null, null],
+                [0, 1],
+            ]
+
+            assertGridValues(outGrid, expectedOutput)
+        })
+    })
+})
+
+function createGridFromNestedArray<T>(array: T[][]): Grid<T> {
+
+    const grid = new Grid<T>()
+
+    for (let row = 0; row < array.length; row++) {
+        const rowItems = array[row]
+
+        for (let col = 0; col < rowItems.length; col++) {
+            const colItem = rowItems[col]
+
+            grid.setCell(col, row, colItem)
+        }
+    }
+
+    return grid
+}
+
+function assertGridValues<T>(grid: Grid<T>, array: T[][]): void {
+
+    for (let row = 0; row < array.length; row++) {
+        const rowItems = array[row]
+
+        for (let col = 0; col < rowItems.length; col++) {
+            // var colItem = rowItems[col]
+
+            const item = grid.getCell(col, row)
+            assert.strictEqual(item, array[row][col], `Validate item at row: ${row} and ${col}`)
+        }
+    }
+}
+*/

--- a/extensions/oni-plugin-markdown-preview/src/test.ts
+++ b/extensions/oni-plugin-markdown-preview/src/test.ts
@@ -1,233 +1,42 @@
-//import * as assert from "assert"
+import * as assert from "assert"
 
 import * as MarkdownPreview from "./index"
 
 import * as OniApi from "oni-api"
 
 export const test = (oni: OniApi.Plugin.Api): void => {
-    it("no error", () => {
-        //
-    })
-    //throw Error("This is my test")
-    //MarkdownPreview.activate(oni)
-}
+    //const splitRoot = oni.windows.splitRoot;
 
-/*
-describe("MarkdownPreview", () => {
+    describe("initially", () => {
+        it("has only one split", () => {
+            //assert.strictEqual(splitRoot.leaves.length, 1)
+        })
+    })
+
     describe("activate", () => {
-        it("returns empty if the string doesn't have whitespace", () => {
-            const result = AutoClosingPairs.getWhiteSpacePrefix("test")
-            assert.strictEqual(result, "")
-        })
+        MarkdownPreview.activate(oni)
 
-        it("returns tab", () => {
-            const result = AutoClosingPairs.getWhiteSpacePrefix("\ttest")
-            assert.strictEqual(result, "\t")
-        })
+        describe("open an empty markdown file", () => {
+            oni.automation.sendKeys(":e markdown-preview-test.md")
 
-        it("returns spaces", () => {
-            const result = AutoClosingPairs.getWhiteSpacePrefix("  test")
-            assert.strictEqual(result, "  ")
-        })
-    })
-})
-*/
+            it("opens a new preview split", () => {
+                //assert.strictEqual(splitRoot.leaves.length, 2)
+            })
 
+            describe("the markdown-preview split", () => {
+                it("has no text", () => {
+                    // assert.strictEqual(splitRoot.leaves[1].content.text.trim(), "")
+                })
+            })
 
-
-/*
-describe(`PLUGIN ${plugin._oniPluginMetadata.name}`, () => {
-    it("getCell returns correct value", () => {
-        const grid = new Grid<string>()
-
-        grid.setCell(1, 1, "a")
-
-        assert.strictEqual(grid.getCell(0, 0), null)
-        assert.strictEqual(grid.getCell(1, 1), "a")
-    })
-
-    it("width and height are 0 by default", () => {
-        const grid = new Grid<void>()
-
-        assert.strictEqual(grid.width, 0)
-        assert.strictEqual(grid.height, 0)
-    })
-
-    describe("shift", () => {
-        it("shift(0) does not shift", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-            startGrid.shiftRows(0)
-            assertGridValues(startGrid, val)
-        })
-
-        it("shift(1) shifts upwards", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-            startGrid.shiftRows(1)
-
-            const expectedOutput = [
-                [3, 4],
-                [null, null],
-            ]
-            assertGridValues(startGrid, expectedOutput)
-        })
-
-        it("shift(-1) shifts downwards", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-            startGrid.shiftRows(-1)
-
-            const expectedOutput = [
-                [null, null],
-                [1, 2],
-            ]
-            assertGridValues(startGrid, expectedOutput)
+            describe("with Markdown title", () => {
+                oni.automation.sendKeys("i# Title 1")
+                it("has a Header element", () => {
+                    // const headers = splitRoot.leaves[1].content.getElements("h1")
+                    // assert.strictEqual(headers.length, 1)
+                    // assert.strictEqual(headers[0].text.trim(), "Title 1")
+                })
+            })
         })
     })
-
-    describe("setRegion", () => {
-        it("sets value", () => {
-
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-
-            startGrid.setRegion(0, 0, 2, 2, 5)
-
-            const expectedVal = [
-                [5, 5],
-                [5, 5],
-            ]
-
-            assertGridValues(startGrid, expectedVal)
-        })
-
-        it("sets null correctly", () => {
-            const val = [
-                [1, 2, 3],
-                [3, 4, 5],
-                [6, 7, 8],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-
-            startGrid.setRegion(0, 0, 2, 2, null)
-
-            const expectedOuput = [
-                [null, null, 3],
-                [null, null, 5],
-                [6, 7, 8],
-            ]
-
-            assertGridValues(startGrid, expectedOuput)
-        })
-    })
-
-    describe("cloneRegion", () => {
-        it("returns new grid for single item", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-
-            const topLeftGrid = startGrid.cloneRegion(0, 0, 1, 1)
-            assert.strictEqual(topLeftGrid.width, 1)
-            assert.strictEqual(topLeftGrid.height, 1)
-            assert.strictEqual(topLeftGrid.getCell(0, 0), 1)
-
-            const bottomRightGrid = startGrid.cloneRegion(1, 1, 1, 1)
-            assert.strictEqual(bottomRightGrid.width, 1)
-            assert.strictEqual(bottomRightGrid.height, 1)
-            assert.strictEqual(bottomRightGrid.getCell(0, 0), 4)
-        })
-
-        it("returns square subsection", () => {
-            const val = [
-                [1, 2, 3],
-                [3, 4, 5],
-                [6, 7, 8],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-
-            const topLeftGrid = startGrid.cloneRegion(0, 0, 2, 2)
-            assert.strictEqual(topLeftGrid.width, 2)
-            assert.strictEqual(topLeftGrid.height, 2)
-
-            const expectedOutput = [
-                [1, 2],
-                [3, 4],
-            ]
-
-            assertGridValues(topLeftGrid, expectedOutput)
-        })
-
-        it("handles null & undefined correctly", () => {
-            const val = [
-                [null, undefined, 3],
-                [0, 1, 5],
-                [6, 7, 8],
-            ]
-
-            const startGrid = createGridFromNestedArray(val)
-            const outGrid = startGrid.cloneRegion(0, 0, 2, 2)
-
-            const expectedOutput = [
-                [null, null],
-                [0, 1],
-            ]
-
-            assertGridValues(outGrid, expectedOutput)
-        })
-    })
-})
-
-function createGridFromNestedArray<T>(array: T[][]): Grid<T> {
-
-    const grid = new Grid<T>()
-
-    for (let row = 0; row < array.length; row++) {
-        const rowItems = array[row]
-
-        for (let col = 0; col < rowItems.length; col++) {
-            const colItem = rowItems[col]
-
-            grid.setCell(col, row, colItem)
-        }
-    }
-
-    return grid
 }
-
-function assertGridValues<T>(grid: Grid<T>, array: T[][]): void {
-
-    for (let row = 0; row < array.length; row++) {
-        const rowItems = array[row]
-
-        for (let col = 0; col < rowItems.length; col++) {
-            // var colItem = rowItems[col]
-
-            const item = grid.getCell(col, row)
-            assert.strictEqual(item, array[row][col], `Validate item at row: ${row} and ${col}`)
-        }
-    }
-}
-*/


### PR DESCRIPTION
So, for the past few days I worked on making plugins testable (with the `Markdown-preview` plugin as a test subject) using a mock for `Oni` itself.

@bryphe, I currently seek feedback.

The goal is to have tests for the **behavior** of the plugin itself, assuming `Oni` works correctly.

The changes in this PR contains:

- Refactoring singleton usage (received at construction time)
- Make a mock `Oni` class for plugins' tests
- Add plugin's test-runner
- Add commented-out tests I would like to implement for the Markdown-preview plugin

In addition, what do you think about:
1. The general approach taken in the PR (please code-review)
2. Taking a step forward in refactoring the singleton-usage by eliminating the singletons' `export`
3. Move more `type`-'s, `enum`-'s & `interface`-'s to the API in order to implement the behavior tests (should also be useful for implementing other plugins)