### PR TITLE
Fixes default config json syntax.

### DIFF
--- a/configuration/config.default.js
+++ b/configuration/config.default.js
@@ -29,7 +29,7 @@ module.exports = {
    "ui.colorscheme": "onedark",
 
    //"oni.useDefaultConfig": true,
-   //"oni.bookmarks": ["~/Documents",]
+   //"oni.bookmarks": ["~/Documents"],
    //"oni.loadInitVim": false,
    //"editor.fontSize": "14px",
    //"editor.fontFamily": "Monaco"


### PR DESCRIPTION
Before, when uncommenting the `oni.bookmarks` option, 
the next configuration line option you uncomment will cause parsing the config file to fail.