### PR TITLE
Remove default command line icon/Add Octicons

### DIFF
--- a/browser/src/UI/Icon.tsx
+++ b/browser/src/UI/Icon.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import Octicon, { OcticonSymbol } from "react-component-octicons"
 
 export const Default = ""
 export const Large = "fa-lg"
@@ -20,6 +21,14 @@ export interface IconProps {
     name: string
     size?: IconSize
     className?: string
+}
+
+interface OcticonProps {
+    name?: OcticonSymbol
+}
+
+export function OcticonIcon(props: OcticonProps) {
+        return <Octicon name={props.name}/>
 }
 
 export class Icon extends React.PureComponent<IconProps, {}> {

--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -128,12 +128,6 @@ class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> 
                     <CommandLineIcon name="search" key={`${character}-search`} />,
                     <CommandLineIcon arrow name="arrow-right" key={`${character}-arrow-right`} />,
                 ]
-            case ":":
-                return (
-                    <IconContainer>
-                        <CommandLineIcon name="terminal" octicon />
-                    </IconContainer>
-                )
             case "?":
                 return [
                     <CommandLineIcon name="search" key={`${character}-search`} />,

--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -42,10 +42,6 @@ const Cursor = styled.span`
     height: 1.3em;
 `
 
-const IconContainer = styled.span`
-    margin-right: 0.5em;
-`
-
 const ArrowContainer = styled.span`
     font-size: 0.7em;
     margin-right: 0.6em;

--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { connect } from "react-redux"
 import styled from "styled-components"
 
-import { Icon } from "./../../UI/Icon"
+import { Icon, OcticonIcon } from "./../../UI/Icon"
 import { fadeInAndDown } from "./animations"
 import { boxShadow } from "./common"
 
@@ -51,6 +51,10 @@ const ArrowContainer = styled.span`
     margin-right: 0.6em;
 `
 
+const SelectorSpan = styled.span`
+    display: inline-flex;
+`
+
 export interface ICommandLineRendererProps {
     showIcons: boolean
     visible: boolean
@@ -66,17 +70,32 @@ interface State {
     waiting: boolean
 }
 
-const CommandLineIcon = (props: { iconName: string; arrow?: boolean }) => (
-    <span>
-        {!props.arrow ? (
-            <Icon name={props.iconName} />
-        ) : (
-            <ArrowContainer>
-                <Icon name={props.iconName} />
-            </ArrowContainer>
-        )}
-    </span>
-)
+interface ICommandlineIconProps {
+    name: any
+    arrow?: boolean
+    octicon?: boolean
+}
+
+const CommandLineIcon = ({ arrow, name, octicon }: ICommandlineIconProps) => {
+    switch (true) {
+        case arrow:
+            return (
+                <span>
+                    <ArrowContainer>
+                        <Icon name={name} />
+                    </ArrowContainer>
+                </span>
+            )
+        case octicon:
+            return (
+                <SelectorSpan>
+                    <OcticonIcon name={name} />
+                </SelectorSpan>
+            )
+        default:
+            return <Icon name={name} />
+    }
+}
 
 class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> {
     public state = {
@@ -106,23 +125,19 @@ class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> 
         switch (character) {
             case "/":
                 return [
-                    <CommandLineIcon iconName="search" key={`${character}-search`} />,
-                    <CommandLineIcon
-                        arrow
-                        iconName="arrow-right"
-                        key={`${character}-arrow-right`}
-                    />,
+                    <CommandLineIcon name="search" key={`${character}-search`} />,
+                    <CommandLineIcon arrow name="arrow-right" key={`${character}-arrow-right`} />,
                 ]
             case ":":
                 return (
                     <IconContainer>
-                        <CommandLineIcon iconName="file-code-o" />
+                        <CommandLineIcon name="terminal" octicon />
                     </IconContainer>
                 )
             case "?":
                 return [
-                    <CommandLineIcon iconName="search" key={`${character}-search`} />,
-                    <CommandLineIcon key={`${character}-arrow-left`} arrow iconName="arrow-left" />,
+                    <CommandLineIcon name="search" key={`${character}-search`} />,
+                    <CommandLineIcon key={`${character}-arrow-left`} arrow name="arrow-left" />,
                 ]
             default:
                 return character

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "lint": "npm run lint:browser && npm run lint:main && npm run lint:test && npm run lint:plugins",
     "lint:plugins": "npm run lint:plugin:oni-layer-browser",
     "lint:plugin:oni-layer-browser": "tslint --project extensions/oni-layer-browser/tsconfig.json --config tslint.json",
-    "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+    "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
     "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
     "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
     "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "lint": "npm run lint:browser && npm run lint:main && npm run lint:test && npm run lint:plugins",
     "lint:plugins": "npm run lint:plugin:oni-layer-browser",
     "lint:plugin:oni-layer-browser": "tslint --project extensions/oni-layer-browser/tsconfig.json --config tslint.json",
-    "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+    "lint:browser": "tslint --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
     "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
     "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
     "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "oni-ripgrep": "0.0.3",
     "oni-types": "0.0.4",
     "react": "16.0.0",
+    "react-component-octicons": "^1.3.1",
     "react-dom": "16.0.0",
     "redux-batched-subscribe": "^0.1.6",
     "shell-env": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5020,6 +5020,10 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7, rc@^1.2.1:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-component-octicons@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-component-octicons/-/react-component-octicons-1.3.1.tgz#50b0455f9e9de492c51e2d763a6e8bb75315902f"
+
 react-dom@16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
@@ -6406,13 +6410,6 @@ vscode-css-languageserver-bin@^1.2.1:
   dependencies:
     vscode-css-languageservice "^3.0.3"
     vscode-languageserver "^3.5.0"
-
-vscode-css-languageservice@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-3.0.3.tgz#02cc4efa5335f5104e0a2f3b6920faaf59db4f7a"
-  dependencies:
-    vscode-languageserver-types "3.5.0"
-    vscode-nls "^2.0.1"
 
 vscode-css-languageservice@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
@bryphe as you suggested the code file icon doesn't quite make sense and I recently discovered an octicon react/typescript component library [`react-octicon-components`](https://github.com/rhysd/react-component-octicons) here's also a [link to the available octicons](https://octicons.github.com/). These icons seem to be more code specific than `font-awesome` and there appear to be several nice looking alternatives I've currently settled for 

*terminal*
<img width="860" alt="screen shot 2018-01-07 at 19 36 45" src="https://user-images.githubusercontent.com/22454918/34653432-ae3a156e-f3e3-11e7-8035-2374a6181b0a.png">

lemme know what you think as I'm happy to change it as there are several alternatives.
