### PR TITLE
Fix #1265 - Bring 'editor.completions.enabled' back, as a deprecated configuration

### DIFF
--- a/browser/src/Services/Completion/CompletionStore.ts
+++ b/browser/src/Services/Completion/CompletionStore.ts
@@ -171,7 +171,7 @@ const nullAction: CompletionAction = { type: null } as CompletionAction
 
 const createGetCompletionMeetEpic = (languageManager: LanguageManager, configuration: Configuration): Epic<CompletionAction, ICompletionState> => (action$, store) =>
     action$.ofType("CURSOR_MOVED")
-        .filter(() => configuration.getValue("editor.completions.mode") === "oni")
+        .filter(() => configuration.getValue("editor.completions.mode") === "oni" && configuration.getValue("editor.completions.enabled") !== false)
         .auditTime(10)
         .map((action: CompletionAction) => {
             const currentState: ICompletionState = store.getState()

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -14,6 +14,7 @@ import { diff } from "./../../Utility"
 
 import { DefaultConfiguration } from "./DefaultConfiguration"
 import { IConfigurationValues } from "./IConfigurationValues"
+import { checkDeprecatedSettings } from "./DeprecatedConfigurationValues"
 
 export class Configuration implements Oni.Configuration {
 
@@ -133,6 +134,8 @@ export class Configuration implements Oni.Configuration {
             this._configEverHadValue = true
             this._config = { ...DefaultConfiguration, ...this._setValues, ...userRuntimeConfigOrError}
         }
+
+        checkDeprecatedSettings(this._config)
 
         this._deactivate()
         this._activateIfOniObjectIsAvailable()

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -13,8 +13,8 @@ import * as Platform from "./../../Platform"
 import { diff } from "./../../Utility"
 
 import { DefaultConfiguration } from "./DefaultConfiguration"
-import { IConfigurationValues } from "./IConfigurationValues"
 import { checkDeprecatedSettings } from "./DeprecatedConfigurationValues"
+import { IConfigurationValues } from "./IConfigurationValues"
 
 export class Configuration implements Oni.Configuration {
 

--- a/browser/src/Services/Configuration/DeprecatedConfigurationValues.ts
+++ b/browser/src/Services/Configuration/DeprecatedConfigurationValues.ts
@@ -1,0 +1,31 @@
+/**
+ * DeprecatedConfigurationValues
+ *
+ * The purpose of this is to give users a heads up when we plan on deprecating a configuration,
+ * by providing them with a notice. As we move towards v1, we'll want to have some sort of 
+ * deprecation policy in place - like we'll support deprecated configurations for x releases.
+ */
+
+import * as Log from "./../../Log"
+
+export interface IDeprecatedConfigurationInfo {
+    replacementConfigurationName: string
+    documentationUrl: string
+}
+
+const deprecatedSettings: { [deprecatedConfigurationName: string]: IDeprecatedConfigurationInfo } = {
+    "editor.completions.enabled": {
+        replacementConfigurationName: "editor.completions.mode",
+        documentationUrl: "https://github.com/onivim/oni/wiki/Configuration#editor",
+    }
+}
+
+export const checkDeprecatedSettings = (config: {[key: string]: any}): void => {
+    Object.keys(config).forEach((configurationName) => {
+        if (deprecatedSettings[configurationName]) {
+
+            const deprecationInfo = deprecatedSettings[configurationName]
+            Log.warn(`Configuration setting '${configurationName}' is deprecated and will be replaced with '${deprecationInfo.replacementConfigurationName}'. See more info at: ${deprecationInfo.documentationUrl}`)
+        }
+    })
+}

--- a/browser/src/Services/Configuration/DeprecatedConfigurationValues.ts
+++ b/browser/src/Services/Configuration/DeprecatedConfigurationValues.ts
@@ -2,7 +2,7 @@
  * DeprecatedConfigurationValues
  *
  * The purpose of this is to give users a heads up when we plan on deprecating a configuration,
- * by providing them with a notice. As we move towards v1, we'll want to have some sort of 
+ * by providing them with a notice. As we move towards v1, we'll want to have some sort of
  * deprecation policy in place - like we'll support deprecated configurations for x releases.
  */
 
@@ -17,7 +17,7 @@ const deprecatedSettings: { [deprecatedConfigurationName: string]: IDeprecatedCo
     "editor.completions.enabled": {
         replacementConfigurationName: "editor.completions.mode",
         documentationUrl: "https://github.com/onivim/oni/wiki/Configuration#editor",
-    }
+    },
 }
 
 export const checkDeprecatedSettings = (config: {[key: string]: any}): void => {

--- a/browser/test/Services/Completion/CompletionTests.ts
+++ b/browser/test/Services/Completion/CompletionTests.ts
@@ -119,6 +119,25 @@ describe("Completion", () => {
         assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 0, "There should be no completion requests, because 'editor.completions.mode' is set to 'hidden'")
     })
 
+    it("doesn't fetch completions if 'editor.completions.enabled' === 'false'", () => {
+
+        mockConfiguration.setValue("editor.completions.enabled", false)
+
+        mockEditor.simulateBufferEnter(new Mocks.MockBuffer("typescript", "test1.ts", []))
+
+        // Switch to insert mode
+        mockEditor.simulateModeChange("insert")
+
+        // Simulate typing
+        mockEditor.simulateCursorMoved(0, 3)
+        mockEditor.setActiveBufferLine(0, "win")
+
+        clock.runAll()
+
+        // Validate we do not have requests for completion, because completions are turned off.
+        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 0, "There should be no completion requests, because 'editor.completions.enabled' is set to 'false'")
+    })
+
     it("if there is a completion matching the base, it should be the first shown", async () => {
 
         mockEditor.simulateBufferEnter(new Mocks.MockBuffer("typescript", "test1.ts", []))

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "test:unit": "npm run test:unit:browser",
     "test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
     "fix-lint": "npm run fix-lint:browser && npm run fix-lint:main && npm run fix-lint:test",
-    "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+    "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
     "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
     "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
     "lint": "npm run lint:browser && npm run lint:main && npm run lint:test && npm run lint:plugins",


### PR DESCRIPTION
This brings back `editor.completions.enabled` back temporarily, in the form of a deprecated setting. When using it, this message will show up in the developer console:
![image](https://user-images.githubusercontent.com/13532591/34795498-658bcb3e-f607-11e7-972b-51f37e119c01.png)

Later, we could look at another, more visible way of notifying the user (ie, integrating with #98)

I also added some quick notes to the wiki page for `editor.completions.enabled` and `editor.completions.mode`: https://github.com/onivim/oni/wiki/Configuration#editor
