### PR TITLE
Auto-Closing Pairs: Fix race condition on initial buffer enter

### DIFF
--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -125,7 +125,7 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         return true
     }
 
-    const onBufferEnter = (newBuffer) => {
+    const onBufferEnter = (newBuffer: Oni.Buffer) => {
 
         if (!configuration.getValue("autoClosingPairs.enabled")) {
             Log.verbose("[Auto Closing Pairs] Not enabled.")

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -125,7 +125,7 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         return true
     }
 
-    editorManager.activeEditor.onBufferEnter.subscribe((newBuffer) => {
+    const onBufferEnter = (newBuffer) => {
 
         if (!configuration.getValue("autoClosingPairs.enabled")) {
             Log.verbose("[Auto Closing Pairs] Not enabled.")
@@ -148,7 +148,14 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         subscriptions.push(inputManager.bind("<bs>", handleBackspaceCharacter(autoClosingPairs, editorManager.activeEditor), insertModeFilter))
         subscriptions.push(inputManager.bind("<enter>", handleEnterCharacter(autoClosingPairs, editorManager.activeEditor), insertModeFilter))
 
-    })
+    }
+
+    editorManager.activeEditor.onBufferEnter.subscribe(onBufferEnter)
+
+    const activeEditor = editorManager.activeEditor
+    if (activeEditor && activeEditor.activeBuffer) {
+        onBufferEnter(activeEditor.activeBuffer)
+    }
 }
 
 const nonWhiteSpaceRegEx = /\S/

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -42,7 +42,7 @@ export class Automation implements OniApi.Automation.Api {
     }
 
     public async waitFor(condition: () => boolean, timeout: number = 10000): Promise<void> {
-        Log.info("[AUTOMATION] Starting wait - limit: " + timeout)
+        Log.info("[AUTOMATION] Starting wait - limit: " + timeout + " condition: " + condition.toString())
         let time = 0
         const interval = 1000
 
@@ -56,7 +56,7 @@ export class Automation implements OniApi.Automation.Api {
             Log.info("[AUTOMATION] Wait condition still not met: " + time + " / " + timeout)
         }
 
-        Log.info("[AUTOMATION]: waitFor timeout expired")
+        Log.info("[AUTOMATION]: waitFor timeout expired for condition: " + condition.toString())
 
         throw new Error("waitFor: Timeout expired")
     }


### PR DESCRIPTION
__Issue:__ Looking at automation logs, it seems that there are cases where auto-closing pairs may not be activated for the very first buffer. I believe this may be a 'real' issue, because I believe I have seen this when running via `npm run start` too.

__Defect:__ The AutoClosingPairs service assumes that any `BufferEnter` event will come _after_ it is initialized, but this actually isn't a guarantee - we may have passed a file for Neovim to open on startup, for example.

__Fix:__ When we activate auto closing pairs, if there is an active buffer currently, we should handle that too.