### PR TITLE
Fix #1263 - Rename also renames strings

### DIFF
--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -254,7 +254,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
             file,
             line,
             offset,
-            findInComments: true,
+            findInComments: false,
             findInStrings: false,
         })
     }

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -255,7 +255,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
             line,
             offset,
             findInComments: true,
-            findInStrings: true,
+            findInStrings: false,
         })
     }
 


### PR DESCRIPTION
Adjusts the `findInStrings` and `findInComments` to more conservative defaults, so that the rename operation (for TypeScript) does not modify strings / comments.