### PR TITLE
Bugfix/update colors when config changes

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -520,7 +520,7 @@ export class NeovimEditor extends Editor implements IEditor {
     }
 
     public async newFile(filePath: string): Promise<Oni.Buffer> {
-        await this._neovimInstance.command(":new " + filePath)
+        await this._neovimInstance.command(":vsp " + filePath)
         const context = await this._neovimInstance.getContext()
         const buffer = this._bufferManager.updateBufferFromEvent(context)
         return buffer

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -707,7 +707,7 @@ export class NeovimEditor extends Editor implements IEditor {
         .then(ids => this._actions.setCurrentBuffers(ids))
     }
 
-    private async _onConfigChanged(newValues: Partial<IConfigurationValues>): Promise<void> {
+    private  _onConfigChanged(newValues: Partial<IConfigurationValues>): void {
         const fontFamily = this._configuration.getValue("editor.fontFamily")
         const fontSize = addDefaultUnitIfNeeded(this._configuration.getValue("editor.fontSize"))
         const linePadding = this._configuration.getValue("editor.linePadding")
@@ -715,13 +715,9 @@ export class NeovimEditor extends Editor implements IEditor {
         this._actions.setFont(fontFamily, fontSize)
         this._neovimInstance.setFont(fontFamily, fontSize, linePadding)
 
-        Object.keys(newValues).forEach(async (key) => {
+        Object.keys(newValues).forEach((key) => {
             const value = newValues[key]
             this._actions.setConfigValue(key, value)
-            if (key && key.includes("ui.colorscheme")) {
-                await this._themeManager.setTheme(value)
-                Shell.Actions.setColors(this._themeManager.getColors())
-            }
         })
 
         if (this._hasLoaded) {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -707,7 +707,7 @@ export class NeovimEditor extends Editor implements IEditor {
         .then(ids => this._actions.setCurrentBuffers(ids))
     }
 
-    private  _onConfigChanged(newValues: Partial<IConfigurationValues>): void {
+    private _onConfigChanged(newValues: Partial<IConfigurationValues>): void {
         const fontFamily = this._configuration.getValue("editor.fontFamily")
         const fontSize = addDefaultUnitIfNeeded(this._configuration.getValue("editor.fontSize"))
         const linePadding = this._configuration.getValue("editor.linePadding")

--- a/browser/src/Services/Themes/index.ts
+++ b/browser/src/Services/Themes/index.ts
@@ -1,4 +1,5 @@
 export * from "./ThemeManager"
+import * as Shell from "./../../UI/Shell"
 
 import { Configuration, IConfigurationValues } from "./../Configuration"
 import { getThemeManagerInstance } from "./ThemeManager"
@@ -10,6 +11,7 @@ export const activate = async (configuration: Configuration): Promise<void> => {
         if (colorscheme) {
             const themeManager = getThemeManagerInstance()
             await themeManager.setTheme(colorscheme)
+            Shell.Actions.setColors(themeManager.getColors())
         }
     }
 


### PR DESCRIPTION
Adds a check in the config changes handler to update the theme if key that was changed includes `ui.colorscheme`

Fixes #1275 