### PR TITLE
Fix part of #1272 - Clearing highlights when line has moved

### DIFF
--- a/browser/src/Editor/BufferHighlights.ts
+++ b/browser/src/Editor/BufferHighlights.ts
@@ -9,8 +9,7 @@ import * as SyntaxHighlighting from "./../Services/SyntaxHighlighting"
 import { NeovimInstance } from "./../neovim"
 
 // Line number to highlight src id, for clearing
-export type HighlightSourceId = number
-export interface BufferHighlightState { [key: number]: HighlightSourceId }
+export type BufferHighlightId = number
 
 export interface IBufferHighlightsUpdater {
     setHighlightsForLine(line: number, highlights: SyntaxHighlighting.HighlightInfo[]): void
@@ -20,23 +19,18 @@ export interface IBufferHighlightsUpdater {
 // Helper class to efficiently update
 // buffer highlights in a batch.
 export class BufferHighlightsUpdater implements IBufferHighlightsUpdater {
-
-    private _newSrcId: number
     private _calls: any[] = []
-    private _newState: BufferHighlightState
 
     constructor(
         private _bufferId: number,
         private _neovimInstance: NeovimInstance,
-        private _previousState: BufferHighlightState,
+        private _highlightId: BufferHighlightId
     ) {}
 
     public async start(): Promise<void> {
-        this._newState = {
-            ...this._previousState,
+        if (!this._highlightId) {
+            this._highlightId = await this._neovimInstance.request<number>("nvim_buf_add_highlight", [this._bufferId, 0, "", 0, 0, 0])
         }
-
-        this._newSrcId = await this._neovimInstance.request<number>("nvim_buf_add_highlight", [this._bufferId, 0, "", 0, 0, 0])
     }
 
     public setHighlightsForLine(line: number, highlights: SyntaxHighlighting.HighlightInfo[]): void {
@@ -47,31 +41,21 @@ export class BufferHighlightsUpdater implements IBufferHighlightsUpdater {
         }
 
         const addHighlightCalls = highlights.map((hl) => {
-            return ["nvim_buf_add_highlight", [this._bufferId, this._newSrcId, hl.highlightGroup,
+            return ["nvim_buf_add_highlight", [this._bufferId, this._highlightId, hl.highlightGroup,
                 hl.range.start.line, hl.range.start.character, hl.range.end.character]]
         })
-
-        this._newState[line] = this._newSrcId
 
         this._calls = this._calls.concat(addHighlightCalls)
     }
     public clearHighlightsForLine(line: number): void {
-        const previousLine = this._previousState[line]
 
-        if (!previousLine) {
-            return
-        }
-
-        const oldSrcId = this._previousState[line]
-        this._newState[line] = null
-
-        this._calls.push(["nvim_buf_clear_highlight", [this._bufferId, oldSrcId, line, line + 1]])
+        this._calls.push(["nvim_buf_clear_highlight", [this._bufferId, this._highlightId, line, line + 1]])
     }
 
-    public async apply(): Promise<BufferHighlightState> {
+    public async apply(): Promise<BufferHighlightId> {
         if (this._calls.length > 0) {
             await this._neovimInstance.request<void>("nvim_call_atomic", [this._calls])
         }
-        return this._newState
+        return this._highlightId
     }
 }

--- a/browser/src/Editor/BufferHighlights.ts
+++ b/browser/src/Editor/BufferHighlights.ts
@@ -24,7 +24,7 @@ export class BufferHighlightsUpdater implements IBufferHighlightsUpdater {
     constructor(
         private _bufferId: number,
         private _neovimInstance: NeovimInstance,
-        private _highlightId: BufferHighlightId
+        private _highlightId: BufferHighlightId,
     ) {}
 
     public async start(): Promise<void> {

--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -21,7 +21,7 @@ import { PromiseQueue } from "./../Services/Language/PromiseQueue"
 
 import * as SyntaxHighlighting from "./../Services/SyntaxHighlighting"
 
-import { BufferHighlightsUpdater, BufferHighlightId, IBufferHighlightsUpdater } from "./BufferHighlights"
+import { BufferHighlightId, BufferHighlightsUpdater, IBufferHighlightsUpdater } from "./BufferHighlights"
 
 import * as Actions from "./NeovimEditor/NeovimEditorActions"
 

--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -21,7 +21,7 @@ import { PromiseQueue } from "./../Services/Language/PromiseQueue"
 
 import * as SyntaxHighlighting from "./../Services/SyntaxHighlighting"
 
-import { BufferHighlightState, BufferHighlightsUpdater, IBufferHighlightsUpdater } from "./BufferHighlights"
+import { BufferHighlightsUpdater, BufferHighlightId, IBufferHighlightsUpdater } from "./BufferHighlights"
 
 import * as Actions from "./NeovimEditor/NeovimEditorActions"
 
@@ -37,9 +37,9 @@ export class Buffer implements Oni.Buffer {
     private _version: number
     private _modified: boolean
     private _lineCount: number
+    private _bufferHighlightId: BufferHighlightId = null
 
     private _promiseQueue = new PromiseQueue()
-    private _previousHighlightState: BufferHighlightState = {}
 
     public get filePath(): string {
         return this._filePath
@@ -158,12 +158,12 @@ export class Buffer implements Oni.Buffer {
     public async updateHighlights(updateFunction: (highlightsUpdater: IBufferHighlightsUpdater) => void): Promise<void> {
         this._promiseQueue.enqueuePromise(async () => {
             const bufferId = parseInt(this._id, 10)
-            const bufferUpdater = new BufferHighlightsUpdater(bufferId, this._neovimInstance, this._previousHighlightState)
+            const bufferUpdater = new BufferHighlightsUpdater(bufferId, this._neovimInstance, this._bufferHighlightId)
             await bufferUpdater.start()
 
             updateFunction(bufferUpdater)
 
-            this._previousHighlightState = await bufferUpdater.apply()
+            this._bufferHighlightId = await bufferUpdater.apply()
         })
     }
 


### PR DESCRIPTION
__Issue:__ In the case where a line has moved, we don't clear the highlights correctly.

An example would be: 
- Apply syntax highlighting to line 1 (ie `const test = 1`)
- Add a line before
- Comment out line 2 (used to be line 1)

This would fail, because we'd check to see if there were highlights previously for line 2, and there would be nothing in our dictionary - so we'd skip clearing the lines. This left some awkward state, like partial highlighting being retained for comment.

__Fix:__  The reason we need to store state per line is to get the srcId, but it turns out we can just reuse the same src id for the buffer, negating the need to store per-line state in the buffer highlights.

I believe this is a contributing factor to #1272, and seems to fix the comment case. However, I believe there are still some problems with insert mode.