### PR TITLE
Fix #978 - Add 'tabs.showIndex' option

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -199,11 +199,8 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.height": "2.5em",
     "tabs.highlight": true,
     "tabs.maxWidth": "30em",
-<<<<<<< HEAD
-    "tabs.showIndex": false,
-=======
     "tabs.showFileIcon": true,
->>>>>>> master
+    "tabs.showIndex": false,
     "tabs.wrap": false,
 
     "ui.animations.enabled": true,

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -199,6 +199,7 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.height": "2.5em",
     "tabs.highlight": true,
     "tabs.maxWidth": "30em",
+    "tabs.showIndex": false,
     "tabs.wrap": false,
 
     "ui.animations.enabled": true,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -214,6 +214,9 @@ export interface IConfigurationValues {
     // Maximum width of a tab
     "tabs.maxWidth": string
 
+    // Whether or not to show the index alongside the tab
+    "tabs.showIndex": boolean
+
     // Whether or not tabs should wrap.
     // If `false`, a scrollbar will be shown.
     // If `true`, will wrap the tabs.

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -178,15 +178,23 @@ export const getHighlightColor = (state: State.IState) => {
     return color || "transparent"
 }
 
+export const showTabId = (state: State.IState) => {
+    return state.configuration["tabs.showIndex"]
+}
+
+export const getIdPrefix = (id: string, shouldShow: boolean): string => {
+    return shouldShow ? id + ": " : ""
+}
+
 const getTabsFromBuffers = createSelector(
-    [BufferSelectors.getBufferMetadata, BufferSelectors.getActiveBufferId, getHighlightColor],
-    (allBuffers: any, activeBufferId: any, color: string) => {
+    [BufferSelectors.getBufferMetadata, BufferSelectors.getActiveBufferId, getHighlightColor, showTabId],
+    (allBuffers: any, activeBufferId: any, color: string, shouldShowId: boolean) => {
         const bufferCount = allBuffers.length
         const tabs = allBuffers.map((buf: any): ITabProps => {
             const isActive = (activeBufferId !== null && buf.id === activeBufferId) || bufferCount === 1
             return {
                 id: buf.id,
-                name: getTabName(buf.file),
+                name: getIdPrefix(buf.id, shouldShowId) + getTabName(buf.file),
                 iconFileName: getTabName(buf.file),
                 highlightColor: isActive ? color : "transparent",
                 isSelected: isActive,
@@ -198,11 +206,11 @@ const getTabsFromBuffers = createSelector(
     })
 
 const getTabsFromVimTabs = createSelector(
-    [getTabState, getHighlightColor],
-    (tabState: any, color: any) => {
-        return tabState.tabs.map((t: any) => ({
+    [getTabState, getHighlightColor, showTabId],
+    (tabState: any, color: any, shouldShowId: boolean) => {
+        return tabState.tabs.map((t: any, idx: number) => ({
             id: t.id,
-            name: getTabName(t.name),
+            name: getIdPrefix((idx + 1).toString(), shouldShowId) + getTabName(t.name),
             highlightColor: t.id === tabState.selectedTabId ? color : "transparent",
             iconFileName: "",
             isSelected: t.id === tabState.selectedTabId,


### PR DESCRIPTION
This adds a `tabs.showIndex` configuration option, which, when enabled, adds a number to the tab for easy switching via `{n}gt`:
![image](https://user-images.githubusercontent.com/13532591/34901545-8b5bb166-f7c0-11e7-97af-ebaf50f022c6.png)
