### PR TITLE
Tabs: Show file icon by default

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -199,6 +199,7 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.height": "2.5em",
     "tabs.highlight": true,
     "tabs.maxWidth": "30em",
+    "tabs.showFileIcon": true,
     "tabs.wrap": false,
 
     "ui.animations.enabled": true,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -219,6 +219,10 @@ export interface IConfigurationValues {
     // If `true`, will wrap the tabs.
     "tabs.wrap": boolean
 
+    // Whether or not the file icon
+    // should be shown in the tab
+    "tabs.showFileIcon": boolean
+
     "ui.animations.enabled": boolean
     "ui.iconTheme": string
     "ui.colorscheme": string

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -178,16 +178,20 @@ export const getHighlightColor = (state: State.IState) => {
     return color || "transparent"
 }
 
+export const shouldShowFileIcon = (state: State.IState): boolean => {
+    return state.configuration["tabs.showFileIcon"]
+}
+
 const getTabsFromBuffers = createSelector(
-    [BufferSelectors.getBufferMetadata, BufferSelectors.getActiveBufferId, getHighlightColor],
-    (allBuffers: any, activeBufferId: any, color: string) => {
+    [BufferSelectors.getBufferMetadata, BufferSelectors.getActiveBufferId, getHighlightColor, shouldShowFileIcon],
+    (allBuffers: any, activeBufferId: any, color: string, showFileIcon: boolean) => {
         const bufferCount = allBuffers.length
         const tabs = allBuffers.map((buf: any): ITabProps => {
             const isActive = (activeBufferId !== null && buf.id === activeBufferId) || bufferCount === 1
             return {
                 id: buf.id,
                 name: getTabName(buf.file),
-                iconFileName: getTabName(buf.file),
+                iconFileName: showFileIcon ? getTabName(buf.file) : "",
                 highlightColor: isActive ? color : "transparent",
                 isSelected: isActive,
                 isDirty: buf.modified,
@@ -198,13 +202,13 @@ const getTabsFromBuffers = createSelector(
     })
 
 const getTabsFromVimTabs = createSelector(
-    [getTabState, getHighlightColor],
-    (tabState: any, color: any) => {
+    [getTabState, getHighlightColor, shouldShowFileIcon],
+    (tabState: any, color: any, showFileIcon: boolean) => {
         return tabState.tabs.map((t: any) => ({
             id: t.id,
             name: getTabName(t.name),
             highlightColor: t.id === tabState.selectedTabId ? color : "transparent",
-            iconFileName: "",
+            iconFileName: showFileIcon ? getTabName(t.name) : "",
             isSelected: t.id === tabState.selectedTabId,
             isDirty: false,
             description: t.name,


### PR DESCRIPTION
- Add a setting `tabs.showFileIcon`
- Default to true, so we always show file icons in both buffer / tabs mode