### PR TITLE
Fix #1220 - Add 'editor.insertSpaces' and 'editor.tabSize' options

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -103,6 +103,9 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.cursorColumn": false,
     "editor.cursorColumnOpacity": 0.1,
 
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+
     "editor.tokenColors": [{
         scope: "variable.object",
         settings: "Identifier",

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -141,6 +141,13 @@ export interface IConfigurationValues {
     // Allow overriding token colors for specific textmate scopes
     "editor.tokenColors": ITokenColorsSetting[]
 
+    // The number of spaces a tab is equal to.
+    "editor.tabSize": number | null
+
+    // Insert spaces when pressing Tab.
+    // Set to 'null' to defer to Vim's configuration.
+    "editor.insertSpaces": boolean | null
+
     // Additional paths to include when launching sub-process from Oni
     // (and available in terminal integration, later)
     "environment.additionalPaths": string[]

--- a/browser/src/Services/VimConfigurationSynchronizer.ts
+++ b/browser/src/Services/VimConfigurationSynchronizer.ts
@@ -46,4 +46,22 @@ export const synchronizeConfiguration = (neovimInstance: INeovimInstance, config
         const globalSettingName = key.substring(vimGlobalPrefix.length, key.length)
         neovimInstance.command(`let g:${globalSettingName}=${vimGlobalValue}`)
     })
+
+    synchronizeTabSettings(neovimInstance, configuration)
+}
+
+export const synchronizeTabSettings = (neovimInstance: INeovimInstance, configuration: IConfigurationValues) => {
+    const useSpaces = configuration["editor.insertSpaces"]
+
+    // If useSpaces is not `true`, or `false`, we'll defer to Vim
+    if (typeof useSpaces !== "boolean") {
+        return
+    }
+
+    if (!useSpaces) {
+        neovimInstance.command("set noexpandtab")
+    } else {
+        const spaceCount = configuration["editor.tabSize"]
+        neovimInstance.command(`set tabstop=${spaceCount} shiftwidth=${spaceCount} softtabstop=${spaceCount} expandtab`)
+    }
 }

--- a/browser/src/Services/VimConfigurationSynchronizer.ts
+++ b/browser/src/Services/VimConfigurationSynchronizer.ts
@@ -52,16 +52,20 @@ export const synchronizeConfiguration = (neovimInstance: INeovimInstance, config
 
 export const synchronizeTabSettings = (neovimInstance: INeovimInstance, configuration: IConfigurationValues) => {
     const useSpaces = configuration["editor.insertSpaces"]
+    const spaceCount = configuration["editor.tabSize"]
 
     // If useSpaces is not `true`, or `false`, we'll defer to Vim
-    if (typeof useSpaces !== "boolean") {
-        return
+
+    if (typeof useSpaces === "boolean") {
+
+        if (!useSpaces) {
+            neovimInstance.command("set noexpandtab")
+        } else {
+            neovimInstance.command(`set expandtab`)
+        }
     }
 
-    if (!useSpaces) {
-        neovimInstance.command("set noexpandtab")
-    } else {
-        const spaceCount = configuration["editor.tabSize"]
-        neovimInstance.command(`set tabstop=${spaceCount} shiftwidth=${spaceCount} softtabstop=${spaceCount} expandtab`)
+    if (typeof spaceCount === "number") {
+        neovimInstance.command(`set tabstop=${spaceCount} shiftwidth=${spaceCount} softtabstop=${spaceCount}`)
     }
 }

--- a/browser/test/Mocks/neovim.ts
+++ b/browser/test/Mocks/neovim.ts
@@ -7,6 +7,19 @@
 
 import * as Neovim from "./../../src/neovim"
 
+export class MockNeovimInstance {
+
+    private _commands: string[] = []
+
+    public get commandsSentToNeovim(): string[] {
+        return this._commands
+    }
+
+    public async command(command: string): Promise<void> {
+        this._commands.push(command)
+    }
+}
+
 export class MockScreen implements Neovim.IScreen {
 
     public backgroundColor: string

--- a/browser/test/Services/VimConfigurationSynchronizerTests.ts
+++ b/browser/test/Services/VimConfigurationSynchronizerTests.ts
@@ -35,7 +35,12 @@ describe("VimConfigurationSynchronizer", () => {
 
         it("sets 'expandtab' + space settings if set to true", () => {
             synchronizeTabSettings(mockNeovimInstance as any, { "editor.insertSpaces": true, "editor.tabSize": 3 })
-            assert.deepEqual(mockNeovimInstance.commandsSentToNeovim, ["set tabstop=3 shiftwidth=3 softtabstop=3 expandtab"], "Verify expandtab + sizes are sent")
+            assert.deepEqual(mockNeovimInstance.commandsSentToNeovim, ["set expandtab", "set tabstop=3 shiftwidth=3 softtabstop=3"], "Verify expandtab + sizes are sent")
+        })
+
+        it("if 'editor.tabSize' is set without 'editor.insertSpaces', still gets set", () => {
+            synchronizeTabSettings(mockNeovimInstance as any, { "editor.tabSize": 3 })
+            assert.deepEqual(mockNeovimInstance.commandsSentToNeovim, ["set tabstop=3 shiftwidth=3 softtabstop=3"], "Verify expandtab + sizes are sent")
         })
     })
 })

--- a/browser/test/Services/VimConfigurationSynchronizerTests.ts
+++ b/browser/test/Services/VimConfigurationSynchronizerTests.ts
@@ -1,0 +1,41 @@
+/**
+ * VimConfigurationSynchronizerTests.ts
+ */
+
+import * as assert from "assert"
+
+import {synchronizeTabSettings } from "./../../src/Services/VimConfigurationSynchronizer"
+
+import * as Mocks from "./../Mocks/neovim"
+
+describe("VimConfigurationSynchronizer", () => {
+
+    let mockNeovimInstance: Mocks.MockNeovimInstance
+
+    beforeEach(() => {
+        mockNeovimInstance = new Mocks.MockNeovimInstance()
+    })
+
+    describe("synchronizeTabSettings", () => {
+
+        it("doesn't synchronize if 'editor.insertSpaces' is not defined", () => {
+            synchronizeTabSettings(mockNeovimInstance as any, { })
+            assert.strictEqual(mockNeovimInstance.commandsSentToNeovim.length, 0, "Verify no commands sent to neovim")
+        })
+
+        it("doesn't synchronize if 'editor.insertSpaces' is null", () => {
+            synchronizeTabSettings(mockNeovimInstance as any, { "editor.insertSpaces": null })
+            assert.strictEqual(mockNeovimInstance.commandsSentToNeovim.length, 0, "Verify no commands sent to neovim")
+        })
+
+        it("sets 'noexpandtab' if 'editor.insertSpaces' is set to false", () => {
+            synchronizeTabSettings(mockNeovimInstance as any, { "editor.insertSpaces": false })
+            assert.deepEqual(mockNeovimInstance.commandsSentToNeovim, ["set noexpandtab"], "Verify noexpandtab is set")
+        })
+
+        it("sets 'expandtab' + space settings if set to true", () => {
+            synchronizeTabSettings(mockNeovimInstance as any, { "editor.insertSpaces": true, "editor.tabSize": 3 })
+            assert.deepEqual(mockNeovimInstance.commandsSentToNeovim, ["set tabstop=3 shiftwidth=3 softtabstop=3 expandtab"], "Verify expandtab + sizes are sent")
+        })
+    })
+})

--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -5,12 +5,6 @@ set smartcase
 set splitright
 set splitbelow
 
-" Default tab settings
-set tabstop=4
-set shiftwidth=4
-set softtabstop=4
-set expandtab
-
 " Turn off statusbar, because it is externalized
 set noshowmode
 set noruler


### PR DESCRIPTION
This change adds `editor.insertSpaces` and `editor.tabSize` options, so that the space/tab settings can be adjusted directly from the `config.js`.

If `editor.insertSpaces` is set to 'null', we will not set `expandtab`/`noexpandtab`.
If `editor.tabSize` is set to 'null', we will not set `tabstop`, `shiftwidth`, `softtabstop`.