### PR TITLE
remove icon for default command line

### DIFF
--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -113,12 +113,6 @@ class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> 
                         key={`${character}-arrow-right`}
                     />,
                 ]
-            case ":":
-                return (
-                    <IconContainer>
-                        <CommandLineIcon iconName="file-code-o" />
-                    </IconContainer>
-                )
             case "?":
                 return [
                     <CommandLineIcon iconName="search" key={`${character}-search`} />,

--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -42,10 +42,6 @@ const Cursor = styled.span`
     height: 1.3em;
 `
 
-const IconContainer = styled.span`
-    margin-right: 0.5em;
-`
-
 const ArrowContainer = styled.span`
     font-size: 0.7em;
     margin-right: 0.6em;


### PR DESCRIPTION
@bryphe apologies re the bugs with #1249 🙇 , this PR just removes the case for the icon for `:` so there is no default icon as discussed in #1249 without any octicon baggage. Should be bug free just a small deletion.