### PR TITLE
Nord theme: Bump up brightness of cursor

### DIFF
--- a/extensions/theme-nord/colors/nord.json
+++ b/extensions/theme-nord/colors/nord.json
@@ -9,7 +9,7 @@
         "title.foreground": "#ECEFF4",
 
         "editor.background": "#2F3440",
-        "editor.foreground": "#ABB2BF",
+        "editor.foreground": "#DCDCDC",
 
         "tabs.background": "#2F3440",
         "tabs.foreground": "#E5E9F0",


### PR DESCRIPTION
When using the `nord` theme, it works great - except the cursor color blends in with the highlights for bracket/parentheses matching.

This change brightens up the cursor a bit to make it more visible in those cases.