### PR TITLE
Fix #1235 - Use 'ONI_WEBPACK_LOAD' environment variable instead of 'NODE_ENV'

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       <script>
         console.timeStamp("browser.domloaded")
         var path = "lib/browser/bundle.js"
-        if(process.env.NODE_ENV === "development") {
+        if(process.env.ONI_WEBPACK_LOAD) {
             path = "http://localhost:8191/bundle.js";
             const hotReloadElement = document.createElement("div");
             hotReloadElement.textContent = "Waiting for webpack compilation... You may need to reload the browser once webpack finishes compiling."

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "ccov:test:browser": "cd browser && cross-env ONI_CCOV=1 electron-mocha --renderer --require testHelpers.js -R testCoverageReporter --recursive ../lib_test/browser/test",
     "ccov:report": "nyc report && nyc report --reporter=html && nyc report --reporter=lcov",
     "start": "concurrently --kill-others \"npm run start-hot\" \"npm run watch:browser\" \"npm run watch:plugins\"",
-    "start-hot": "cross-env NODE_ENV=development electron lib/main/src/main.js",
+    "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
     "start-not-dev": "cross-env electron main.js",
     "watch:browser": "webpack-dev-server --config browser/webpack.debug.config.js --host localhost --port 8191",
     "watch:plugins": "npm run watch:plugins:oni-layer-browser && npm run watch:plugins:oni-plugin-typescript && npm run watch:plugins:oni-plugin-markdown-preview",


### PR DESCRIPTION
It's still not clear all the cases that cause #1235 , but there is definitely a conflict with the `NODE_ENV` variable - if `NODE_ENV` is set, we'll try and load from webpack-dev-server instead of the local file. This is problematic for anyone who uses `NODE_ENV` in their local workflow, so we should use a different environment variable to gate this.