### PR TITLE
Add initial configuration for 'oni-bot'

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,3 @@
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: >
+  Hello and welcome to the Oni repository! Thanks for opening your first issue here. To help us out, please make sure to include as much detail as possible - including screenshots and logs, if possible.


### PR DESCRIPTION
This adds initial configuration for oni-bot: https://github.com/onivim/oni-bot

Doesn't do too much today except welcome new users - but I'd like to use it to help me prioritize issues (ie, tag issues with 'backer' and 'sponsor')