### PR TITLE
Automation: Fix instability with 'NoAdditionalProcesses' test

### DIFF
--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -13,6 +13,7 @@ import * as Utility from "./../Utility"
 import { getUserConfigFilePath } from "./Configuration"
 import { editorManager } from "./EditorManager"
 import { inputManager } from "./InputManager"
+import { getInstance as getSharedNeovimInstance } from "./../neovim/SharedNeovimInstance"
 
 import * as Log from "./../Log"
 import * as Shell from "./../UI/Shell"
@@ -75,9 +76,13 @@ export class Automation implements OniApi.Automation.Api {
         await this.waitFor(() => (Shell.store.getState() as any).isLoaded, 30000)
         Log.info("[AUTOMATION] Startup complete!")
 
-        Log.info("[AUTOMATION] Waiting for neovim to attach...")
+        Log.info("[AUTOMATION] Waiting for neovim to attach to editor...")
         await this.waitFor(() => editorManager.activeEditor.neovim && (editorManager.activeEditor as any).neovim.isInitialized, 30000)
-        Log.info("[AUTOMATION] Neovim attached!")
+        Log.info("[AUTOMATION] Neovim initialized!")
+
+        Log.info("[AUTOMATION] Waiting for shared neovim instance...")
+        await this.waitFor(() => getSharedNeovimInstance() && getSharedNeovimInstance().isInitialized, 30000)
+        Log.info("[AUTOMATION] Shared neovim instance initialized!")
     }
 
     public async runTest(testPath: string): Promise<void> {

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -10,10 +10,10 @@ import * as OniApi from "oni-api"
 
 import * as Utility from "./../Utility"
 
+import { getInstance as getSharedNeovimInstance } from "./../neovim/SharedNeovimInstance"
 import { getUserConfigFilePath } from "./Configuration"
 import { editorManager } from "./EditorManager"
 import { inputManager } from "./InputManager"
-import { getInstance as getSharedNeovimInstance } from "./../neovim/SharedNeovimInstance"
 
 import * as Log from "./../Log"
 import * as Shell from "./../UI/Shell"

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -115,6 +115,10 @@ class SharedNeovimInstance implements SharedNeovimInstance {
     private _initPromise: Promise<void>
     private _neovimInstance: NeovimInstance
 
+    public get isInitialized(): boolean {
+        return this._neovimInstance.isInitialized
+    }
+
     constructor(
         private _configuration: Configuration,
         private _pluginManager: PluginManager,

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "dist:win": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
     "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
     "test": "npm run test:unit && npm run test:integration",
-    "test:integration": "npm run build:test && mocha -t 60000 lib_test/test/CiTests.js",
+    "test:integration": "npm run build:test && mocha -t 120000 lib_test/test/CiTests.js",
     "test:unit": "npm run test:unit:browser",
     "test:unit:browser": "npm run build:test:unit && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
     "fix-lint": "npm run fix-lint:browser && npm run fix-lint:main && npm run fix-lint:test",

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -78,16 +78,10 @@ export const runInProcTest = (rootPath: string, testName: string, timeout: numbe
             oni.client.execute("Oni.automation.runTest('" + testCase.testPath + "')")
 
             logWithTimeStamp("Waiting for result...") // tslint:disable-line
-            await oni.client.waitForExist(".automated-test-result", 30000)
-            const resultText = await oni.client.getText(".automated-test-result")
-
-            logWithTimeStamp("---RESULT")
-            console.log(resultText) // tslint:disable-line
-            console.log("---")
-            console.log("")
+            const value = await oni.client.waitForExist(".automated-test-result", 60000)
+            logWithTimeStamp("waitForExist for 'automated-test-result' complete: " + value)
 
             console.log("Retrieving logs...")
-
             const writeLogs = (logs: any[]): void => {
                 logs.forEach((log) => {
                     console.log(`[${log.level}] ${log.message}`)
@@ -95,9 +89,19 @@ export const runInProcTest = (rootPath: string, testName: string, timeout: numbe
             }
 
             const rendererLogs: any[] = await oni.client.getRenderProcessLogs()
-            console.log("---LOGS (Renderer): ")
+            console.log("")
+            console.log("---LOGS (Renderer): " + testName)
             writeLogs(rendererLogs)
-            console.log("---")
+            console.log("--- " + testName + " ---")
+
+            console.log("Getting result...")
+            const resultText = await oni.client.getText(".automated-test-result")
+
+            console.log("")
+            logWithTimeStamp("---RESULT: " + testName)
+            console.log(resultText) // tslint:disable-line
+            console.log("--- " + testName + " ---")
+            console.log("")
 
             const result = JSON.parse(resultText)
             assert.ok(result.passed)


### PR DESCRIPTION
The 'NoAdditionalProcesses' test expects there to be two processes on startup, but it's actually only waiting for the editor neovim instance to be started - so in some cases, it's only seeing one process start.

In addition, I noticed that occasionally the very first test is failing - I believe this may be because it is slow to warm up on first boot & timing out. Trying to add more logging to catch and fix that.