### PR TITLE
Automation: Enable CiTests for linux builds

### DIFF
--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -58,7 +58,7 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
     const nvimMacProcessPath = path.join(__dirname, "node_modules", "oni-neovim-binaries", "bin", "nvim-osx64", "bin", "nvim")
 
     // Assume nvim is available in path for Linux
-    const nvimLinuxPath = process.env["ONI_NEOVIM_PATH"] || "nvim"
+    const nvimLinuxPath = process.env["ONI_NEOVIM_PATH"] || "nvim" // tslint:disable-line
 
     let nvimProcessPath = Platform.isWindows() ? nvimWindowsProcessPath : Platform.isMac() ? nvimMacProcessPath : nvimLinuxPath
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -70,6 +70,8 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
         nvimProcessPath = neovimPath
     }
 
+    Log.info("[NeovimProcessSpawnwer::startNeovim] Neovim process path: " + nvimProcessPath)
+
     const joinedRuntimePaths = runtimePaths
                                     .map((p) => remapPathToUnpackedAsar(p))
                                     .join(",")
@@ -89,7 +91,7 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
 
     const nvimProc = await spawnProcess(nvimProcessPath, argsToPass, {})
 
-    console.log(`Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
+    Log.info(`[NeovimProcessSpawner::startNeovim] Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
 
     return await getSessionFromProcess(nvimProc, options.transport)
 }

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -59,6 +59,7 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
 
     // Assume nvim is available in path for Linux
     const nvimLinuxPath = process.env["ONI_NEOVIM_PATH"] || "nvim" // tslint:disable-line
+    Log.info("[NeovimProcessSpawnwer::startNeovim] process.env: " + JSON.stringify(process.env))
 
     let nvimProcessPath = Platform.isWindows() ? nvimWindowsProcessPath : Platform.isMac() ? nvimMacProcessPath : nvimLinuxPath
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -58,7 +58,7 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
     const nvimMacProcessPath = path.join(__dirname, "node_modules", "oni-neovim-binaries", "bin", "nvim-osx64", "bin", "nvim")
 
     // Assume nvim is available in path for Linux
-    const nvimLinuxPath = "nvim"
+    const nvimLinuxPath = process.env["ONI_NEOVIM_PATH"] || "nvim"
 
     let nvimProcessPath = Platform.isWindows() ? nvimWindowsProcessPath : Platform.isMac() ? nvimMacProcessPath : nvimLinuxPath
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -59,7 +59,6 @@ export const startNeovim = async (options: INeovimStartOptions = DefaultStartOpt
 
     // Assume nvim is available in path for Linux
     const nvimLinuxPath = process.env["ONI_NEOVIM_PATH"] || "nvim" // tslint:disable-line
-    Log.info("[NeovimProcessSpawnwer::startNeovim] process.env: " + JSON.stringify(process.env))
 
     let nvimProcessPath = Platform.isWindows() ? nvimWindowsProcessPath : Platform.isMac() ? nvimMacProcessPath : nvimLinuxPath
 

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -10,6 +10,11 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   export DISPLAY=:99.0
   sh -e /etc/init.d/xvfb start
   sleep 3
+
+  # Install Neovim
+  curl -LO https://github.com/neovim/neovim/releases/download/v0.2.2/nvim.appimage
+  chmod u+x nvim.appimage
+  ./nvim.appimage --version
 fi
 
 npm run build

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -23,6 +23,8 @@ npm run test:unit
 npm run lint
 npm run pack
 
+echo Using neovim path: $ONI_NEOVIM_PATH
+
 npm run test:integration
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -14,8 +14,8 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   # Install Neovim
   curl -LO https://github.com/neovim/neovim/releases/download/v0.2.2/nvim.appimage
   chmod u+x nvim.appimage
-  which nvim.appimage
   ./nvim.appimage --version
+  ONI_NEOVIM_PATH="$(cd "$(dirname "$1")"; pwd)/nvim.appimage"
 fi
 
 npm run build

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -22,8 +22,9 @@ npm run test:unit
 npm run lint
 npm run pack
 
+npm run test:integration
+
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-   npm run test:integration
    npm run demo
 fi
 

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -15,7 +15,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   curl -LO https://github.com/neovim/neovim/releases/download/v0.2.2/nvim.appimage
   chmod u+x nvim.appimage
   ./nvim.appimage --version
-  ONI_NEOVIM_PATH="$(cd "$(dirname "$1")"; pwd)/nvim.appimage"
+  export ONI_NEOVIM_PATH="$(cd "$(dirname "$1")"; pwd)/nvim.appimage"
 fi
 
 npm run build

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -14,6 +14,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   # Install Neovim
   curl -LO https://github.com/neovim/neovim/releases/download/v0.2.2/nvim.appimage
   chmod u+x nvim.appimage
+  which nvim.appimage
   ./nvim.appimage --version
 fi
 

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -38,8 +38,6 @@ export class Oni {
 
         log("Start options: " + JSON.stringify(options))
 
-        log("automation - env: " + JSON.stringify(process.env))
-
         this._app = new Application({
             path: executablePath,
             env: options.configurationPath ? { "ONI_CONFIG_FILE": options.configurationPath } : {},

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -38,6 +38,8 @@ export class Oni {
 
         log("Start options: " + JSON.stringify(options))
 
+        log("automation - env: " + JSON.stringify(process.env))
+
         this._app = new Application({
             path: executablePath,
             env: options.configurationPath ? { "ONI_CONFIG_FILE": options.configurationPath } : {},


### PR DESCRIPTION
I want to have the tests run on at least two platforms build-over-build - since we are disabling OSX due to issues on Travis, this is an attempt to get the CiTests to run on the Linux machines.