### PR TITLE
Bugfix/broken tooltip conditional

### DIFF
--- a/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
@@ -158,7 +158,11 @@ const getTitleAndContents = (result: types.Hover) => {
 
 const getQuickInfoElementsFromHover = (hover: types.Hover): JSX.Element => {
     const titleAndContents = getTitleAndContents(hover)
-    const hasDocs = !!(titleAndContents && titleAndContents.description.__html)
+    const hasDocs = !!(
+        titleAndContents
+        && titleAndContents.description
+        && titleAndContents.description.__html
+    )
 
     return titleAndContents && (
         <QuickInfoContainer hasDocs={hasDocs}>


### PR DESCRIPTION
@bryphe seems I missed a bug in a conditional I'm using to add padding to the documentation for the tooltip I noted the errors in my console whilst using a `vue` file  (I failed to check an iterim value existed which causes this error).