### PR TITLE
Dependency: Upgrade electron to 1.8.2-beta4

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "coveralls": "^3.0.0",
     "cross-env": "3.1.3",
     "css-loader": "0.28.4",
-    "electron": "1.8.1",
+    "electron": "^1.8.2-beta.4",
     "electron-builder": "19.46.4",
     "electron-devtools-installer": "2.2.1",
     "electron-mocha": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,9 +2181,9 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.1.tgz#19b6f39f2013e204a91a60bc3086dc7a4a07ed88"
+electron@^1.8.2-beta.4:
+  version "1.8.2-beta.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.2-beta.4.tgz#1836b204eeace9dc77062ed4820fdbc6cbd9a195"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"
@@ -6654,13 +6654,6 @@ vscode-css-languageserver-bin@^1.2.1:
   dependencies:
     vscode-css-languageservice "^3.0.3"
     vscode-languageserver "^3.5.0"
-
-vscode-css-languageservice@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-3.0.3.tgz#02cc4efa5335f5104e0a2f3b6920faaf59db4f7a"
-  dependencies:
-    vscode-languageserver-types "3.5.0"
-    vscode-nls "^2.0.1"
 
 vscode-css-languageservice@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
- Upgrade electron to 1.8.2-beta4, which includes security fixes: https://github.com/electron/electron/releases/tag/v1.8.2-beta.4