### PR TITLE
Automation: Fix QuickOpenTest

### DIFF
--- a/test/ci/QuickOpenTest.ts
+++ b/test/ci/QuickOpenTest.ts
@@ -3,7 +3,7 @@
  */
 
 export const test = async (oni: any) => {
-    oni.automation.waitForEditors()
+    await oni.automation.waitForEditors()
 
     oni.commands.executeCommand("quickOpen.show")
     await oni.automation.waitFor(() => oni.menu.isMenuOpen())


### PR DESCRIPTION
QuickOpenTest is failing on the Linux machines. It seems that the `waitForEditors` call isn't being properly awaited, which is causing a race condition.