### PR TITLE
Refactoring: Move 'Menu' to use 'Overlay' API

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -50,7 +50,8 @@ import {
     SyntaxHighlighter,
 } from "./../../Services/SyntaxHighlighting"
 
-import { tasks } from "./../../Services/Tasks"
+import { MenuManager } from "./../../Services/Menu"
+import { Tasks } from "./../../Services/Tasks"
 import { ThemeManager } from "./../../Services/Themes"
 import { TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 import { Workspace } from "./../../Services/Workspace"
@@ -146,7 +147,9 @@ export class NeovimEditor extends Editor implements IEditor {
         private _configuration: Configuration,
         private _diagnostics: IDiagnosticsDataSource,
         private _languageManager: LanguageManager,
+        private _menuManager: MenuManager,
         private _pluginManager: PluginManager,
+        private _tasks: Tasks,
         private _themeManager: ThemeManager,
         private _workspace: Workspace,
     ) {
@@ -169,7 +172,7 @@ export class NeovimEditor extends Editor implements IEditor {
         this._hoverRenderer = new HoverRenderer(this._colors, this, this._configuration, this._toolTipsProvider)
 
         this._definition = new Definition(this, this._store)
-        this._symbols = new Symbols(this, this._definition, this._languageManager)
+        this._symbols = new Symbols(this, this._definition, this._languageManager, this._menuManager)
 
         this._diagnostics.onErrorsChanged.subscribe(() => {
             const errors = this._diagnostics.getErrors()
@@ -197,6 +200,7 @@ export class NeovimEditor extends Editor implements IEditor {
             this._contextMenuManager,
             this._definition,
             this._languageIntegration,
+            this._menuManager,
             this._neovimInstance,
             this._rename,
             this._symbols,
@@ -211,8 +215,8 @@ export class NeovimEditor extends Editor implements IEditor {
         window.addEventListener("resize", updateViewport)
         updateViewport()
 
-        tasks.registerTaskProvider(commandManager)
-        tasks.registerTaskProvider(errorService)
+        this._tasks.registerTaskProvider(commandManager)
+        this._tasks.registerTaskProvider(errorService)
 
         services.push(errorService)
 
@@ -457,16 +461,6 @@ export class NeovimEditor extends Editor implements IEditor {
         this._languageIntegration.onHideDefinition.subscribe((definition) => {
             this._actions.hideDefinition()
         })
-
-        this._commands = new NeovimEditorCommands(
-            commandManager,
-            this._contextMenuManager,
-            this._definition,
-            this._languageIntegration,
-            this._neovimInstance,
-            this._rename,
-            this._symbols,
-        )
 
         this._render()
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -17,7 +17,7 @@ import { getUserConfigFilePath } from "./../../Services/Configuration"
 import { ContextMenuManager } from "./../../Services/ContextMenu"
 import { editorManager } from "./../../Services/EditorManager"
 import { findAllReferences, format, LanguageEditorIntegration } from "./../../Services/Language"
-import { menuManager } from "./../../Services/Menu"
+import { MenuManager } from "./../../Services/Menu"
 import { QuickOpen } from "./../../Services/QuickOpen"
 import { replaceAll } from "./../../Utility"
 
@@ -34,6 +34,7 @@ export class NeovimEditorCommands {
         private _contextMenuManager: ContextMenuManager,
         private _definition: Definition,
         private _languageEditorIntegration: LanguageEditorIntegration,
+        private _menuManager: MenuManager,
         private _neovimInstance: NeovimInstance,
         private _rename: Rename,
         private _symbols: Symbols,
@@ -45,7 +46,7 @@ export class NeovimEditorCommands {
         // TODO: This should be extracted
         // - Should not depend on NeovimInstance
         // - Should be able to work against the public 'IEditor' interface
-        const quickOpen = new QuickOpen(this._neovimInstance)
+        const quickOpen = new QuickOpen(this._menuManager, this._neovimInstance)
 
         const quickOpenCommand = (innerCommand: Oni.Commands.CommandCallback) => (qo: QuickOpen) => {
             return () => {
@@ -116,7 +117,7 @@ export class NeovimEditorCommands {
     }
 
         const shouldShowMenu = () => {
-            return !menuManager.isMenuOpen()
+            return !this._menuManager.isMenuOpen()
         }
 
         const openFolder = (neovimInstance: NeovimInstance) => {

--- a/browser/src/Editor/NeovimEditor/Symbols.ts
+++ b/browser/src/Editor/NeovimEditor/Symbols.ts
@@ -7,7 +7,7 @@ import * as types from "vscode-languageserver-types"
 
 import * as Oni from "oni-api"
 
-import { menuManager } from "./../../Services/Menu"
+import { MenuManager } from "./../../Services/Menu"
 
 import { LanguageManager } from "./../../Services/Language"
 
@@ -21,12 +21,13 @@ export class Symbols {
         private _editor: Oni.Editor,
         private _definition: Definition,
         private _languageManager: LanguageManager,
+        private _menuManager: MenuManager,
     ) {
 
     }
 
     public async openWorkspaceSymbolsMenu() {
-        const menu = menuManager.create()
+        const menu = this._menuManager.create()
 
         menu.show()
         menu.setItems([{
@@ -79,7 +80,7 @@ export class Symbols {
     }
 
     public async openDocumentSymbolsMenu(): Promise<void> {
-        const menu = menuManager.create()
+        const menu = this._menuManager.create()
 
         menu.show()
         menu.setLoading(true)

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -26,10 +26,13 @@ import {
     LanguageManager,
 } from "./../../Services/Language"
 
+import { MenuManager } from "./../../Services/Menu"
+
 import {
     ISyntaxHighlighter,
 } from "./../../Services/SyntaxHighlighting"
 
+import { Tasks } from "./../../Services/Tasks"
 import { ThemeManager } from "./../../Services/Themes"
 import { Workspace } from "./../../Services/Workspace"
 
@@ -104,11 +107,13 @@ export class OniEditor implements IEditor {
          configuration: Configuration,
          diagnostics: IDiagnosticsDataSource,
          languageManager: LanguageManager,
+         menuManager: MenuManager,
          pluginManager: PluginManager,
+        tasks: Tasks,
          themeManager: ThemeManager,
          workspace: Workspace,
     ) {
-        this._neovimEditor = new NeovimEditor(colors, completionProviders, configuration, diagnostics, languageManager, pluginManager, themeManager, workspace)
+        this._neovimEditor = new NeovimEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, pluginManager, tasks, themeManager, workspace)
 
         this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.scrollbar", <BufferScrollBarContainer />))
         this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.definition", <DefinitionContainer />))

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -109,7 +109,7 @@ export class OniEditor implements IEditor {
          languageManager: LanguageManager,
          menuManager: MenuManager,
          pluginManager: PluginManager,
-        tasks: Tasks,
+         tasks: Tasks,
          themeManager: ThemeManager,
          workspace: Workspace,
     ) {

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -23,7 +23,7 @@ import { getInstance as getDiagnosticsInstance } from "./../../Services/Diagnost
 import { editorManager } from "./../../Services/EditorManager"
 import { inputManager } from "./../../Services/InputManager"
 import * as LanguageManager from "./../../Services/Language"
-import { menuManager } from "./../../Services/Menu"
+import { getInstance as getMenuManagerInstance } from "./../../Services/Menu"
 import { getInstance as getOverlayInstance } from "./../../Services/Overlay"
 import { recorder } from "./../../Services/Recorder"
 import { getInstance as getSidebarInstance } from "./../../Services/Sidebar"
@@ -111,7 +111,7 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
     }
 
     public get menu(): any /* TODO */ {
-        return menuManager
+        return getMenuManagerInstance()
     }
 
     public get overlays(): any /* TODO */ {

--- a/browser/src/Services/Commands/GlobalCommands.ts
+++ b/browser/src/Services/Commands/GlobalCommands.ts
@@ -9,10 +9,10 @@ import { remote } from "electron"
 
 import * as Oni from "oni-api"
 
-import { menuManager } from "./../../Services/Menu"
+import { MenuManager } from "./../../Services/Menu"
 import { showAboutMessage } from "./../../Services/Metadata"
 import { multiProcess } from "./../../Services/MultiProcess"
-import { tasks } from "./../../Services/Tasks"
+import { Tasks } from "./../../Services/Tasks"
 import { windowManager } from "./../../Services/WindowManager"
 
 // import * as UI from "./../UI/index"
@@ -21,7 +21,22 @@ import { CallbackCommand, CommandManager } from "./../CommandManager"
 
 import * as Platform from "./../../Platform"
 
-export const activate = (commandManager: CommandManager) => {
+export const activate = (commandManager: CommandManager, menuManager: MenuManager, tasks: Tasks) => {
+
+    const popupMenuCommand = (innerCommand: Oni.Commands.CommandCallback) => {
+        return () => {
+            if (menuManager.isMenuOpen()) {
+                return innerCommand()
+            }
+
+            return false
+        }
+    }
+
+    const popupMenuClose = popupMenuCommand(() => menuManager.closeActiveMenu())
+    const popupMenuNext = popupMenuCommand(() => menuManager.nextMenuItem())
+    const popupMenuPrevious = popupMenuCommand(() => menuManager.previousMenuItem())
+    const popupMenuSelect = popupMenuCommand(() => menuManager.selectMenuItem())
 
     const commands = [
 
@@ -76,17 +91,3 @@ export const activate = (commandManager: CommandManager) => {
     commands.forEach((c) => commandManager.registerCommand(c))
 }
 
-const popupMenuCommand = (innerCommand: Oni.Commands.CommandCallback) => {
-    return () => {
-        if (menuManager.isMenuOpen()) {
-            return innerCommand()
-        }
-
-        return false
-    }
-}
-
-const popupMenuClose = popupMenuCommand(() => menuManager.closeActiveMenu())
-const popupMenuNext = popupMenuCommand(() => menuManager.nextMenuItem())
-const popupMenuPrevious = popupMenuCommand(() => menuManager.previousMenuItem())
-const popupMenuSelect = popupMenuCommand(() => menuManager.selectMenuItem())

--- a/browser/src/Services/Commands/GlobalCommands.ts
+++ b/browser/src/Services/Commands/GlobalCommands.ts
@@ -90,4 +90,3 @@ export const activate = (commandManager: CommandManager, menuManager: MenuManage
 
     commands.forEach((c) => commandManager.registerCommand(c))
 }
-

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -143,5 +143,3 @@ export class Menu {
         return menuState.menu.filteredOptions[index]
     }
 }
-
-export const menuManager = new MenuManager()

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -15,6 +15,10 @@ import * as MenuFilter from "./MenuFilter"
 import { createReducer } from "./MenuReducer"
 import * as State from "./MenuState"
 
+import { MenuContainer } from "./MenuComponent"
+
+import { Overlay, OverlayManager } from "./../Overlay"
+
 export interface IMenuOptionWithHighlights extends Oni.Menu.MenuOption {
     labelHighlights: number[]
     detailHighlights: number[]
@@ -30,6 +34,15 @@ export const menuActions: typeof ActionCreators = bindActionCreators(ActionCreat
 
 export class MenuManager {
     private _id: number = 0
+    private _overlay: Overlay
+
+    constructor(
+        private _overlayManager: OverlayManager,
+    ) {
+        this._overlay = this._overlayManager.createItem()
+        this._overlay.setContents(MenuContainer())
+        this._overlay.show()
+    }
 
     public create(): Menu {
         this._id++

--- a/browser/src/Services/Menu/index.ts
+++ b/browser/src/Services/Menu/index.ts
@@ -1,3 +1,19 @@
 export * from "./Menu"
 export * from "./MenuComponent"
 export * from "./MenuFilter"
+
+import { OverlayManager } from "./../Overlay"
+import { MenuManager } from "./Menu"
+
+let _menuManager: MenuManager
+
+export const activate = (overlayManager: OverlayManager) => {
+    console.dir(overlayManager)
+
+    _menuManager = new MenuManager()
+}
+
+export const getInstance = (): MenuManager => {
+    return _menuManager
+}
+

--- a/browser/src/Services/Menu/index.ts
+++ b/browser/src/Services/Menu/index.ts
@@ -10,7 +10,7 @@ let _menuManager: MenuManager
 export const activate = (overlayManager: OverlayManager) => {
     console.dir(overlayManager)
 
-    _menuManager = new MenuManager()
+    _menuManager = new MenuManager(overlayManager)
 }
 
 export const getInstance = (): MenuManager => {

--- a/browser/src/Services/Menu/index.ts
+++ b/browser/src/Services/Menu/index.ts
@@ -8,12 +8,9 @@ import { MenuManager } from "./Menu"
 let _menuManager: MenuManager
 
 export const activate = (overlayManager: OverlayManager) => {
-    console.dir(overlayManager)
-
     _menuManager = new MenuManager(overlayManager)
 }
 
 export const getInstance = (): MenuManager => {
     return _menuManager
 }
-

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -15,7 +15,7 @@ import { INeovimInstance } from "./../../neovim"
 import { commandManager } from "./../CommandManager"
 import { configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
-import { fuseFilter, Menu, menuManager } from "./../Menu"
+import { fuseFilter, Menu, MenuManager } from "./../Menu"
 
 import { FinderProcess } from "./FinderProcess"
 import { QuickOpenItem, QuickOpenType } from "./QuickOpenItem"
@@ -32,7 +32,7 @@ export class QuickOpen {
     private _menu: Menu
     private _lastCommand: string | null = null
 
-    constructor(neovimInstance: INeovimInstance) {
+    constructor(menuManager: MenuManager, neovimInstance: INeovimInstance) {
         this._neovimInstance = neovimInstance
 
         this._menu = menuManager.create()

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -10,13 +10,12 @@
  */
 
 import { remote } from "electron"
-import {EventEmitter} from "events"
 import * as find from "lodash/find"
 import * as flatten from "lodash/flatten"
 
 import * as Oni from "oni-api"
 
-import { Menu, menuManager } from "./../Services/Menu"
+import { Menu, MenuManager } from "./../Services/Menu"
 
 export interface ITask {
     name: string
@@ -31,12 +30,14 @@ export interface ITaskProvider {
     getTasks(): Promise<ITask[]>
 }
 
-export class Tasks extends EventEmitter {
+export class Tasks {
     private _lastTasks: ITask[] = []
-
     private _menu: Menu
-
     private _providers: ITaskProvider[] = []
+
+    constructor(
+        private _menuManager: MenuManager,
+    ) { }
 
     // TODO: This should be refactored, as it is simply
     // a timing dependency on when the object is created versus when
@@ -57,7 +58,7 @@ export class Tasks extends EventEmitter {
                             }
                         })
 
-            this._menu = menuManager.create()
+            this._menu = this._menuManager.create()
             this._menu.onItemSelected.subscribe((selection: any) => this._onItemSelected(selection))
             this._menu.show()
             this._menu.setItems(options)
@@ -89,4 +90,12 @@ export class Tasks extends EventEmitter {
     }
 }
 
-export const tasks = new Tasks()
+let _tasks: Tasks = null
+
+export const activate = (menuManager: MenuManager) => {
+    _tasks = new Tasks(menuManager)
+}
+
+export const getInstance = (): Tasks => {
+    return _tasks
+}

--- a/browser/src/Services/Themes/ThemePicker.ts
+++ b/browser/src/Services/Themes/ThemePicker.ts
@@ -6,10 +6,10 @@
 
 import { CallbackCommand, commandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
-import { menuManager } from "./../Menu"
+import { MenuManager } from "./../Menu"
 import { ThemeManager } from "./ThemeManager"
 
-const chooseTheme = async (configuration: Configuration, themeManager: ThemeManager) => {
+const chooseTheme = async (configuration: Configuration, menuManager: MenuManager, themeManager: ThemeManager) => {
         const themes = await themeManager.getAllThemes()
 
         const items = themes.map((t) => ({
@@ -44,13 +44,13 @@ const chooseTheme = async (configuration: Configuration, themeManager: ThemeMana
         })
 }
 
-export const activate = (configuration: Configuration, themeManager: ThemeManager) => {
+export const activate = (configuration: Configuration, menuManager: MenuManager, themeManager: ThemeManager) => {
 
     commandManager.registerCommand(
         new CallbackCommand(
             "oni.themes.choose",
             "Themes: Choose Theme",
             "Choose your theme from the available bundled themes.",
-            () => chooseTheme(configuration, themeManager),
+            () => chooseTheme(configuration, menuManager, themeManager),
         ))
 }

--- a/browser/src/UI/Shell/ShellView.tsx
+++ b/browser/src/UI/Shell/ShellView.tsx
@@ -9,7 +9,6 @@ import * as Platform from "./../../Platform"
 import { getKeyEventToVimKey } from "./../../Input/Keyboard"
 import { focusManager } from "./../../Services/FocusManager"
 import { inputManager } from "./../../Services/InputManager"
-import { MenuContainer } from "./../../Services/Menu"
 import { IThemeColors } from "./../../Services/Themes/ThemeManager"
 import * as WindowManager from "./../../Services/WindowManager"
 
@@ -46,9 +45,6 @@ export class ShellView extends React.PureComponent<IShellViewComponentProps, {}>
                         <div className="container full">
                             <div className="stack">
                                 <WindowSplits windowManager={this.props.windowManager} />
-                            </div>
-                            <div className="stack layer">
-                                <MenuContainer />
                             </div>
                             <Overlays />
                         </div>

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -14,13 +14,15 @@ import { Configuration } from "./Services/Configuration"
 import { IDiagnosticsDataSource } from "./Services/Diagnostics"
 import { editorManager } from "./Services/EditorManager"
 import { LanguageManager } from "./Services/Language"
+import { MenuManager } from "./Services/Menu"
+import { Tasks } from "./Services/Tasks"
 import { ThemeManager } from "./Services/Themes"
 import { windowManager } from "./Services/WindowManager"
 import { Workspace } from "./Services/Workspace"
 
-export const startEditors = async (args: any, colors: Colors, completionProviders: CompletionProviders, configuration: Configuration, diagnostics: IDiagnosticsDataSource, languageManager: LanguageManager, pluginManager: PluginManager, themeManager: ThemeManager, workspace: Workspace): Promise<void> => {
+export const startEditors = async (args: any, colors: Colors, completionProviders: CompletionProviders, configuration: Configuration, diagnostics: IDiagnosticsDataSource, languageManager: LanguageManager, menuManager: MenuManager, pluginManager: PluginManager, tasks: Tasks, themeManager: ThemeManager, workspace: Workspace): Promise<void> => {
 
-    const editor = new OniEditor(colors, completionProviders, configuration, diagnostics, languageManager, pluginManager, themeManager, workspace)
+    const editor = new OniEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, pluginManager, tasks, themeManager, workspace)
     editorManager.setActiveEditor(editor)
     windowManager.split(0, editor)
 


### PR DESCRIPTION
- Move the `Menu`/`MenuManager` to the `Overlay` API, as opposed to being hardcoded
- Make the dependencies explicit for `MenuManager` and `Tasks`