### PR TITLE
Regression: Fix external command line that was broken by #1356

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -269,8 +269,8 @@ export class NeovimEditor extends Editor implements IEditor {
             this._actions.wildMenuSelect(wildMenuInfo)
         })
 
-        this._neovimInstance.onWildMenuHide.subscribe(() => { 
-            this._actions.hideWildMenu() 
+        this._neovimInstance.onWildMenuHide.subscribe(() => {
+            this._actions.hideWildMenu()
             this._externalMenuOverlay.hide()
         })
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -36,6 +36,7 @@ import { Completion, CompletionProviders } from "./../../Services/Completion"
 import { Configuration, IConfigurationValues } from "./../../Services/Configuration"
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 import { Errors } from "./../../Services/Errors"
+import { Overlay, OverlayManager } from "./../../Services/Overlay"
 import * as Shell from "./../../UI/Shell"
 
 import {
@@ -79,6 +80,10 @@ import { Rename } from "./Rename"
 import { Symbols } from "./Symbols"
 import { IToolTipsProvider, NeovimEditorToolTipsProvider } from "./ToolTipsProvider"
 
+import CommandLine from "./../../UI/components/CommandLine"
+import ExternalMenus from "./../../UI/components/ExternalMenus"
+import WildMenu from "./../../UI/components/WildMenu"
+
 import { WelcomeBufferLayer } from "./WelcomeBufferLayer"
 
 export class NeovimEditor extends Editor implements IEditor {
@@ -121,6 +126,7 @@ export class NeovimEditor extends Editor implements IEditor {
     private _definition: Definition = null
     private _toolTipsProvider: IToolTipsProvider
     private _commands: NeovimEditorCommands
+    private _externalMenuOverlay: Overlay
 
     private _bufferLayerManager: BufferLayerManager
 
@@ -148,6 +154,7 @@ export class NeovimEditor extends Editor implements IEditor {
         private _diagnostics: IDiagnosticsDataSource,
         private _languageManager: LanguageManager,
         private _menuManager: MenuManager,
+        private _overlayManager: OverlayManager,
         private _pluginManager: PluginManager,
         private _tasks: Tasks,
         private _themeManager: ThemeManager,
@@ -178,6 +185,15 @@ export class NeovimEditor extends Editor implements IEditor {
             const errors = this._diagnostics.getErrors()
             this._actions.setErrors(errors)
         })
+
+        this._externalMenuOverlay = this._overlayManager.createItem()
+        this._externalMenuOverlay.setContents(
+                <Provider store={this._store}>
+                    <ExternalMenus>
+                        <CommandLine />
+                        <WildMenu />
+                    </ExternalMenus>
+                </Provider>)
 
         this._popupMenu = new NeovimPopupMenu(
             this._neovimInstance.onShowPopupMenu,
@@ -241,20 +257,26 @@ export class NeovimEditor extends Editor implements IEditor {
                 showCommandLineInfo.indent,
                 showCommandLineInfo.level,
             )
+            this._externalMenuOverlay.show()
         })
 
         this._neovimInstance.onWildMenuShow.subscribe(wildMenuInfo => {
             this._actions.showWildMenu(wildMenuInfo)
+            this._externalMenuOverlay.show()
         })
 
         this._neovimInstance.onWildMenuSelect.subscribe(wildMenuInfo => {
             this._actions.wildMenuSelect(wildMenuInfo)
         })
 
-        this._neovimInstance.onWildMenuHide.subscribe(this._actions.hideWildMenu)
+        this._neovimInstance.onWildMenuHide.subscribe(() => { 
+            this._actions.hideWildMenu() 
+            this._externalMenuOverlay.hide()
+        })
 
         this._neovimInstance.onCommandLineHide.subscribe(() => {
             this._actions.hideCommandLine()
+            this._externalMenuOverlay.hide()
         })
 
         this._neovimInstance.onCommandLineSetCursorPosition.subscribe(commandLinePos => {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -262,7 +262,6 @@ export class NeovimEditor extends Editor implements IEditor {
 
         this._neovimInstance.onWildMenuShow.subscribe(wildMenuInfo => {
             this._actions.showWildMenu(wildMenuInfo)
-            this._externalMenuOverlay.show()
         })
 
         this._neovimInstance.onWildMenuSelect.subscribe(wildMenuInfo => {
@@ -271,7 +270,6 @@ export class NeovimEditor extends Editor implements IEditor {
 
         this._neovimInstance.onWildMenuHide.subscribe(() => {
             this._actions.hideWildMenu()
-            this._externalMenuOverlay.hide()
         })
 
         this._neovimInstance.onCommandLineHide.subscribe(() => {

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -11,15 +11,12 @@ import { IEvent } from "oni-types"
 import { NeovimInstance, NeovimScreen } from "./../../neovim"
 import { INeovimRenderer } from "./../../Renderer"
 
-import CommandLine from "./../../UI/components/CommandLine"
 import { Cursor } from "./../../UI/components/Cursor"
 import { CursorLine } from "./../../UI/components/CursorLine"
-import ExternalMenus from "./../../UI/components/ExternalMenus"
 import { InstallHelp } from "./../../UI/components/InstallHelp"
 import { TabsContainer } from "./../../UI/components/Tabs"
 import { ToolTips } from "./../../UI/components/ToolTip"
 import { TypingPrediction } from "./../../UI/components/TypingPredictions"
-import WildMenu from "./../../UI/components/WildMenu"
 
 import { TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 
@@ -58,10 +55,6 @@ export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> 
                     onTabSelect={this.props.onTabSelect}/>
             </div>
             <div className="container full">
-                <ExternalMenus>
-                    <CommandLine />
-                    <WildMenu />
-                </ExternalMenus>
                 <div className="stack">
                     <NeovimRenderer renderer={this.props.renderer}
                         neovimInstance={this.props.neovimInstance}

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -27,6 +27,7 @@ import {
 } from "./../../Services/Language"
 
 import { MenuManager } from "./../../Services/Menu"
+import { OverlayManager } from "./../../Services/Overlay"
 
 import {
     ISyntaxHighlighter,
@@ -108,12 +109,13 @@ export class OniEditor implements IEditor {
          diagnostics: IDiagnosticsDataSource,
          languageManager: LanguageManager,
          menuManager: MenuManager,
+         overlayManager: OverlayManager,
          pluginManager: PluginManager,
          tasks: Tasks,
          themeManager: ThemeManager,
          workspace: Workspace,
     ) {
-        this._neovimEditor = new NeovimEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, pluginManager, tasks, themeManager, workspace)
+        this._neovimEditor = new NeovimEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, overlayManager, pluginManager, tasks, themeManager, workspace)
 
         this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.scrollbar", <BufferScrollBarContainer />))
         this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.definition", <DefinitionContainer />))

--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -137,7 +137,7 @@ class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> 
         return (
             !waiting &&
             visible && (
-                <CommandLineBox className="command-line-box">
+                <CommandLineBox className="command-line">
                     <CommandLineOutput innerRef={e => (this._inputElement = e)}>
                         {this.renderIconOrChar(firstchar)}
                         {this.props.prompt}

--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -137,7 +137,7 @@ class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> 
         return (
             !waiting &&
             visible && (
-                <CommandLineBox>
+                <CommandLineBox className="command-line-box">
                     <CommandLineOutput innerRef={e => (this._inputElement = e)}>
                         {this.renderIconOrChar(firstchar)}
                         {this.props.prompt}

--- a/browser/src/UI/components/ExternalMenus.tsx
+++ b/browser/src/UI/components/ExternalMenus.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import * as ReactDOM from "react-dom"
 import { connect } from "react-redux"
 import styled from "styled-components"
 
@@ -28,23 +27,12 @@ interface Props {
 
 class ExternalMenus extends React.Component<Props> {
 
-    public constructor(props: Props, private stackLayer: HTMLDivElement) {
-        super(props)
-
-        this.stackLayer = document.querySelector(".stack .layer")
-    }
-
     public render() {
         const { wildmenu, commandLine } = this.props
         const visible = commandLine.visible || wildmenu.visible
-        return (
-            visible && ReactDOM.createPortal(
-                <MenuContainer loaded={commandLine.visible && wildmenu.visible}>
+        return visible ? <MenuContainer loaded={commandLine.visible && wildmenu.visible}>
                     {this.props.children}
-                </MenuContainer>,
-                this.stackLayer,
-            )
-        )
+                </MenuContainer> : null
     }
 }
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -148,7 +148,7 @@ const start = async (args: string[]): Promise<void> => {
    await Promise.race([Utility.delay(5000),
      Promise.all([
         SharedNeovimInstance.activate(configuration, pluginManager),
-        startEditors(filesToOpen, Colors.getInstance(), CompletionProviders.getInstance(), configuration, diagnostics, languageManager, menuManager, pluginManager, tasks, Themes.getThemeManagerInstance(), workspace)
+        startEditors(filesToOpen, Colors.getInstance(), CompletionProviders.getInstance(), configuration, diagnostics, languageManager, menuManager, overlayManager, pluginManager, tasks, Themes.getThemeManagerInstance(), workspace)
     ])
    ])
     Performance.endMeasure("Oni.Start.Editors")

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -15,14 +15,15 @@ import { IDiagnosticsDataSource } from "./Services/Diagnostics"
 import { editorManager } from "./Services/EditorManager"
 import { LanguageManager } from "./Services/Language"
 import { MenuManager } from "./Services/Menu"
+import { OverlayManager } from "./Services/Overlay"
 import { Tasks } from "./Services/Tasks"
 import { ThemeManager } from "./Services/Themes"
 import { windowManager } from "./Services/WindowManager"
 import { Workspace } from "./Services/Workspace"
 
-export const startEditors = async (args: any, colors: Colors, completionProviders: CompletionProviders, configuration: Configuration, diagnostics: IDiagnosticsDataSource, languageManager: LanguageManager, menuManager: MenuManager, pluginManager: PluginManager, tasks: Tasks, themeManager: ThemeManager, workspace: Workspace): Promise<void> => {
+export const startEditors = async (args: any, colors: Colors, completionProviders: CompletionProviders, configuration: Configuration, diagnostics: IDiagnosticsDataSource, languageManager: LanguageManager, menuManager: MenuManager, overlayManager: OverlayManager, pluginManager: PluginManager, tasks: Tasks, themeManager: ThemeManager, workspace: Workspace): Promise<void> => {
 
-    const editor = new OniEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, pluginManager, tasks, themeManager, workspace)
+    const editor = new OniEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, overlayManager, pluginManager, tasks, themeManager, workspace)
     editorManager.setActiveEditor(editor)
     windowManager.split(0, editor)
 

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -17,6 +17,7 @@ const CiTests = [
     "AutoCompletionTest-CSS",
     "AutoCompletionTest-HTML",
     "AutoCompletionTest-TypeScript",
+    "Editor.ExternalCommandLineTest",
     "LargeFileTest",
     "PaintPerformanceTest",
     "QuickOpenTest",

--- a/test/ci/Editor.ExternalCommandLine.config.js
+++ b/test/ci/Editor.ExternalCommandLine.config.js
@@ -1,0 +1,7 @@
+// For more information on customizing Oni,
+// check out our wiki page:
+// https://github.com/onivim/oni/wiki/Configuration
+
+module.exports = {
+    "experimental.commandline.mode": true,
+};

--- a/test/ci/Editor.ExternalCommandLineTest.ts
+++ b/test/ci/Editor.ExternalCommandLineTest.ts
@@ -1,0 +1,23 @@
+/**
+ * Test script to validate the external command line
+ */
+
+import * as assert from "assert"
+import * as Oni from "oni-api"
+
+import { getElementByClassName } from "./Common"
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    oni.automation.sendKeys(":")
+
+    await oni.automation.waitFor(() => !!getElementByClassName("command-line"))
+
+    assert.ok(!!getElementByClassName("command-line"), "Validate command line UI is shown")
+}
+
+// Bring in custom config to turn off animations, in order to reduce noise.
+export const settings = {
+    configPath: "Editor.ExternalCommandLine.config.js",
+}


### PR DESCRIPTION
PR #1356 caused a regression in the external command line / wildmenu - it no longer shows when pressing `:` and having `external.commandline.mode` set.

The issue was that the `<ExternalMenu>` component relied on having DOM rendered somewhere with className `stack layer` via portals. This let it render in the same spot that the `QuickOpen` and `Command Palette` experiences were rendered, but still have state managed by Neovim. The only downside is this is dependent on DOM that's external to the domain of the component, and might be a bit fragile, given that there is lots of churn especially with window management etc. Therefore, I moved it to also use the new `Overlay` API for now.

I also added a test to try and protect against this regression in the future - the ci test I added just types `:` and validates the command line shows up.