### PR TITLE
Workspace: Fix bugs with test-file mappings

### DIFF
--- a/.oni/config.js
+++ b/.oni/config.js
@@ -16,6 +16,6 @@ module.exports = {
     "workspace.testFileMappings": [{
         sourceFolder: "browser/src",
         mappedFolder: "browser/test",
-        mappedFileName: "${fileName}Test.ts",
+        mappedFileName: "${fileName}Tests.ts",
     }]
 }

--- a/.oni/config.js
+++ b/.oni/config.js
@@ -16,6 +16,6 @@ module.exports = {
     "workspace.testFileMappings": [{
         sourceFolder: "browser/src",
         mappedFolder: "browser/test",
-        mappedFileName: "sourceTest.ts",
+        mappedFileName: "${fileName}Test.ts",
     }]
 }

--- a/browser/src/Services/FileMappings.ts
+++ b/browser/src/Services/FileMappings.ts
@@ -4,7 +4,6 @@
  * Shared code / utilities for mapping files
  */
 
-import * as fs from "fs"
 import * as path from "path"
 
 export interface IFileMapping {
@@ -15,7 +14,7 @@ export interface IFileMapping {
     mappedFileName: string
 }
 
-export const getMappedFile = (rootFolder: string, filePath: string, mappings: IFileMapping[], _fs: typeof fs = fs): string | null => {
+export const getMappedFile = (rootFolder: string, filePath: string, mappings: IFileMapping[]): string | null => {
     const mappingsThatApply = mappings.filter((m) => doesMappingMatchFile(rootFolder, filePath, m))
 
     if (mappingsThatApply.length === 0) {
@@ -24,22 +23,18 @@ export const getMappedFile = (rootFolder: string, filePath: string, mappings: IF
 
     const mapping = mappingsThatApply[0]
 
-    return getMappedFileFromMapping(rootFolder, filePath, mapping, _fs)
+    return getMappedFileFromMapping(rootFolder, filePath, mapping)
 }
 
 export const doesMappingMatchFile = (rootFolder: string, filePath: string, mapping: IFileMapping): boolean => {
     return filePath.indexOf(path.join(rootFolder, mapping.sourceFolder)) === 0
 }
 
-export const getMappedFileFromMapping = (rootFolder: string, filePath: string, mapping: IFileMapping, _fs: typeof fs = fs): string | null => {
+export const getMappedFileFromMapping = (rootFolder: string, filePath: string, mapping: IFileMapping): string | null => {
     const fullSourceRoot = path.join(rootFolder, mapping.sourceFolder)
     const difference = getPathDifference(fullSourceRoot, path.dirname(filePath))
 
     const mappedFile = path.join(rootFolder, mapping.mappedFolder, difference, mapping.mappedFileName)
-
-    if (!_fs.existsSync(mappedFile)) {
-        return null
-    }
 
     return mappedFile
 }

--- a/browser/src/Services/FileMappings.ts
+++ b/browser/src/Services/FileMappings.ts
@@ -34,9 +34,27 @@ export const getMappedFileFromMapping = (rootFolder: string, filePath: string, m
     const fullSourceRoot = path.join(rootFolder, mapping.sourceFolder)
     const difference = getPathDifference(fullSourceRoot, path.dirname(filePath))
 
-    const mappedFile = path.join(rootFolder, mapping.mappedFolder, difference, mapping.mappedFileName)
+    // Resolve the variables in the file path, like `${fileName}`
+    const resolvedMappedFile = replaceVariablesInFileName(mapping.mappedFileName, filePath)
+
+    const mappedFile = path.join(rootFolder, mapping.mappedFolder, difference, resolvedMappedFile)
 
     return mappedFile
+}
+
+export const replaceVariablesInFileName = (mappingFileNameWithVariables: string, originalFilePath: string): string => {
+
+    const originalFileNameWithExtension = path.basename(originalFilePath)
+    const originalExtension = path.extname(originalFileNameWithExtension)
+
+    const originalFileNameWithoutExtension = path.basename(originalFilePath, originalExtension)
+
+    let ret = mappingFileNameWithVariables
+
+    // Resolve '${fileName}' variable
+    ret = ret.split("${fileName}").join(originalFileNameWithoutExtension) // tslint:disable-line
+
+    return ret
 }
 
 export const getPathDifference = (path1: string, path2: string): string => {

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -3,7 +3,11 @@
  *
  * Commands registered for the workspace
  */
+import * as fs from "fs"
+import * as path from "path"
+
 import { remote } from "electron"
+import * as mkdirp from "mkdirp"
 
 import { CallbackCommand, commandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
@@ -31,31 +35,54 @@ export const activateCommands = (configuration: Configuration, editorManager: Ed
     }
 
     const openTestFileInSplit = () => {
+        const mappedFile = getTestFileMappedToCurrentFile()
+
+        if (mappedFile) {
+
+            if (!fs.existsSync(mappedFile)) {
+                // Ensure the folder exists for the mapped file
+                const containingFolder = path.dirname(mappedFile)
+                mkdirp.sync(containingFolder)
+            }
+            
+            editorManager.activeEditor.openFile(mappedFile)
+        }
+    }
+
+    const hasExistingTestFile = () => {
+        const mappedFile = getTestFileMappedToCurrentFile()
+
+        return fs.existsSync(mappedFile)
+    }
+
+    const canCreateTestFile = () => {
+        const mappedFile = getTestFileMappedToCurrentFile()
+
+        return !fs.existsSync(mappedFile)
+    }
+
+    const getTestFileMappedToCurrentFile = (): string => {
         const mappings: FileMappings.IFileMapping[] = configuration.getValue("workspace.testFileMappings")
 
         if (!mappings) {
-            return
+            return null
         }
 
         const currentEditor = editorManager.activeEditor
         const currentBufferPath = currentEditor.activeBuffer.filePath
 
         if (!currentBufferPath) {
-            return
+            return null
         }
 
         const mappedFile = FileMappings.getMappedFile(workspace.activeWorkspace, currentBufferPath, mappings)
-
-        editorManager.activeEditor.openFile(mappedFile)
-
-        // TODO: Get current workspace directory and map to it
-        // WAITING on configuration work
-
+        return mappedFile
     }
 
     const commands = [
         new CallbackCommand("workspace.openFolder", "Workspace: Open Folder", "Set a folder as the working directory for Oni", () => openFolder(), () => !!!workspace.activeWorkspace),
-        new CallbackCommand("workspace.openTestFile", "Workspace: Open Test File", "Open the test file corresponding to this source file.", () => openTestFileInSplit()),
+        new CallbackCommand("workspace.openTestFile", "Workspace: Open Test File", "Open the test file corresponding to this source file.", () => openTestFileInSplit(), () => hasExistingTestFile()),
+        new CallbackCommand("workspace.createTestFile", "Workspace: Create Test File", "Create a test file for this source file.", () => openTestFileInSplit(), () => canCreateTestFile()),
         new CallbackCommand("workspace.closeFolder", "Workspace: Close Folder", "Close the current folder", () => workspace.changeDirectory(null), () => !!workspace.activeWorkspace),
     ]
 

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -44,7 +44,7 @@ export const activateCommands = (configuration: Configuration, editorManager: Ed
                 const containingFolder = path.dirname(mappedFile)
                 mkdirp.sync(containingFolder)
             }
-            
+
             editorManager.activeEditor.openFile(mappedFile)
         }
     }

--- a/browser/test/Services/FileMappingsTests.ts
+++ b/browser/test/Services/FileMappingsTests.ts
@@ -36,7 +36,7 @@ describe("FileMappings", () => {
                 mappedFileName: "${fileName}Test.${ext}", // tslint:disable-line
             }
 
-            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping, fileSystem)
+            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)
             assert.strictEqual(mappedFile, null, "Validate mapping returned null since there was no test file")
         })
 
@@ -52,10 +52,10 @@ describe("FileMappings", () => {
                 sourceFolder: "browser/src",
 
                 mappedFolder: "browser/test",
-                mappedFileName: "sourceTest.ts",
+                mappedFileName: "${fileName}Test.ts",
             }
 
-            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping, fileSystem)
+            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)
             assert.strictEqual(mappedFile, testFile, "Validate mapping worked correctly")
         })
 
@@ -67,7 +67,7 @@ describe("FileMappings", () => {
             fileSystem.mkdirpSync(nestedTestFolder)
 
             const srcFile = path.join(nestedSrcFolder, "source.ts")
-            const testFile = path.join(nestedTestFolder, "sourceTest.ts")
+            const testFile = path.join(nestedTestFolder, "source.test.ts")
 
             fileSystem.writeFileSync(srcFile, " ")
             fileSystem.writeFileSync(testFile, " ")
@@ -76,10 +76,10 @@ describe("FileMappings", () => {
                 sourceFolder: "browser/src",
 
                 mappedFolder: "browser/test",
-                mappedFileName: "sourceTest.ts",
+                mappedFileName: "{fileName}.test.ts",
             }
 
-            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping, fileSystem)
+            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)
             assert.strictEqual(mappedFile, testFile, "Validate mapping worked correctly")
         })
     })

--- a/browser/test/Services/FileMappingsTests.ts
+++ b/browser/test/Services/FileMappingsTests.ts
@@ -25,21 +25,6 @@ describe("FileMappings", () => {
     })
 
     describe("getMappedFile", () => {
-        it("returns null if no mapped file exists", () => {
-            const srcFile = path.join(srcPath, "source.ts")
-            fileSystem.writeFileSync(srcFile, " ")
-
-            const mapping: FileMappings.IFileMapping = {
-                sourceFolder: "browser/src",
-
-                mappedFolder: "browser/test",
-                mappedFileName: "${fileName}Test.${ext}", // tslint:disable-line
-            }
-
-            const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)
-            assert.strictEqual(mappedFile, null, "Validate mapping returned null since there was no test file")
-        })
-
         it("returns simple mapping", () => {
 
             const srcFile = path.join(srcPath, "source.ts")
@@ -76,7 +61,7 @@ describe("FileMappings", () => {
                 sourceFolder: "browser/src",
 
                 mappedFolder: "browser/test",
-                mappedFileName: "{fileName}.test.ts",
+                mappedFileName: "${fileName}.test.ts",
             }
 
             const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)

--- a/browser/test/Services/FileMappingsTests.ts
+++ b/browser/test/Services/FileMappingsTests.ts
@@ -37,7 +37,7 @@ describe("FileMappings", () => {
                 sourceFolder: "browser/src",
 
                 mappedFolder: "browser/test",
-                mappedFileName: "${fileName}Test.ts",
+                mappedFileName: "${fileName}Test.ts", // tslint:disable-line
             }
 
             const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)
@@ -61,7 +61,7 @@ describe("FileMappings", () => {
                 sourceFolder: "browser/src",
 
                 mappedFolder: "browser/test",
-                mappedFileName: "${fileName}.test.ts",
+                mappedFileName: "${fileName}.test.ts", // tslint:disable-line
             }
 
             const mappedFile = FileMappings.getMappedFileFromMapping(rootPath, srcFile, mapping)


### PR DESCRIPTION
This fixes some issues with the test-file mappings:
- Needed to add variable resolution, ie, `${fileName}`
- Needed to fix up `.oni/config.js` to pick up the new functionality