### PR TITLE
Run prettier on all files in repo

### DIFF
--- a/browser/src/Editor/BufferHighlights.ts
+++ b/browser/src/Editor/BufferHighlights.ts
@@ -29,27 +29,44 @@ export class BufferHighlightsUpdater implements IBufferHighlightsUpdater {
 
     public async start(): Promise<void> {
         if (!this._highlightId) {
-            this._highlightId = await this._neovimInstance.request<number>("nvim_buf_add_highlight", [this._bufferId, 0, "", 0, 0, 0])
+            this._highlightId = await this._neovimInstance.request<number>(
+                "nvim_buf_add_highlight",
+                [this._bufferId, 0, "", 0, 0, 0],
+            )
         }
     }
 
-    public setHighlightsForLine(line: number, highlights: SyntaxHighlighting.HighlightInfo[]): void {
+    public setHighlightsForLine(
+        line: number,
+        highlights: SyntaxHighlighting.HighlightInfo[],
+    ): void {
         this.clearHighlightsForLine(line)
 
         if (!highlights || !highlights.length) {
             return
         }
 
-        const addHighlightCalls = highlights.map((hl) => {
-            return ["nvim_buf_add_highlight", [this._bufferId, this._highlightId, hl.highlightGroup,
-                hl.range.start.line, hl.range.start.character, hl.range.end.character]]
+        const addHighlightCalls = highlights.map(hl => {
+            return [
+                "nvim_buf_add_highlight",
+                [
+                    this._bufferId,
+                    this._highlightId,
+                    hl.highlightGroup,
+                    hl.range.start.line,
+                    hl.range.start.character,
+                    hl.range.end.character,
+                ],
+            ]
         })
 
         this._calls = this._calls.concat(addHighlightCalls)
     }
     public clearHighlightsForLine(line: number): void {
-
-        this._calls.push(["nvim_buf_clear_highlight", [this._bufferId, this._highlightId, line, line + 1]])
+        this._calls.push([
+            "nvim_buf_clear_highlight",
+            [this._bufferId, this._highlightId, line, line + 1],
+        ])
     }
 
     public async apply(): Promise<BufferHighlightId> {

--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -21,7 +21,11 @@ import { PromiseQueue } from "./../Services/Language/PromiseQueue"
 
 import * as SyntaxHighlighting from "./../Services/SyntaxHighlighting"
 
-import { BufferHighlightId, BufferHighlightsUpdater, IBufferHighlightsUpdater } from "./BufferHighlights"
+import {
+    BufferHighlightId,
+    BufferHighlightsUpdater,
+    IBufferHighlightsUpdater,
+} from "./BufferHighlights"
 
 import * as Actions from "./NeovimEditor/NeovimEditorActions"
 
@@ -33,7 +37,6 @@ export interface IBuffer extends Oni.Buffer {
 }
 
 export class Buffer implements Oni.Buffer {
-
     private _id: string
     private _filePath: string
     private _language: string
@@ -73,9 +76,11 @@ export class Buffer implements Oni.Buffer {
         return this._id
     }
 
-    constructor(private _neovimInstance: NeovimInstance,
-                private _actions: typeof Actions,
-                evt: EventContext) {
+    constructor(
+        private _neovimInstance: NeovimInstance,
+        private _actions: typeof Actions,
+        evt: EventContext,
+    ) {
         this.updateFromEvent(evt)
     }
 
@@ -84,13 +89,12 @@ export class Buffer implements Oni.Buffer {
     }
 
     public async getCursorPosition(): Promise<types.Position> {
-       const pos = await this._neovimInstance.callFunction("getpos", ["."])
-       const [, oneBasedLine, oneBasedColumn] = pos
-       return types.Position.create(oneBasedLine - 1, oneBasedColumn - 1)
+        const pos = await this._neovimInstance.callFunction("getpos", ["."])
+        const [, oneBasedLine, oneBasedColumn] = pos
+        return types.Position.create(oneBasedLine - 1, oneBasedColumn - 1)
     }
 
     public async getLines(start?: number, end?: number): Promise<string[]> {
-
         if (typeof start !== "number") {
             start = 0
         }
@@ -103,21 +107,29 @@ export class Buffer implements Oni.Buffer {
             Log.warn("getLines called with over 2500 lines, this may cause instability.")
         }
 
-        const lines = await this._neovimInstance.request<any>("nvim_buf_get_lines", [parseInt(this._id, 10), start, end, false])
+        const lines = await this._neovimInstance.request<any>("nvim_buf_get_lines", [
+            parseInt(this._id, 10),
+            start,
+            end,
+            false,
+        ])
         return lines
     }
 
     public async setLanguage(language: string): Promise<void> {
-        await this._neovimInstance.request<any>("nvim_buf_set_option", [parseInt(this._id, 10), "filetype", language])
+        await this._neovimInstance.request<any>("nvim_buf_set_option", [
+            parseInt(this._id, 10),
+            "filetype",
+            language,
+        ])
     }
 
     public async applyTextEdits(textEdits: types.TextEdit | types.TextEdit[]): Promise<void> {
-
         const textEditsAsArray = textEdits instanceof Array ? textEdits : [textEdits]
 
         const sortedEdits = LanguageManager.sortTextEdits(textEditsAsArray)
 
-        const deferredEdits = sortedEdits.map((te) => {
+        const deferredEdits = sortedEdits.map(te => {
             return Observable.defer(async () => {
                 const range = te.range
                 Log.info("[Buffer] Applying edit")
@@ -139,10 +151,16 @@ export class Buffer implements Oni.Buffer {
 
                     const lines = newLine.split(os.EOL)
 
-                    calls.push(["nvim_buf_set_lines", [parseInt(this._id, 10), lineStart, lineStart + 1, false, lines ]])
+                    calls.push([
+                        "nvim_buf_set_lines",
+                        [parseInt(this._id, 10), lineStart, lineStart + 1, false, lines],
+                    ])
                 } else if (characterEnd === 0 && characterStart === 0) {
                     const lines = te.newText.split(os.EOL)
-                    calls.push(["nvim_buf_set_lines", [parseInt(this._id, 10), lineStart, lineEnd, false, lines ]])
+                    calls.push([
+                        "nvim_buf_set_lines",
+                        [parseInt(this._id, 10), lineStart, lineEnd, false, lines],
+                    ])
                 } else {
                     Log.warn("Multi-line mid character edits not currently supported")
                 }
@@ -152,11 +170,13 @@ export class Buffer implements Oni.Buffer {
         })
 
         await Observable.from(deferredEdits)
-                .concatMap(de => de)
-                .toPromise()
+            .concatMap(de => de)
+            .toPromise()
     }
 
-    public async getOrCreateHighlightGroup(highlight: SyntaxHighlighting.IHighlight | string): Promise<SyntaxHighlighting.HighlightGroupId> {
+    public async getOrCreateHighlightGroup(
+        highlight: SyntaxHighlighting.IHighlight | string,
+    ): Promise<SyntaxHighlighting.HighlightGroupId> {
         if (typeof highlight === "string") {
             return highlight
         } else {
@@ -165,10 +185,16 @@ export class Buffer implements Oni.Buffer {
         }
     }
 
-    public async updateHighlights(updateFunction: (highlightsUpdater: IBufferHighlightsUpdater) => void): Promise<void> {
+    public async updateHighlights(
+        updateFunction: (highlightsUpdater: IBufferHighlightsUpdater) => void,
+    ): Promise<void> {
         this._promiseQueue.enqueuePromise(async () => {
             const bufferId = parseInt(this._id, 10)
-            const bufferUpdater = new BufferHighlightsUpdater(bufferId, this._neovimInstance, this._bufferHighlightId)
+            const bufferUpdater = new BufferHighlightsUpdater(
+                bufferId,
+                this._neovimInstance,
+                this._bufferHighlightId,
+            )
             await bufferUpdater.start()
 
             updateFunction(bufferUpdater)
@@ -178,7 +204,13 @@ export class Buffer implements Oni.Buffer {
     }
 
     public async setLines(start: number, end: number, lines: string[]): Promise<void> {
-        return this._neovimInstance.request<any>("nvim_buf_set_lines", [parseInt(this._id, 10), start, end, false, lines])
+        return this._neovimInstance.request<any>("nvim_buf_set_lines", [
+            parseInt(this._id, 10),
+            start,
+            end,
+            false,
+            lines,
+        ])
     }
 
     public async setCursorPosition(row: number, column: number): Promise<void> {
@@ -189,8 +221,8 @@ export class Buffer implements Oni.Buffer {
         const startRange = await this._neovimInstance.callFunction("getpos", ["'<'"])
         const endRange = await this._neovimInstance.callFunction("getpos", ["'>"])
 
-        const [, startLine, startColumn ] = startRange
-        let [, endLine, endColumn ] = endRange
+        const [, startLine, startColumn] = startRange
+        let [, endLine, endColumn] = endRange
 
         if (startLine === 0 && startColumn === 0 && endLine === 0 && endColumn === 0) {
             return null
@@ -209,7 +241,12 @@ export class Buffer implements Oni.Buffer {
 
         const tokenRegEx = LanguageManager.getInstance().getTokenRegex(this.language)
 
-        const getLastMatchingCharacter = (lineContents: string, character: number, dir: number, regex: RegExp) => {
+        const getLastMatchingCharacter = (
+            lineContents: string,
+            character: number,
+            dir: number,
+            regex: RegExp,
+        ) => {
             while (character > 0 && character < lineContents.length) {
                 if (!lineContents[character].match(regex)) {
                     return character - dir
@@ -254,12 +291,10 @@ export class Buffer implements Oni.Buffer {
 
 // Helper for managing buffer state
 export class BufferManager {
-    private _idToBuffer: { [id: string]: Buffer } = { }
-    private _filePathToId: { [filePath: string]: string } = { }
+    private _idToBuffer: { [id: string]: Buffer } = {}
+    private _filePathToId: { [filePath: string]: string } = {}
 
-    constructor(
-        private _neovimInstance: NeovimInstance,
-        private _actions: typeof Actions) { }
+    constructor(private _neovimInstance: NeovimInstance, private _actions: typeof Actions) {}
 
     public updateBufferFromEvent(evt: EventContext): Buffer {
         const id = evt.bufferNumber.toString()

--- a/browser/src/Editor/NeovimEditor/BufferLayerManager.ts
+++ b/browser/src/Editor/NeovimEditor/BufferLayerManager.ts
@@ -15,7 +15,6 @@ export const createBufferFilterFromLanguage = (language: string) => (buf: Oni.Bu
     } else {
         return buf.language === language
     }
-
 }
 
 export interface BufferLayerInfo {
@@ -27,16 +26,21 @@ export class BufferLayerManager {
     private _layers: BufferLayerInfo[] = []
 
     private _buffers: Oni.Buffer[] = []
-    public addBufferLayer(filterOrLanguage: BufferFilter | string, layerFactory: BufferLayerFactory) {
-
-        const filter: BufferFilter = typeof filterOrLanguage === "string" ? createBufferFilterFromLanguage(filterOrLanguage) : filterOrLanguage
+    public addBufferLayer(
+        filterOrLanguage: BufferFilter | string,
+        layerFactory: BufferLayerFactory,
+    ) {
+        const filter: BufferFilter =
+            typeof filterOrLanguage === "string"
+                ? createBufferFilterFromLanguage(filterOrLanguage)
+                : filterOrLanguage
 
         this._layers.push({
             filter,
             layerFactory,
         })
 
-        this._buffers.forEach((buf) => {
+        this._buffers.forEach(buf => {
             if (filter(buf)) {
                 buf.addLayer(layerFactory(buf))
             }
@@ -47,7 +51,7 @@ export class BufferLayerManager {
         if (this._buffers.indexOf(buf) === -1) {
             this._buffers.push(buf)
 
-            this._layers.forEach((layerInfo) => {
+            this._layers.forEach(layerInfo => {
                 if (layerInfo.filter(buf)) {
                     buf.addLayer(layerInfo.layerFactory(buf))
                 }
@@ -56,9 +60,12 @@ export class BufferLayerManager {
     }
 }
 
-export const wrapReactComponentWithLayer = (id: string, component: JSX.Element): Oni.EditorLayer => {
+export const wrapReactComponentWithLayer = (
+    id: string,
+    component: JSX.Element,
+): Oni.EditorLayer => {
     return {
         id,
-        render: (context: Oni.EditorLayerRenderContext) => context.isActive ? component : null,
+        render: (context: Oni.EditorLayerRenderContext) => (context.isActive ? component : null),
     }
 }

--- a/browser/src/Editor/NeovimEditor/CompletionMenu.ts
+++ b/browser/src/Editor/NeovimEditor/CompletionMenu.ts
@@ -24,11 +24,11 @@ export class CompletionMenu {
         return this._onItemSelectedEvent
     }
 
-    constructor(
-        private _contextMenu: ContextMenu,
-    ) {
-        this._contextMenu.onSelectedItemChanged.subscribe((item) => this._onItemFocusedEvent.dispatch(item))
-        this._contextMenu.onItemSelected.subscribe((item) => this._onItemSelectedEvent.dispatch(item))
+    constructor(private _contextMenu: ContextMenu) {
+        this._contextMenu.onSelectedItemChanged.subscribe(item =>
+            this._onItemFocusedEvent.dispatch(item),
+        )
+        this._contextMenu.onItemSelected.subscribe(item => this._onItemSelectedEvent.dispatch(item))
     }
 
     public show(options: types.CompletionItem[], filterText: string): void {
@@ -43,5 +43,4 @@ export class CompletionMenu {
     public hide(): void {
         this._contextMenu.hide()
     }
-
 }

--- a/browser/src/Editor/NeovimEditor/Definition.ts
+++ b/browser/src/Editor/NeovimEditor/Definition.ts
@@ -17,11 +17,7 @@ export enum OpenType {
 }
 
 export class Definition {
-
-    constructor(
-        private _editor: Oni.Editor,
-        private _store: Store<State.IState>,
-    ) { }
+    constructor(private _editor: Oni.Editor, private _store: Store<State.IState>) {}
 
     public async gotoDefinitionUnderCursor(openType: OpenType = OpenType.NewTab): Promise<void> {
         const activeDefinition = this._store.getState().definition
@@ -38,7 +34,12 @@ export class Definition {
         await this.gotoPositionInUri(uri, line, column, openType)
     }
 
-    public async gotoPositionInUri(uri: string, line: number, column: number, openType: OpenType = OpenType.NewTab): Promise<void> {
+    public async gotoPositionInUri(
+        uri: string,
+        line: number,
+        column: number,
+        openType: OpenType = OpenType.NewTab,
+    ): Promise<void> {
         const filePath = Helpers.unwrapFileUriPath(uri)
 
         const activeEditor = this._editor

--- a/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
@@ -26,16 +26,19 @@ import { IToolTipsProvider } from "./ToolTipsProvider"
 const HoverToolTipId = "hover-tool-tip"
 
 export class HoverRenderer {
-
     constructor(
         private _colors: IColors,
         private _editor: Oni.Editor,
         private _configuration: Configuration,
         private _toolTipsProvider: IToolTipsProvider,
-    ) {
-    }
+    ) {}
 
-    public showQuickInfo(x: number, y: number, hover: types.Hover, errors: types.Diagnostic[]): void {
+    public showQuickInfo(
+        x: number,
+        y: number,
+        hover: types.Hover,
+        errors: types.Diagnostic[],
+    ): void {
         const elem = this._renderQuickInfoElement(hover, errors)
 
         if (!elem) {
@@ -79,15 +82,15 @@ export class HoverRenderer {
             return null
         }
 
-        return <div className="quickinfo-container enable-mouse">
-            <div className="quickinfo">
-                <div className="container horizontal center">
-                    <div className="container full">
-                        {elements}
+        return (
+            <div className="quickinfo-container enable-mouse">
+                <div className="quickinfo">
+                    <div className="container horizontal center">
+                        <div className="container full">{elements}</div>
                     </div>
                 </div>
             </div>
-        </div>
+        )
     }
 
     private _getDebugScopesElement(): JSX.Element {
@@ -107,12 +110,12 @@ export class HoverRenderer {
             return null
         }
         const items = scopeInfo.scopes.map((si: string) => <li>{si}</li>)
-        return <QuickInfoDocumentation>
-            <div>DEBUG: TextMate Scopes:</div>
-            <ul>
-                {items}
-            </ul>
-        </QuickInfoDocumentation>
+        return (
+            <QuickInfoDocumentation>
+                <div>DEBUG: TextMate Scopes:</div>
+                <ul>{items}</ul>
+            </QuickInfoDocumentation>
+        )
     }
 }
 
@@ -159,15 +162,19 @@ const getTitleAndContents = (result: types.Hover) => {
 const getQuickInfoElementsFromHover = (hover: types.Hover): JSX.Element => {
     const titleAndContents = getTitleAndContents(hover)
     const hasDocs = !!(
-        titleAndContents
-        && titleAndContents.description
-        && titleAndContents.description.__html
+        titleAndContents &&
+        titleAndContents.description &&
+        titleAndContents.description.__html
     )
 
-    return titleAndContents && (
-        <QuickInfoContainer hasDocs={hasDocs}>
-            <QuickInfoTitle padding={hasDocs ? "0.5rem" : null } html={titleAndContents.title} />
-            {titleAndContents.description && <QuickInfoDocumentation html={titleAndContents.description} />}
-        </QuickInfoContainer>
+    return (
+        titleAndContents && (
+            <QuickInfoContainer hasDocs={hasDocs}>
+                <QuickInfoTitle padding={hasDocs ? "0.5rem" : null} html={titleAndContents.title} />
+                {titleAndContents.description && (
+                    <QuickInfoDocumentation html={titleAndContents.description} />
+                )}
+            </QuickInfoContainer>
+        )
     )
 }

--- a/browser/src/Editor/NeovimEditor/NeovimActiveWindow.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimActiveWindow.tsx
@@ -16,7 +16,6 @@ export interface IActiveWindowProps {
 
 export class NeovimActiveWindow extends React.PureComponent<IActiveWindowProps, {}> {
     public render(): JSX.Element {
-
         const px = (str: number): string => `${str}px`
 
         const style: React.CSSProperties = {
@@ -27,8 +26,6 @@ export class NeovimActiveWindow extends React.PureComponent<IActiveWindowProps, 
             height: px(this.props.pixelHeight),
         }
 
-        return <div style={style}>
-            {this.props.children}
-        </div>
+        return <div style={style}>{this.props.children}</div>
     }
 }

--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -23,9 +23,9 @@ export interface NeovimBufferLayersViewProps {
 
 export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLayersViewProps, {}> {
     public render(): JSX.Element {
-
-        const containers = this.props.windows.map((windowState) => {
-            const layers = this.props.layers[windowState.bufferId] || (EmptyArray as Oni.EditorLayer[])
+        const containers = this.props.windows.map(windowState => {
+            const layers =
+                this.props.layers[windowState.bufferId] || (EmptyArray as Oni.EditorLayer[])
 
             const layerContext = {
                 isActive: windowState.windowId === this.props.activeWindowId,
@@ -36,20 +36,20 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
                 dimensions: windowState.dimensions,
             }
 
-            const layerElements = layers.map((l) => {
+            const layerElements = layers.map(l => {
                 return <div key={l.id}>{l.render(layerContext)}</div>
             })
 
             const dimensions = getWindowPixelDimensions(windowState)
 
-            return <NeovimActiveWindow {...dimensions} key={windowState.windowId.toString()}>
+            return (
+                <NeovimActiveWindow {...dimensions} key={windowState.windowId.toString()}>
                     {layerElements}
                 </NeovimActiveWindow>
+            )
         })
 
-        return <div className="stack layer">
-                    {containers}
-                </div>
+        return <div className="stack layer">{containers}</div>
     }
 }
 
@@ -61,7 +61,6 @@ const EmptySize = {
 }
 
 const getWindowPixelDimensions = (win: State.IWindow) => {
-
     if (!win || !win.screenToPixel) {
         return EmptySize
     }
@@ -93,7 +92,7 @@ const mapStateToProps = (state: State.IState): NeovimBufferLayersViewProps => {
         }
     }
 
-    const windows = state.activeVimTabPage.windowIds.map((windowId) => {
+    const windows = state.activeVimTabPage.windowIds.map(windowId => {
         return state.windowState.windows[windowId]
     })
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -24,192 +24,192 @@ export type DispatchFunction = (action: any) => void
 export type GetStateFunction = () => State.IState
 
 export interface ISetHasFocusAction {
-    type: "SET_HAS_FOCUS",
+    type: "SET_HAS_FOCUS"
     payload: {
-        hasFocus: boolean,
+        hasFocus: boolean
     }
 }
 
 export interface ISetLoadingCompleteAction {
-    type: "SET_LOADING_COMPLETE",
+    type: "SET_LOADING_COMPLETE"
 }
 
 export interface ISetColorsAction {
-    type: "SET_COLORS",
+    type: "SET_COLORS"
     payload: {
-        colors: IThemeColors,
+        colors: IThemeColors
     }
 }
 
 export interface IAddBufferLayerAction {
-    type: "ADD_BUFFER_LAYER",
+    type: "ADD_BUFFER_LAYER"
     payload: {
-        bufferId: number,
-        layer: Oni.EditorLayer,
+        bufferId: number
+        layer: Oni.EditorLayer
     }
 }
 
 export interface ISetViewportAction {
-    type: "SET_VIEWPORT",
+    type: "SET_VIEWPORT"
     payload: {
-        width: number,
-        height: number,
+        width: number
+        height: number
     }
 }
 
 export interface ISetCommandLinePosition {
-    type: "SET_COMMAND_LINE_POSITION",
+    type: "SET_COMMAND_LINE_POSITION"
     payload: {
-        position: number,
-        level: number,
-    },
+        position: number
+        level: number
+    }
 }
 
 export interface IHideCommandLineAction {
-    type: "HIDE_COMMAND_LINE",
+    type: "HIDE_COMMAND_LINE"
 }
 
 export interface IShowCommandLineAction {
-    type: "SHOW_COMMAND_LINE",
+    type: "SHOW_COMMAND_LINE"
     payload: {
-        content: Array<[any, string]>,
-        position: number,
-        firstchar: string,
-        prompt: string,
-        indent: number,
-        level: number,
-    },
+        content: Array<[any, string]>
+        position: number
+        firstchar: string
+        prompt: string
+        indent: number
+        level: number
+    }
 }
 
 export interface IWildMenuSelectedAction {
-    type: "WILDMENU_SELECTED",
+    type: "WILDMENU_SELECTED"
     payload: {
-        selected: number,
+        selected: number
     }
 }
 
 export interface IShowWildMenuAction {
-    type: "SHOW_WILDMENU",
+    type: "SHOW_WILDMENU"
     payload: {
-        options: string[],
+        options: string[]
     }
 }
 
 export interface IHideWildMenuAction {
-    type: "HIDE_WILDMENU",
+    type: "HIDE_WILDMENU"
 }
 
 export interface ISetNeovimErrorAction {
-    type: "SET_NEOVIM_ERROR",
+    type: "SET_NEOVIM_ERROR"
     payload: {
-        neovimError: boolean,
+        neovimError: boolean
     }
 }
 
 export interface ISetCursorScaleAction {
-    type: "SET_CURSOR_SCALE",
+    type: "SET_CURSOR_SCALE"
     payload: {
-        cursorScale: number,
+        cursorScale: number
     }
 }
 
 export interface ISetCurrentBuffersAction {
-    type: "SET_CURRENT_BUFFERS",
+    type: "SET_CURRENT_BUFFERS"
     payload: {
-        bufferIds: number[],
+        bufferIds: number[]
     }
 }
 
 export interface ISetImeActive {
-    type: "SET_IME_ACTIVE",
+    type: "SET_IME_ACTIVE"
     payload: {
-        imeActive: boolean,
+        imeActive: boolean
     }
 }
 
 export interface ISetFont {
-    type: "SET_FONT",
+    type: "SET_FONT"
     payload: {
-        fontFamily: string,
-        fontSize: string,
+        fontFamily: string
+        fontSize: string
     }
 }
 
 export interface IBufferEnterAction {
-    type: "BUFFER_ENTER",
+    type: "BUFFER_ENTER"
     payload: {
-        buffers: State.IBuffer[],
+        buffers: State.IBuffer[]
     }
 }
 
 export interface IShowToolTipAction {
-    type: "SHOW_TOOL_TIP",
+    type: "SHOW_TOOL_TIP"
     payload: {
-        id: string,
-        element: JSX.Element,
-        options?: Oni.ToolTip.ToolTipOptions,
+        id: string
+        element: JSX.Element
+        options?: Oni.ToolTip.ToolTipOptions
     }
 }
 
 export interface IHideToolTipAction {
-    type: "HIDE_TOOL_TIP",
+    type: "HIDE_TOOL_TIP"
     payload: {
-        id: string,
+        id: string
     }
 }
 
 export interface IBufferUpdateAction {
-    type: "BUFFER_UPDATE",
+    type: "BUFFER_UPDATE"
     payload: {
-        id: number,
-        modified: boolean,
-        version: number,
-        totalLines: number,
+        id: number
+        modified: boolean
+        version: number
+        totalLines: number
     }
 }
 
 export interface IBufferSaveAction {
-    type: "BUFFER_SAVE",
+    type: "BUFFER_SAVE"
     payload: {
-        id: number,
-        modified: boolean,
-        version: number,
+        id: number
+        modified: boolean
+        version: number
     }
 }
 
 export interface ISetTabs {
-    type: "SET_TABS",
+    type: "SET_TABS"
     payload: {
         selectedTabId: number
-        tabs: State.ITab[],
+        tabs: State.ITab[]
     }
 }
 
 export interface ISetActiveVimTabPage {
-    type: "SET_ACTIVE_VIM_TAB_PAGE",
+    type: "SET_ACTIVE_VIM_TAB_PAGE"
     payload: {
-        id: number,
-        windowIds: number[],
+        id: number
+        windowIds: number[]
     }
 }
 
 export interface ISetWindowCursor {
-    type: "SET_WINDOW_CURSOR",
+    type: "SET_WINDOW_CURSOR"
     payload: {
-        windowId: number,
-        line: number,
-        column: number,
-    },
+        windowId: number
+        line: number
+        column: number
+    }
 }
 
 export interface ISetWindowState {
-    type: "SET_WINDOW_STATE",
+    type: "SET_WINDOW_STATE"
     payload: {
-        windowId: number,
-        bufferId: number,
-        file: string,
-        column: number,
-        line: number,
+        windowId: number
+        bufferId: number
+        file: string
+        column: number
+        line: number
 
         dimensions: Oni.Shapes.Rectangle
 
@@ -217,102 +217,100 @@ export interface ISetWindowState {
         screenToPixel: Oni.Coordinates.ScreenToPixel
 
         topBufferLine: number
-        bottomBufferLine: number,
+        bottomBufferLine: number
     }
 }
 
 export interface ISetInactiveWindowState {
-    type: "SET_INACTIVE_WINDOW_STATE",
+    type: "SET_INACTIVE_WINDOW_STATE"
     payload: {
-        windowId: number,
-        dimensions: Oni.Shapes.Rectangle,
+        windowId: number
+        dimensions: Oni.Shapes.Rectangle
     }
 }
 
 export interface ISetErrorsAction {
-    type: "SET_ERRORS",
+    type: "SET_ERRORS"
     payload: {
-        errors: Errors,
+        errors: Errors
     }
 }
 
 export interface ISetCursorPositionAction {
-    type: "SET_CURSOR_POSITION",
+    type: "SET_CURSOR_POSITION"
     payload: {
-        pixelX: number,
-        pixelY: number,
-        fontPixelWidth: number,
-        fontPixelHeight: number,
-        cursorCharacter: string,
-        cursorPixelWidth: number,
+        pixelX: number
+        pixelY: number
+        fontPixelWidth: number
+        fontPixelHeight: number
+        cursorCharacter: string
+        cursorPixelWidth: number
     }
 }
 
 export interface ISetModeAction {
-    type: "SET_MODE",
+    type: "SET_MODE"
     payload: {
-        mode: string,
+        mode: string
     }
 }
 
 export interface IShowDefinitionAction {
-    type: "SHOW_DEFINITION",
+    type: "SHOW_DEFINITION"
     payload: {
-        token: Oni.IToken,
-        definitionLocation: types.Location,
+        token: Oni.IToken
+        definitionLocation: types.Location
     }
 }
 
 export interface IHideDefinitionAction {
-    type: "HIDE_DEFINITION",
+    type: "HIDE_DEFINITION"
 }
 
 export interface ISetConfigurationValue<K extends keyof IConfigurationValues> {
     type: "SET_CONFIGURATION_VALUE"
     payload: {
-        key: K,
-        value: IConfigurationValues[K],
+        key: K
+        value: IConfigurationValues[K]
     }
 }
 
-export type Action<K extends keyof IConfigurationValues> =
-    SimpleAction | ActionWithGeneric<K>
+export type Action<K extends keyof IConfigurationValues> = SimpleAction | ActionWithGeneric<K>
 
 export type SimpleAction =
-    IAddBufferLayerAction |
-    IBufferEnterAction |
-    IBufferSaveAction |
-    IBufferUpdateAction |
-    ISetColorsAction |
-    ISetCursorPositionAction |
-    ISetImeActive |
-    ISetFont |
-    IHideToolTipAction |
-    IShowToolTipAction |
-    IHideDefinitionAction |
-    IShowDefinitionAction |
-    ISetModeAction |
-    ISetCursorScaleAction |
-    ISetErrorsAction |
-    ISetCurrentBuffersAction |
-    ISetHasFocusAction |
-    ISetNeovimErrorAction |
-    ISetTabs |
-    ISetActiveVimTabPage |
-    ISetLoadingCompleteAction |
-    ISetViewportAction |
-    ISetWindowCursor |
-    ISetWindowState |
-    ISetInactiveWindowState |
-    IShowCommandLineAction |
-    IHideCommandLineAction |
-    ISetCommandLinePosition |
-    IHideWildMenuAction |
-    IShowWildMenuAction |
-    IWildMenuSelectedAction
+    | IAddBufferLayerAction
+    | IBufferEnterAction
+    | IBufferSaveAction
+    | IBufferUpdateAction
+    | ISetColorsAction
+    | ISetCursorPositionAction
+    | ISetImeActive
+    | ISetFont
+    | IHideToolTipAction
+    | IShowToolTipAction
+    | IHideDefinitionAction
+    | IShowDefinitionAction
+    | ISetModeAction
+    | ISetCursorScaleAction
+    | ISetErrorsAction
+    | ISetCurrentBuffersAction
+    | ISetHasFocusAction
+    | ISetNeovimErrorAction
+    | ISetTabs
+    | ISetActiveVimTabPage
+    | ISetLoadingCompleteAction
+    | ISetViewportAction
+    | ISetWindowCursor
+    | ISetWindowState
+    | ISetInactiveWindowState
+    | IShowCommandLineAction
+    | IHideCommandLineAction
+    | ISetCommandLinePosition
+    | IHideWildMenuAction
+    | IShowWildMenuAction
+    | IWildMenuSelectedAction
 
-export type ActionWithGeneric<K extends keyof IConfigurationValues> =
-    ISetConfigurationValue<K>
+export type ActionWithGeneric<K extends keyof IConfigurationValues> = ISetConfigurationValue<K>
 
 export const setHasFocus = (hasFocus: boolean) => {
     return {
@@ -339,10 +337,10 @@ export const setColors = (colors: IThemeColors) => ({
 export const setCommandLinePosition = ({
     pos: position,
     level,
-    }: {
-        pos: number,
-        level: number,
-    }) => ({
+}: {
+    pos: number
+    level: number
+}) => ({
     type: "SET_COMMAND_LINE_POSITION",
     payload: {
         position,
@@ -420,7 +418,10 @@ const formatBuffers = (buffer: InactiveBufferContext & EventContext) => {
     }
 }
 
-export const addBufferLayer = (bufferId: number, layer: Oni.EditorLayer): IAddBufferLayerAction => ({
+export const addBufferLayer = (
+    bufferId: number,
+    layer: Oni.EditorLayer,
+): IAddBufferLayerAction => ({
     type: "ADD_BUFFER_LAYER",
     payload: {
         bufferId,
@@ -428,7 +429,7 @@ export const addBufferLayer = (bufferId: number, layer: Oni.EditorLayer): IAddBu
     },
 })
 
-export const bufferEnter = (buffers: (Array<InactiveBufferContext | EventContext>)) => ({
+export const bufferEnter = (buffers: Array<InactiveBufferContext | EventContext>) => ({
     type: "BUFFER_ENTER",
     payload: {
         buffers: buffers.map(formatBuffers),
@@ -492,21 +493,22 @@ export const setWindowCursor = (windowId: number, line: number, column: number) 
     },
 })
 
-export const setWindowState = (windowId: number,
-                               bufferId: number,
-                               file: string,
-                               column: number,
-                               line: number,
-                               bottomBufferLine: number,
-                               topBufferLine: number,
-                               dimensions: Oni.Shapes.Rectangle,
-                               bufferToScreen: Oni.Coordinates.BufferToScreen) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
-
+export const setWindowState = (
+    windowId: number,
+    bufferId: number,
+    file: string,
+    column: number,
+    line: number,
+    bottomBufferLine: number,
+    topBufferLine: number,
+    dimensions: Oni.Shapes.Rectangle,
+    bufferToScreen: Oni.Coordinates.BufferToScreen,
+) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
     const { fontPixelWidth, fontPixelHeight } = getState()
 
     const screenToPixel = (screenSpace: Oni.Coordinates.ScreenSpacePoint) => ({
-            pixelX: screenSpace.screenX * fontPixelWidth,
-            pixelY: screenSpace.screenY * fontPixelHeight,
+        pixelX: screenSpace.screenX * fontPixelWidth,
+        pixelY: screenSpace.screenY * fontPixelHeight,
     })
 
     dispatch({
@@ -526,7 +528,10 @@ export const setWindowState = (windowId: number,
     })
 }
 
-export const setInactiveWindowState = (windowId: number, dimensions: Oni.Shapes.Rectangle): ISetInactiveWindowState => ({
+export const setInactiveWindowState = (
+    windowId: number,
+    dimensions: Oni.Shapes.Rectangle,
+): ISetInactiveWindowState => ({
     type: "SET_INACTIVE_WINDOW_STATE",
     payload: {
         windowId,
@@ -534,7 +539,11 @@ export const setInactiveWindowState = (windowId: number, dimensions: Oni.Shapes.
     },
 })
 
-export const showToolTip = (id: string, element: JSX.Element, options?: Oni.ToolTip.ToolTipOptions) => ({
+export const showToolTip = (
+    id: string,
+    element: JSX.Element,
+    options?: Oni.ToolTip.ToolTipOptions,
+) => ({
     type: "SHOW_TOOL_TIP",
     payload: {
         id,
@@ -560,7 +569,16 @@ export const setErrors = (errors: Errors) => ({
 export const setCursorPosition = (screen: IScreen) => (dispatch: DispatchFunction) => {
     const cell = screen.getCell(screen.cursorColumn, screen.cursorRow)
 
-    dispatch(_setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels, cell.character, cell.characterWidth * screen.fontWidthInPixels))
+    dispatch(
+        _setCursorPosition(
+            screen.cursorColumn * screen.fontWidthInPixels,
+            screen.cursorRow * screen.fontHeightInPixels,
+            screen.fontWidthInPixels,
+            screen.fontHeightInPixels,
+            cell.character,
+            cell.characterWidth * screen.fontWidthInPixels,
+        ),
+    )
 }
 
 export const setMode = (mode: string) => ({
@@ -568,7 +586,10 @@ export const setMode = (mode: string) => ({
     payload: { mode },
 })
 
-export const setDefinition = (token: Oni.IToken, definitionLocation: types.Location): IShowDefinitionAction => ({
+export const setDefinition = (
+    token: Oni.IToken,
+    definitionLocation: types.Location,
+): IShowDefinitionAction => ({
     type: "SHOW_DEFINITION",
     payload: {
         token,
@@ -602,7 +623,10 @@ export const setActiveVimTabPage = (tabId: number, windowIds: number[]): ISetAct
     },
 })
 
-export function setConfigValue<K extends keyof IConfigurationValues>(k: K, v: IConfigurationValues[K]): ISetConfigurationValue<K> {
+export function setConfigValue<K extends keyof IConfigurationValues>(
+    k: K,
+    v: IConfigurationValues[K],
+): ISetConfigurationValue<K> {
     return {
         type: "SET_CONFIGURATION_VALUE",
         payload: {
@@ -612,7 +636,14 @@ export function setConfigValue<K extends keyof IConfigurationValues>(k: K, v: IC
     }
 }
 
-const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
+const _setCursorPosition = (
+    cursorPixelX: any,
+    cursorPixelY: any,
+    fontPixelWidth: any,
+    fontPixelHeight: any,
+    cursorCharacter: string,
+    cursorPixelWidth: number,
+) => ({
     type: "SET_CURSOR_POSITION",
     payload: {
         pixelX: cursorPixelX,

--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -26,7 +26,6 @@ import { Rename } from "./Rename"
 import { Symbols } from "./Symbols"
 
 export class NeovimEditorCommands {
-
     private _lastCommands: CallbackCommand[] = []
 
     constructor(
@@ -38,7 +37,7 @@ export class NeovimEditorCommands {
         private _neovimInstance: NeovimInstance,
         private _rename: Rename,
         private _symbols: Symbols,
-    ) { }
+    ) {}
 
     public activate(): void {
         const isContextMenuOpen = () => this._contextMenuManager.isMenuOpen()
@@ -48,7 +47,9 @@ export class NeovimEditorCommands {
         // - Should be able to work against the public 'IEditor' interface
         const quickOpen = new QuickOpen(this._menuManager, this._neovimInstance)
 
-        const quickOpenCommand = (innerCommand: Oni.Commands.CommandCallback) => (qo: QuickOpen) => {
+        const quickOpenCommand = (innerCommand: Oni.Commands.CommandCallback) => (
+            qo: QuickOpen,
+        ) => {
             return () => {
                 if (qo.isOpen()) {
                     return innerCommand(qo)
@@ -95,8 +96,8 @@ export class NeovimEditorCommands {
         const pasteContents = async (neovimInstance: NeovimInstance) => {
             const textToPaste = clipboard.readText()
             const sanitizedText = replaceAll(textToPaste, { "<": "<lt>" })
-                                    .split(os.EOL)
-                                    .join("<cr>")
+                .split(os.EOL)
+                .join("<cr>")
 
             await neovimInstance.command("set paste")
             await neovimInstance.input(sanitizedText)
@@ -104,17 +105,22 @@ export class NeovimEditorCommands {
         }
 
         const openDefaultConfig = async (): Promise<void> => {
+            const activeEditor = editorManager.activeEditor
+            const buf = await activeEditor.openFile(getUserConfigFilePath())
+            const lineCount = buf.lineCount
 
-        const activeEditor = editorManager.activeEditor
-        const buf = await activeEditor.openFile(getUserConfigFilePath())
-        const lineCount = buf.lineCount
-
-        if (lineCount === 1) {
-            const defaultConfigJsPath = path.join(__dirname, "configuration", "config.default.js")
-            const defaultConfigLines = fs.readFileSync(defaultConfigJsPath, "utf8").split(os.EOL)
-            await buf.setLines(0, defaultConfigLines.length, defaultConfigLines)
+            if (lineCount === 1) {
+                const defaultConfigJsPath = path.join(
+                    __dirname,
+                    "configuration",
+                    "config.default.js",
+                )
+                const defaultConfigLines = fs
+                    .readFileSync(defaultConfigJsPath, "utf8")
+                    .split(os.EOL)
+                await buf.setLines(0, defaultConfigLines.length, defaultConfigLines)
+            }
         }
-    }
 
         const shouldShowMenu = () => {
             return !this._menuManager.isMenuOpen()
@@ -126,66 +132,179 @@ export class NeovimEditorCommands {
                 properties: ["openDirectory"],
             }
 
-            remote.dialog.showOpenDialog(remote.getCurrentWindow(), dialogOptions, (folder: string[]) => {
-                if (!folder || !folder[0]) {
-                    return
-                }
+            remote.dialog.showOpenDialog(
+                remote.getCurrentWindow(),
+                dialogOptions,
+                (folder: string[]) => {
+                    if (!folder || !folder[0]) {
+                        return
+                    }
 
-                const folderToOpen = folder[0]
-                neovimInstance.chdir(folderToOpen)
-            })
+                    const folderToOpen = folder[0]
+                    neovimInstance.chdir(folderToOpen)
+                },
+            )
         }
 
         const isRenameActive = () => this._rename.isRenameActive()
 
         const commands = [
-            new CallbackCommand("contextMenu.select", null, null, selectContextMenuItem, isContextMenuOpen),
-            new CallbackCommand("contextMenu.next", null, null, nextContextMenuItem, isContextMenuOpen),
-            new CallbackCommand("contextMenu.previous", null, null, previousContextMenuItem, isContextMenuOpen),
-            new CallbackCommand("contextMenu.close", null, null, closeContextMenu, isContextMenuOpen),
+            new CallbackCommand(
+                "contextMenu.select",
+                null,
+                null,
+                selectContextMenuItem,
+                isContextMenuOpen,
+            ),
+            new CallbackCommand(
+                "contextMenu.next",
+                null,
+                null,
+                nextContextMenuItem,
+                isContextMenuOpen,
+            ),
+            new CallbackCommand(
+                "contextMenu.previous",
+                null,
+                null,
+                previousContextMenuItem,
+                isContextMenuOpen,
+            ),
+            new CallbackCommand(
+                "contextMenu.close",
+                null,
+                null,
+                closeContextMenu,
+                isContextMenuOpen,
+            ),
 
-            new CallbackCommand("editor.clipboard.paste", "Clipboard: Paste", "Paste clipboard contents into active text", () => pasteContents(this._neovimInstance)),
-            new CallbackCommand("editor.clipboard.yank", "Clipboard: Yank", "Yank contents to clipboard", () => this._neovimInstance.input("y")),
-            new CallbackCommand("oni.editor.findAllReferences", null, null, () => findAllReferences()),
-            new CallbackCommand("language.findAllReferences", "Find All References", "Find all references using a language service", () => findAllReferences()),
+            new CallbackCommand(
+                "editor.clipboard.paste",
+                "Clipboard: Paste",
+                "Paste clipboard contents into active text",
+                () => pasteContents(this._neovimInstance),
+            ),
+            new CallbackCommand(
+                "editor.clipboard.yank",
+                "Clipboard: Yank",
+                "Yank contents to clipboard",
+                () => this._neovimInstance.input("y"),
+            ),
+            new CallbackCommand("oni.editor.findAllReferences", null, null, () =>
+                findAllReferences(),
+            ),
+            new CallbackCommand(
+                "language.findAllReferences",
+                "Find All References",
+                "Find all references using a language service",
+                () => findAllReferences(),
+            ),
 
             new CallbackCommand("language.format", null, null, () => format()),
 
             // TODO: Deprecate
-            new CallbackCommand("oni.editor.gotoDefinition", null, null, () => this._definition.gotoDefinitionUnderCursor()),
-            new CallbackCommand("language.gotoDefinition", "Goto Definition", "Goto definition using a language service", () => this._definition.gotoDefinitionUnderCursor()),
-            new CallbackCommand("language.gotoDefinition.openVertical", null, null, () => this._definition.gotoDefinitionUnderCursor(1)),
-            new CallbackCommand("language.gotoDefinition.openHorizontal", null, null, () => this._definition.gotoDefinitionUnderCursor(2)),
+            new CallbackCommand("oni.editor.gotoDefinition", null, null, () =>
+                this._definition.gotoDefinitionUnderCursor(),
+            ),
+            new CallbackCommand(
+                "language.gotoDefinition",
+                "Goto Definition",
+                "Goto definition using a language service",
+                () => this._definition.gotoDefinitionUnderCursor(),
+            ),
+            new CallbackCommand("language.gotoDefinition.openVertical", null, null, () =>
+                this._definition.gotoDefinitionUnderCursor(1),
+            ),
+            new CallbackCommand("language.gotoDefinition.openHorizontal", null, null, () =>
+                this._definition.gotoDefinitionUnderCursor(2),
+            ),
 
-            new CallbackCommand("editor.rename", "Rename", "Rename an item", () => this._rename.startRename()),
-            new CallbackCommand("editor.rename.commit", null, null, () => this._rename.commitRename(), isRenameActive),
-            new CallbackCommand("editor.rename.cancel", null, null, () => this._rename.cancelRename(), isRenameActive),
+            new CallbackCommand("editor.rename", "Rename", "Rename an item", () =>
+                this._rename.startRename(),
+            ),
+            new CallbackCommand(
+                "editor.rename.commit",
+                null,
+                null,
+                () => this._rename.commitRename(),
+                isRenameActive,
+            ),
+            new CallbackCommand(
+                "editor.rename.cancel",
+                null,
+                null,
+                () => this._rename.cancelRename(),
+                isRenameActive,
+            ),
 
-            new CallbackCommand("editor.quickInfo.show", null, null, () => this._languageEditorIntegration.showHover()),
+            new CallbackCommand("editor.quickInfo.show", null, null, () =>
+                this._languageEditorIntegration.showHover(),
+            ),
 
-            new CallbackCommand("language.symbols.document", null, null, () => this._symbols.openDocumentSymbolsMenu()),
-            new CallbackCommand("language.symbols.workspace", null, null, () => this._symbols.openWorkspaceSymbolsMenu()),
-            new CallbackCommand("oni.config.openConfigJs", "Edit Oni Config", "Edit configuration file ('config.js') for Oni", () => openDefaultConfig()),
+            new CallbackCommand("language.symbols.document", null, null, () =>
+                this._symbols.openDocumentSymbolsMenu(),
+            ),
+            new CallbackCommand("language.symbols.workspace", null, null, () =>
+                this._symbols.openWorkspaceSymbolsMenu(),
+            ),
+            new CallbackCommand(
+                "oni.config.openConfigJs",
+                "Edit Oni Config",
+                "Edit configuration file ('config.js') for Oni",
+                () => openDefaultConfig(),
+            ),
 
-            new CallbackCommand("oni.config.openInitVim", "Edit Neovim Config", "Edit configuration file ('init.vim') for Neovim", () => this._neovimInstance.openInitVim()),
+            new CallbackCommand(
+                "oni.config.openInitVim",
+                "Edit Neovim Config",
+                "Edit configuration file ('init.vim') for Neovim",
+                () => this._neovimInstance.openInitVim(),
+            ),
 
-            new CallbackCommand("oni.openFolder", "Open Folder", "Set a folder as the working directory for Oni", () => openFolder(this._neovimInstance)),
+            new CallbackCommand(
+                "oni.openFolder",
+                "Open Folder",
+                "Set a folder as the working directory for Oni",
+                () => openFolder(this._neovimInstance),
+            ),
 
             // TODO: Factor these out
-            new CallbackCommand("quickOpen.show", null, null, () => quickOpen.show(), shouldShowMenu),
-            new CallbackCommand("quickOpen.showBufferLines", null, null, () => quickOpen.showBufferLines()),
-            new CallbackCommand("quickOpen.openFileNewTab", null, null, quickOpenFileNewTab(quickOpen)),
-            new CallbackCommand("quickOpen.openFileVertical", null, null, quickOpenFileVertical(quickOpen)),
-            new CallbackCommand("quickOpen.openFileHorizontal", null, null, quickOpenFileHorizontal(quickOpen)),
-
+            new CallbackCommand(
+                "quickOpen.show",
+                null,
+                null,
+                () => quickOpen.show(),
+                shouldShowMenu,
+            ),
+            new CallbackCommand("quickOpen.showBufferLines", null, null, () =>
+                quickOpen.showBufferLines(),
+            ),
+            new CallbackCommand(
+                "quickOpen.openFileNewTab",
+                null,
+                null,
+                quickOpenFileNewTab(quickOpen),
+            ),
+            new CallbackCommand(
+                "quickOpen.openFileVertical",
+                null,
+                null,
+                quickOpenFileVertical(quickOpen),
+            ),
+            new CallbackCommand(
+                "quickOpen.openFileHorizontal",
+                null,
+                null,
+                quickOpenFileHorizontal(quickOpen),
+            ),
         ]
 
         this._lastCommands = commands
-        commands.forEach((c) => this._commandManager.registerCommand(c))
+        commands.forEach(c => this._commandManager.registerCommand(c))
     }
 
     public deactivate(): void {
-        this._lastCommands.forEach((c) => this._commandManager.unregisterCommand(c.command))
+        this._lastCommands.forEach(c => this._commandManager.unregisterCommand(c.command))
         this._lastCommands = []
     }
 }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorLoadingOverlay.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorLoadingOverlay.tsx
@@ -28,10 +28,10 @@ const LoadingSpinnerWrapper = withProps<{}>(styled.div)`
     }
 `
 
-export const NeovimEditorLoadingOverlayView = (props: {visible: boolean}): JSX.Element => {
-        const className = props.visible ? "stack layer" : " stack layer loaded"
+export const NeovimEditorLoadingOverlayView = (props: { visible: boolean }): JSX.Element => {
+    const className = props.visible ? "stack layer" : " stack layer loaded"
 
-        return <LoadingSpinnerWrapper className={className} />
+    return <LoadingSpinnerWrapper className={className} />
 }
 
 export const mapStateToProps = (state: State.IState): { visible: boolean } => {

--- a/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
@@ -13,8 +13,10 @@ import { Errors } from "./../../Services/Diagnostics"
 
 import * as pick from "lodash/pick"
 
-export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a: Actions.Action<K>): State.IState {
-
+export function reducer<K extends keyof IConfigurationValues>(
+    s: State.IState,
+    a: Actions.Action<K>,
+): State.IState {
     if (!s) {
         return s
     }
@@ -36,29 +38,35 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
                 isLoaded: true,
             }
         case "SET_NEOVIM_ERROR":
-             return { ...s,
-                      neovimError: a.payload.neovimError }
+            return {
+                ...s,
+                neovimError: a.payload.neovimError,
+            }
         case "SET_VIEWPORT":
-            return { ...s,
-                     viewport: viewportReducer(s.viewport, a) }
+            return {
+                ...s,
+                viewport: viewportReducer(s.viewport, a),
+            }
         case "SET_CURSOR_SCALE":
             return {
-            ...s,
-            cursorScale: a.payload.cursorScale,
-        }
+                ...s,
+                cursorScale: a.payload.cursorScale,
+            }
         case "SET_ACTIVE_VIM_TAB_PAGE":
             return {
                 ...s,
                 activeVimTabPage: a.payload,
             }
         case "SET_CURSOR_POSITION":
-            return {...s,
-                    cursorPixelX: a.payload.pixelX,
-                    cursorPixelY: a.payload.pixelY,
-                    fontPixelWidth: a.payload.fontPixelWidth,
-                    fontPixelHeight: a.payload.fontPixelHeight,
-                    cursorCharacter: a.payload.cursorCharacter,
-                    cursorPixelWidth: a.payload.cursorPixelWidth }
+            return {
+                ...s,
+                cursorPixelX: a.payload.pixelX,
+                cursorPixelY: a.payload.pixelY,
+                fontPixelWidth: a.payload.fontPixelWidth,
+                fontPixelHeight: a.payload.fontPixelHeight,
+                cursorCharacter: a.payload.cursorCharacter,
+                cursorPixelWidth: a.payload.cursorPixelWidth,
+            }
         case "SET_IME_ACTIVE":
             return {
                 ...s,
@@ -75,7 +83,7 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
         case "SET_CONFIGURATION_VALUE":
             const obj: Partial<IConfigurationValues> = {}
             obj[a.payload.key] = a.payload.value
-            const newConfig = {...s.configuration, ...obj}
+            const newConfig = { ...s.configuration, ...obj }
             return {
                 ...s,
                 configuration: newConfig,
@@ -136,21 +144,23 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
         case "SET_COMMAND_LINE_POSITION":
             return {
                 ...s,
-                commandLine :  {
+                commandLine: {
                     ...s.commandLine,
                     position: a.payload.position,
                     level: a.payload.level,
                 },
             }
         default:
-            return {...s,
-                    buffers: buffersReducer(s.buffers, a),
-                    definition: definitionReducer(s.definition, a),
-                    layers: layersReducer(s.layers, a),
-                    tabState: tabStateReducer(s.tabState, a),
-                    errors: errorsReducer(s.errors, a),
-                    toolTips: toolTipsReducer(s.toolTips, a),
-                    windowState: windowStateReducer(s.windowState, a)}
+            return {
+                ...s,
+                buffers: buffersReducer(s.buffers, a),
+                definition: definitionReducer(s.definition, a),
+                layers: layersReducer(s.layers, a),
+                tabState: tabStateReducer(s.tabState, a),
+                errors: errorsReducer(s.errors, a),
+                toolTips: toolTipsReducer(s.toolTips, a),
+                windowState: windowStateReducer(s.windowState, a),
+            }
     }
 }
 
@@ -172,9 +182,9 @@ export const definitionReducer = (s: State.IDefinition, a: Actions.SimpleAction)
         case "SHOW_DEFINITION":
             const { definitionLocation, token } = a.payload
             return {
-                    definitionLocation,
-                    token,
-                }
+                definitionLocation,
+                token,
+            }
         case "HIDE_DEFINITION":
             return null
         default:
@@ -188,7 +198,7 @@ export const viewportReducer = (s: State.IViewport, a: Actions.ISetViewportActio
             return {
                 width: a.payload.width,
                 height: a.payload.height,
-        }
+            }
         default:
             return s
     }
@@ -206,8 +216,10 @@ export const tabStateReducer = (s: State.ITabState, a: Actions.SimpleAction): St
     }
 }
 
-export const buffersReducer = (s: State.IBufferState, a: Actions.SimpleAction): State.IBufferState => {
-
+export const buffersReducer = (
+    s: State.IBufferState,
+    a: Actions.SimpleAction,
+): State.IBufferState => {
     let byId = s.byId
     let allIds = s.allIds
 
@@ -222,7 +234,6 @@ export const buffersReducer = (s: State.IBufferState, a: Actions.SimpleAction): 
 
     switch (a.type) {
         case "BUFFER_ENTER":
-
             byId = a.payload.buffers.reduce((buffersById, buffer) => {
                 buffersById[buffer.id] = {
                     ...buffer,
@@ -233,7 +244,7 @@ export const buffersReducer = (s: State.IBufferState, a: Actions.SimpleAction): 
 
             const bufIds = a.payload.buffers.map(b => b.id)
 
-            allIds = [ ...new Set(bufIds)]
+            allIds = [...new Set(bufIds)]
 
             return {
                 activeBufferId: a.payload.buffers[0].id,
@@ -279,7 +290,7 @@ export const buffersReducer = (s: State.IBufferState, a: Actions.SimpleAction): 
                 byId,
             }
         case "SET_CURRENT_BUFFERS":
-            allIds = s.allIds.filter((id) => a.payload.bufferIds.indexOf(id) >= 0)
+            allIds = s.allIds.filter(id => a.payload.bufferIds.indexOf(id) >= 0)
 
             let activeBufferId = s.activeBufferId
 
@@ -334,8 +345,10 @@ export const toolTipsReducer = (s: State.ToolTips, a: Actions.SimpleAction): Sta
     }
 }
 
-export const windowStateReducer = (s: State.IWindowState, a: Actions.SimpleAction): State.IWindowState => {
-
+export const windowStateReducer = (
+    s: State.IWindowState,
+    a: Actions.SimpleAction,
+): State.IWindowState => {
     let currentWindow
     switch (a.type) {
         case "SET_WINDOW_CURSOR":

--- a/browser/src/Editor/NeovimEditor/NeovimEditorSelectors.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorSelectors.ts
@@ -21,16 +21,14 @@ export const EmptyArray: any[] = []
 
 const getWindows = (state: State.IState) => state.windowState
 
-export const getActiveWindow = createSelector(
-    [getWindows],
-    (windowState) => {
-        if (windowState.activeWindow === null) {
-            return null
-        }
+export const getActiveWindow = createSelector([getWindows], windowState => {
+    if (windowState.activeWindow === null) {
+        return null
+    }
 
-        const activeWindow = windowState.activeWindow
-        return windowState.windows[activeWindow]
-    })
+    const activeWindow = windowState.activeWindow
+    return windowState.windows[activeWindow]
+})
 
 const emptyRectangle: Oni.Shapes.Rectangle = {
     x: 0,
@@ -44,15 +42,13 @@ export const getFontPixelWidthHeight = (state: State.IState) => ({
     fontPixelHeight: state.fontPixelHeight,
 })
 
-export const getActiveWindowScreenDimensions = createSelector(
-    [getActiveWindow],
-    (win) => {
-        if (!win || !win.dimensions) {
-            return emptyRectangle
-        }
+export const getActiveWindowScreenDimensions = createSelector([getActiveWindow], win => {
+    if (!win || !win.dimensions) {
+        return emptyRectangle
+    }
 
-        return win.dimensions
-    })
+    return win.dimensions
+})
 
 export const getActiveWindowPixelDimensions = createSelector(
     [getActiveWindowScreenDimensions, getFontPixelWidthHeight],
@@ -65,16 +61,21 @@ export const getActiveWindowPixelDimensions = createSelector(
         }
 
         return pixelDimensions
-    })
+    },
+)
 
 export const getErrors = (state: State.IState) => state.errors
 
 export const getErrorsForActiveFile = createSelector(
     [getActiveWindow, getErrors],
     (win, errors) => {
-        const errorsForFile: types.Diagnostic[] = (win && win.file) ? getAllErrorsForFile(win.file, errors) : (EmptyArray as types.Diagnostic[])
+        const errorsForFile: types.Diagnostic[] =
+            win && win.file
+                ? getAllErrorsForFile(win.file, errors)
+                : (EmptyArray as types.Diagnostic[])
         return errorsForFile
-    })
+    },
+)
 
 export const getErrorsForPosition = createSelector(
     [getActiveWindow, getErrorsForActiveFile],
@@ -84,37 +85,35 @@ export const getErrorsForPosition = createSelector(
         }
 
         const { line, column } = win
-        return errors.filter((diag) => Utility.isInRange(line, column, diag.range))
-    })
-
-const getBufferState = (state: State.IState) => state.buffers
-
-export const getAllBuffers = createSelector(
-    [getBufferState],
-    (buffers) => buffers.allIds.map((id) => buffers.byId[id]).filter((buf) => buf.listed))
-
-export const getBufferMetadata = createSelector(
-    [getAllBuffers],
-    (buffers) => buffers.map((b) => ({
-        id: b.id,
-        file: b.file,
-        modified: b.modified,
-    })))
-
-export const getActiveBuffer = createSelector(
-    [getActiveWindow, getAllBuffers],
-    (win, buffers) => {
-
-        if (!win || !win.file) {
-            return null
-        }
-
-        const buf = buffers.find((b) => b.file === win.file)
-
-        return buf || null
+        return errors.filter(diag => Utility.isInRange(line, column, diag.range))
     },
 )
 
+const getBufferState = (state: State.IState) => state.buffers
+
+export const getAllBuffers = createSelector([getBufferState], buffers =>
+    buffers.allIds.map(id => buffers.byId[id]).filter(buf => buf.listed),
+)
+
+export const getBufferMetadata = createSelector([getAllBuffers], buffers =>
+    buffers.map(b => ({
+        id: b.id,
+        file: b.file,
+        modified: b.modified,
+    })),
+)
+
+export const getActiveBuffer = createSelector([getActiveWindow, getAllBuffers], (win, buffers) => {
+    if (!win || !win.file) {
+        return null
+    }
+
+    const buf = buffers.find(b => b.file === win.file)
+
+    return buf || null
+})
+
 export const getActiveBufferId = createSelector(
     [getActiveBuffer],
-    (buf) => buf === null ? null : buf.id)
+    buf => (buf === null ? null : buf.id),
+)

--- a/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
@@ -16,10 +16,18 @@ import { DefaultThemeColors, IThemeColors } from "./../../Services/Themes"
 
 import { createStore as createReduxStore } from "./../../Redux"
 
-export interface Layers { [id: number]: Oni.EditorLayer[] }
-export interface Buffers { [filePath: string]: IBuffer }
-export interface Errors { [file: string]: { [key: string]: types.Diagnostic[] } }
-export interface ToolTips { [id: string]: IToolTip }
+export interface Layers {
+    [id: number]: Oni.EditorLayer[]
+}
+export interface Buffers {
+    [filePath: string]: IBuffer
+}
+export interface Errors {
+    [file: string]: { [key: string]: types.Diagnostic[] }
+}
+export interface ToolTips {
+    [id: string]: IToolTip
+}
 
 import { reducer } from "./NeovimEditorReducer"
 
@@ -32,8 +40,8 @@ export interface IViewport {
 }
 
 export interface IToolTip {
-    id: string,
-    options?: Oni.ToolTip.ToolTipOptions,
+    id: string
+    options?: Oni.ToolTip.ToolTipOptions
     element: JSX.Element
 }
 
@@ -88,13 +96,13 @@ export interface IWildMenu {
 }
 
 export interface ICommandLine {
-    visible: boolean,
-    content: string,
-    firstchar: string,
-    position: number,
-    prompt: string,
-    indent: number,
-    level: number,
+    visible: boolean
+    content: string
+    firstchar: string
+    position: number
+    prompt: string
+    indent: number
+    level: number
 }
 
 export interface IDefinition {
@@ -125,7 +133,7 @@ export interface ITab {
 }
 
 export interface ITabState {
-    selectedTabId: number | null,
+    selectedTabId: number | null
     tabs: ITab[]
 }
 
@@ -135,8 +143,8 @@ export interface IVimTabPage {
 }
 
 export interface IWindowState {
-    activeWindow: number,
-    windows: { [windowId: number]: IWindow },
+    activeWindow: number
+    windows: { [windowId: number]: IWindow }
 }
 
 export interface IWindow {
@@ -154,8 +162,10 @@ export interface IWindow {
     bottomBufferLine: number
 }
 
-export function readConf<K extends keyof IConfigurationValues>(conf: IConfigurationValues, k: K): IConfigurationValues[K] {
-
+export function readConf<K extends keyof IConfigurationValues>(
+    conf: IConfigurationValues,
+    k: K,
+): IConfigurationValues[K] {
     if (!conf) {
         return null
     } else {
@@ -231,7 +241,8 @@ export const createDefaultState = (): IState => ({
 let neovimEditorId = 0
 
 export const createStore = (): Store<IState> => {
-
     const editorId = neovimEditorId++
-    return createReduxStore("NeovimEditor" + editorId.toString(), reducer, createDefaultState(), [thunk])
+    return createReduxStore("NeovimEditor" + editorId.toString(), reducer, createDefaultState(), [
+        thunk,
+    ])
 }

--- a/browser/src/Editor/NeovimEditor/NeovimInput.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimInput.tsx
@@ -43,14 +43,18 @@ export class NeovimInput extends React.PureComponent<INeovimInputProps, {}> {
     }
 
     public render(): JSX.Element {
-        return <div ref={(elem) => this._mouseElement = elem} className="stack enable-mouse">
-            <KeyboardInput onActivate={this.props.onActivate}
-                typingPrediction={this.props.typingPrediction}
-                onBounceStart={this.props.onBounceStart}
-                onBounceEnd={this.props.onBounceEnd}
-                onImeStart={this.props.onImeStart}
-                onImeEnd={this.props.onImeEnd}
-                onKeyDown={this.props.onKeyDown} />
-        </div>
+        return (
+            <div ref={elem => (this._mouseElement = elem)} className="stack enable-mouse">
+                <KeyboardInput
+                    onActivate={this.props.onActivate}
+                    typingPrediction={this.props.typingPrediction}
+                    onBounceStart={this.props.onBounceStart}
+                    onBounceEnd={this.props.onBounceEnd}
+                    onImeStart={this.props.onImeStart}
+                    onImeEnd={this.props.onImeEnd}
+                    onKeyDown={this.props.onKeyDown}
+                />
+            </div>
+        )
     }
 }

--- a/browser/src/Editor/NeovimEditor/NeovimPopupMenu.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimPopupMenu.tsx
@@ -15,7 +15,11 @@ import { ContextMenuView, IContextMenuItem } from "./../../Services/ContextMenu"
 
 import { IToolTipsProvider } from "./ToolTipsProvider"
 
-const mapNeovimCompletionItemToContextMenuItem = (item: INeovimCompletionItem, idx: number, totalLength: number): IContextMenuItem  => ({
+const mapNeovimCompletionItemToContextMenuItem = (
+    item: INeovimCompletionItem,
+    idx: number,
+    totalLength: number,
+): IContextMenuItem => ({
     label: item.word,
     detail: item.menu,
     documentation: (idx + 1).toString() + " of " + totalLength.toString(),
@@ -23,7 +27,6 @@ const mapNeovimCompletionItemToContextMenuItem = (item: INeovimCompletionItem, i
 })
 
 export class NeovimPopupMenu {
-
     private _lastItems: IContextMenuItem[] = []
 
     constructor(
@@ -34,14 +37,15 @@ export class NeovimPopupMenu {
         private _colors: IColors,
         private _toolTipsProvider: IToolTipsProvider,
     ) {
-
-        this._popupMenuShowEvent.subscribe((completionInfo) => {
-            this._lastItems = completionInfo.items.map((i, idx) => mapNeovimCompletionItemToContextMenuItem(i, idx, completionInfo.items.length))
+        this._popupMenuShowEvent.subscribe(completionInfo => {
+            this._lastItems = completionInfo.items.map((i, idx) =>
+                mapNeovimCompletionItemToContextMenuItem(i, idx, completionInfo.items.length),
+            )
 
             this._renderCompletionMenu(completionInfo.selectedIndex)
         })
 
-        this._popupMenuSelectEvent.subscribe((idx) => {
+        this._popupMenuSelectEvent.subscribe(idx => {
             this._renderCompletionMenu(idx)
         })
 
@@ -60,11 +64,10 @@ export class NeovimPopupMenu {
     }
 
     private _renderCompletionMenu(selectedIndex: number): void {
-
         let itemsToRender: IContextMenuItem[] = []
         let adjustedIndex = selectedIndex
 
-        if  (selectedIndex < 10) {
+        if (selectedIndex < 10) {
             itemsToRender = this._lastItems.slice(0, 10)
         } else {
             itemsToRender = this._lastItems.slice(selectedIndex - 9, selectedIndex + 1)
@@ -82,13 +85,14 @@ export class NeovimPopupMenu {
                 backgroundColor={"black"}
                 borderColor={"black"}
                 highlightColor={highlightColor}
-                foregroundColor={"white"} />
+                foregroundColor={"white"}
+            />
         )
 
         this._toolTipsProvider.showToolTip("nvim-popup", completionElement, {
-                position: null,
-                openDirection: 2,
-                padding: "0px",
-            })
+            position: null,
+            openDirection: 2,
+            padding: "0px",
+        })
     }
 }

--- a/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx
@@ -29,8 +29,8 @@ export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, {}
 
         if (!this._boundOnResizeMethod) {
             this._boundOnResizeMethod = this._onResize.bind(this)
+            // tslint:disable-next-line no-string-literal
             this._resizeObserver = new window["ResizeObserver"]((entries: any) => {
-                // tslint:disable-line no-string-literal
                 if (this._boundOnResizeMethod) {
                     this._boundOnResizeMethod()
                 }

--- a/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx
@@ -16,7 +16,6 @@ export interface INeovimRendererProps {
 }
 
 export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, {}> {
-
     private _element: HTMLDivElement
     private _boundOnResizeMethod: any
     private _resizeObserver: any
@@ -30,7 +29,8 @@ export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, {}
 
         if (!this._boundOnResizeMethod) {
             this._boundOnResizeMethod = this._onResize.bind(this)
-            this._resizeObserver = new window["ResizeObserver"]((entries: any) => { // tslint:disable-line no-string-literal
+            this._resizeObserver = new window["ResizeObserver"]((entries: any) => {
+                // tslint:disable-line no-string-literal
                 if (this._boundOnResizeMethod) {
                     this._boundOnResizeMethod()
                 }
@@ -53,7 +53,7 @@ export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, {}
     }
 
     public render(): JSX.Element {
-        return <div ref={ (elem) => this._element = elem } className="stack layer"></div>
+        return <div ref={elem => (this._element = elem)} className="stack layer" />
     }
 
     private _onResize(): void {

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -46,43 +46,49 @@ export interface INeovimSurfaceProps {
 
 export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> {
     public render(): JSX.Element {
-        return <div className="container vertical full">
-            <div className="container fixed">
-                <TabsContainer
-                    onBufferSelect={this.props.onBufferSelect}
-                    onBufferClose={this.props.onBufferClose}
-                    onTabClose={this.props.onTabClose}
-                    onTabSelect={this.props.onTabSelect}/>
-            </div>
-            <div className="container full">
-                <div className="stack">
-                    <NeovimRenderer renderer={this.props.renderer}
+        return (
+            <div className="container vertical full">
+                <div className="container fixed">
+                    <TabsContainer
+                        onBufferSelect={this.props.onBufferSelect}
+                        onBufferClose={this.props.onBufferClose}
+                        onTabClose={this.props.onTabClose}
+                        onTabSelect={this.props.onTabSelect}
+                    />
+                </div>
+                <div className="container full">
+                    <div className="stack">
+                        <NeovimRenderer
+                            renderer={this.props.renderer}
+                            neovimInstance={this.props.neovimInstance}
+                            screen={this.props.screen}
+                        />
+                    </div>
+                    <div className="stack layer">
+                        <TypingPrediction typingPrediction={this.props.typingPrediction} />
+                        <Cursor typingPrediction={this.props.typingPrediction} />
+                        <CursorLine lineType={"line"} />
+                        <CursorLine lineType={"column"} />
+                    </div>
+                    <NeovimInput
+                        onActivate={this.props.onActivate}
+                        typingPrediction={this.props.typingPrediction}
                         neovimInstance={this.props.neovimInstance}
-                        screen={this.props.screen} />
+                        screen={this.props.screen}
+                        onBounceStart={this.props.onBounceStart}
+                        onBounceEnd={this.props.onBounceEnd}
+                        onImeStart={this.props.onImeStart}
+                        onImeEnd={this.props.onImeEnd}
+                        onKeyDown={this.props.onKeyDown}
+                    />
+                    <NeovimBufferLayers />
+                    <div className="stack layer">
+                        <ToolTips />
+                    </div>
+                    <NeovimEditorLoadingOverlay />
+                    <InstallHelp />
                 </div>
-                <div className="stack layer">
-                    <TypingPrediction typingPrediction={this.props.typingPrediction}/>
-                    <Cursor typingPrediction={this.props.typingPrediction}/>
-                    <CursorLine lineType={"line"} />
-                    <CursorLine lineType={"column"} />
-                </div>
-                <NeovimInput
-                    onActivate={this.props.onActivate}
-                    typingPrediction={this.props.typingPrediction}
-                    neovimInstance={this.props.neovimInstance}
-                    screen={this.props.screen}
-                    onBounceStart={this.props.onBounceStart}
-                    onBounceEnd={this.props.onBounceEnd}
-                    onImeStart={this.props.onImeStart}
-                    onImeEnd={this.props.onImeEnd}
-                    onKeyDown={this.props.onKeyDown}/>
-                <NeovimBufferLayers />
-                <div className="stack layer">
-                    <ToolTips />
-                </div>
-                <NeovimEditorLoadingOverlay />
-                <InstallHelp />
             </div>
-        </div>
+        )
     }
 }

--- a/browser/src/Editor/NeovimEditor/Rename.tsx
+++ b/browser/src/Editor/NeovimEditor/Rename.tsx
@@ -17,7 +17,6 @@ import { IToolTipsProvider } from "./ToolTipsProvider"
 
 const _renameToolTipName = "rename-tool-tip"
 export class Rename {
-
     private _isRenameActive: boolean
     private _isRenameCommitted: boolean
 
@@ -39,7 +38,10 @@ export class Rename {
 
         const activeBuffer = this._editor.activeBuffer
 
-        const activeToken = await activeBuffer.getTokenAt(activeBuffer.cursor.line, activeBuffer.cursor.column)
+        const activeToken = await activeBuffer.getTokenAt(
+            activeBuffer.cursor.line,
+            activeBuffer.cursor.column,
+        )
 
         if (!activeToken || !activeToken.tokenName) {
             return
@@ -47,15 +49,21 @@ export class Rename {
 
         this._isRenameActive = true
 
-        this._toolTipsProvider.showToolTip(_renameToolTipName, <RenameView onComplete={(newValue) => this._onRenameClosed(newValue)} tokenName={activeToken.tokenName} />, {
-            position: null,
-            openDirection: 2,
-            onDismiss: () => this.cancelRename(),
-        })
+        this._toolTipsProvider.showToolTip(
+            _renameToolTipName,
+            <RenameView
+                onComplete={newValue => this._onRenameClosed(newValue)}
+                tokenName={activeToken.tokenName}
+            />,
+            {
+                position: null,
+                openDirection: 2,
+                onDismiss: () => this.cancelRename(),
+            },
+        )
     }
 
     public commitRename(): void {
-
         Log.verbose("[RENAME] Committing rename")
         this._isRenameCommitted = true
         this._isRenameActive = false
@@ -99,8 +107,15 @@ export class Rename {
 
         let result = null
         try {
-            result = await this._languageManager.sendLanguageServerRequest(activeBuffer.language, activeBuffer.filePath, "textDocument/rename", args)
-            } catch (ex) { Log.debug(ex) }
+            result = await this._languageManager.sendLanguageServerRequest(
+                activeBuffer.language,
+                activeBuffer.filePath,
+                "textDocument/rename",
+                args,
+            )
+        } catch (ex) {
+            Log.debug(ex)
+        }
 
         if (result) {
             await this._workspace.applyEdits(result)

--- a/browser/src/Editor/NeovimEditor/Symbols.ts
+++ b/browser/src/Editor/NeovimEditor/Symbols.ts
@@ -16,23 +16,22 @@ import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpe
 import { Definition } from "./Definition"
 
 export class Symbols {
-
     constructor(
         private _editor: Oni.Editor,
         private _definition: Definition,
         private _languageManager: LanguageManager,
         private _menuManager: MenuManager,
-    ) {
-
-    }
+    ) {}
 
     public async openWorkspaceSymbolsMenu() {
         const menu = this._menuManager.create()
 
         menu.show()
-        menu.setItems([{
-            label: "Type to search symbols....",
-        }])
+        menu.setItems([
+            {
+                label: "Type to search symbols....",
+            },
+        ])
         menu.setLoading(true)
 
         const filterTextChanged$ = menu.onFilterTextChanged.asObservable()
@@ -43,9 +42,12 @@ export class Symbols {
             const loc = keyToLocation[key]
 
             if (loc) {
-                this._definition.gotoPositionInUri(loc.uri, loc.range.start.line, loc.range.start.character)
+                this._definition.gotoPositionInUri(
+                    loc.uri,
+                    loc.range.start.line,
+                    loc.range.start.character,
+                )
             }
-
         })
 
         let keyToLocation: any = {}
@@ -57,17 +59,22 @@ export class Symbols {
             .do(() => menu.setLoading(true))
             .concatMap(async (newText: string) => {
                 const buffer = this._editor.activeBuffer
-                const symbols: types.SymbolInformation[] = await this._languageManager.sendLanguageServerRequest(buffer.language, buffer.filePath, "workspace/symbol", {
-                    textDocument: {
-                        uri: Helpers.wrapPathInFileUri(buffer.filePath),
+                const symbols: types.SymbolInformation[] = await this._languageManager.sendLanguageServerRequest(
+                    buffer.language,
+                    buffer.filePath,
+                    "workspace/symbol",
+                    {
+                        textDocument: {
+                            uri: Helpers.wrapPathInFileUri(buffer.filePath),
+                        },
+                        query: newText,
                     },
-                    query: newText,
-                })
+                )
                 return symbols
             })
             .subscribe((newItems: types.SymbolInformation[]) => {
                 menu.setLoading(false)
-                menu.setItems(newItems.map((item) => this._symbolInfoToMenuItem(item)))
+                menu.setItems(newItems.map(item => this._symbolInfoToMenuItem(item)))
 
                 keyToLocation = newItems.reduce((prev, curr) => {
                     return {
@@ -75,7 +82,6 @@ export class Symbols {
                         [getKey(curr)]: curr.location,
                     }
                 }, {})
-
             })
     }
 
@@ -87,13 +93,18 @@ export class Symbols {
 
         const buffer = this._editor.activeBuffer
 
-        const result: types.SymbolInformation[] = await this._languageManager.sendLanguageServerRequest(buffer.language, buffer.filePath, "textDocument/documentSymbol", {
-            textDocument: {
-                uri: Helpers.wrapPathInFileUri(buffer.filePath),
+        const result: types.SymbolInformation[] = await this._languageManager.sendLanguageServerRequest(
+            buffer.language,
+            buffer.filePath,
+            "textDocument/documentSymbol",
+            {
+                textDocument: {
+                    uri: Helpers.wrapPathInFileUri(buffer.filePath),
+                },
             },
-        })
+        )
 
-        const options: Oni.Menu.MenuOption[] = result.map((item) => this._symbolInfoToMenuItem(item))
+        const options: Oni.Menu.MenuOption[] = result.map(item => this._symbolInfoToMenuItem(item))
 
         const labelToLocation = result.reduce((prev, curr) => {
             return {
@@ -102,10 +113,14 @@ export class Symbols {
             }
         }, {})
 
-        menu.onItemSelected.subscribe((selectedItem) => {
+        menu.onItemSelected.subscribe(selectedItem => {
             const location: types.Location = labelToLocation[selectedItem.label]
             if (location) {
-                this._definition.gotoPositionInUri(location.uri, location.range.start.line, location.range.start.character)
+                this._definition.gotoPositionInUri(
+                    location.uri,
+                    location.range.start.line,
+                    location.range.start.character,
+                )
             }
         })
 
@@ -114,7 +129,6 @@ export class Symbols {
     }
 
     private _getDetailFromSymbol(si: types.SymbolInformation): string {
-
         const unwrappedPath = Helpers.unwrapFileUriPath(si.location.uri)
 
         if (si.containerName) {
@@ -134,30 +148,30 @@ export class Symbols {
 
     private _convertSymbolKindToIconName(symbolKind: types.SymbolKind): string {
         switch (symbolKind) {
-                case types.SymbolKind.Class:
-                   return "cube"
-                case types.SymbolKind.Constructor:
-                   return "building"
-                case types.SymbolKind.Enum:
-                   return "sitemap"
-                case types.SymbolKind.Field:
-                   return "var"
-                case types.SymbolKind.File:
-                   return "file"
-                case types.SymbolKind.Function:
-                   return "cog"
-                case types.SymbolKind.Interface:
-                   return "plug"
-                case types.SymbolKind.Method:
-                   return "flash"
-                case types.SymbolKind.Module:
-                   return "cubes"
-                case types.SymbolKind.Property:
-                   return "wrench"
-                case types.SymbolKind.Variable:
-                   return "code"
-                default:
-                    return "question"
+            case types.SymbolKind.Class:
+                return "cube"
+            case types.SymbolKind.Constructor:
+                return "building"
+            case types.SymbolKind.Enum:
+                return "sitemap"
+            case types.SymbolKind.Field:
+                return "var"
+            case types.SymbolKind.File:
+                return "file"
+            case types.SymbolKind.Function:
+                return "cog"
+            case types.SymbolKind.Interface:
+                return "plug"
+            case types.SymbolKind.Method:
+                return "flash"
+            case types.SymbolKind.Module:
+                return "cubes"
+            case types.SymbolKind.Property:
+                return "wrench"
+            case types.SymbolKind.Variable:
+                return "code"
+            default:
+                return "question"
         }
     }
 }

--- a/browser/src/Editor/NeovimEditor/ToolTipsProvider.ts
+++ b/browser/src/Editor/NeovimEditor/ToolTipsProvider.ts
@@ -8,11 +8,13 @@ export interface IToolTipsProvider {
 }
 
 export class NeovimEditorToolTipsProvider implements IToolTipsProvider {
-    constructor(
-        private _actions: typeof Actions,
-    ) { }
+    constructor(private _actions: typeof Actions) {}
 
-    public showToolTip(id: string, element: JSX.Element, options: Oni.ToolTip.ToolTipOptions): void {
+    public showToolTip(
+        id: string,
+        element: JSX.Element,
+        options: Oni.ToolTip.ToolTipOptions,
+    ): void {
         this._actions.showToolTip(id, element, options)
     }
 

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -79,14 +79,13 @@ const HeroImage = styled.img`
 `
 
 const SectionHeader = styled.div`
-
     margin-top: 1em;
     margin-bottom: 1em;
 
     font-size: 1.1em;
     font-weight: bold;
     text-align: center;
-    width:100%;
+    width: 100%;
 `
 
 const WelcomeButtonHoverStyled = `
@@ -140,10 +139,12 @@ export interface WelcomeButtonProps {
 
 export class WelcomeButton extends React.PureComponent<WelcomeButtonProps, {}> {
     public render(): JSX.Element {
-        return <WelcomeButtonWrapper>
+        return (
+            <WelcomeButtonWrapper>
                 <WelcomeButtonTitle>{this.props.title}</WelcomeButtonTitle>
                 <WelcomeButtonDescription>{this.props.description}</WelcomeButtonDescription>
             </WelcomeButtonWrapper>
+        )
     }
 }
 
@@ -152,7 +153,6 @@ export interface WelcomeHeaderState {
 }
 
 export class WelcomeBufferLayer implements Oni.EditorLayer {
-
     public get id(): string {
         return "oni.welcome"
     }
@@ -162,9 +162,14 @@ export class WelcomeBufferLayer implements Oni.EditorLayer {
     }
 
     public render(context: Oni.EditorLayerRenderContext): JSX.Element {
-        return <WelcomeWrapper className="enable-mouse" style={{animation: `${entranceFull} 0.25s ease-in 0.1s forwards`}}>
+        return (
+            <WelcomeWrapper
+                className="enable-mouse"
+                style={{ animation: `${entranceFull} 0.25s ease-in 0.1s forwards` }}
+            >
                 <WelcomeView />
             </WelcomeWrapper>
+        )
     }
 }
 
@@ -184,8 +189,7 @@ export class WelcomeView extends React.PureComponent<{}, WelcomeViewState> {
     }
 
     public componentDidMount(): void {
-
-        getMetadata().then((metadata) => {
+        getMetadata().then(metadata => {
             this.setState({
                 version: metadata.version,
             })
@@ -193,50 +197,104 @@ export class WelcomeView extends React.PureComponent<{}, WelcomeViewState> {
     }
 
     public render(): JSX.Element {
-
         if (!this.state.version) {
             return null
         }
 
-        return <Column>
-                    <Row style={{width: "100%", paddingTop: "32px", animation: `${entranceFull} 0.25s ease-in 0.25s forwards`}}>
-                        <Column />
-                        <Column style={{alignItems: "flex-end"}}>
-                            <TitleText>Oni</TitleText>
-                            <SubtitleText>Modern Modal Editing</SubtitleText>
-                        </Column>
-                        <Column style={{flex: "0 0"}}>
-                            <HeroImage src="images/oni-icon-no-border.svg"/>
-                        </Column>
-                        <Column style={{alignItems: "flex-start"}}>
-                            <SubtitleText>{"v" + this.state.version}</SubtitleText>
-                            <div>{"https://onivim.io"}</div>
-                        </Column>
-                        <Column />
-                    </Row>
-                    <Row style={{width: "100%", marginTop: "64px", opacity: 1}}>
-                        <Column />
-                        <Column>
-                            <div style={{width: "100%", animation: `${entranceFull} 0.25s ease-in 0.5s both`}}>
-                                <SectionHeader>Learn</SectionHeader>
-                                <WelcomeButton title="Tutor" description="Learn VIM with an interactive tutorial." command="oni.tutor.open" />
-                                <WelcomeButton title="Documentation" description="Discover what Oni can do for you." command="oni.docs.open" />
-                            </div>
-                            <div style={{width: "100%", animation: `${entranceFull} 0.25s ease-in 0.75s both`}}>
-                                <SectionHeader>Customize</SectionHeader>
-                                <WelcomeButton title="Configure" description="Make Oni work the way you want." command="oni.configuration.open" />
-                                <WelcomeButton title="Themes" description="Choose a theme that works for you." command="oni.themes.open" />
-                            </div>
-                            <div style={{width: "100%", animation: `${entranceFull} 0.25s ease-in 1s both`}}>
-                                <SectionHeader>Quick Commands</SectionHeader>
-                                <WelcomeButton title="New File" description="Control + N" command="oni.configuration.open" />
-                                <WelcomeButton title="Open File / Folder" description="Control + O" command="oni.configuration.open" />
-                                <WelcomeButton title="Command Palette" description="Control + Shift + P" command="oni.configuration.open" />
-                                <WelcomeButton title="Vim Ex Commands" description=":" command="oni.openEx" />
-                            </div>
-                        </Column>
-                        <Column />
-                    </Row>
-                </Column>
+        return (
+            <Column>
+                <Row
+                    style={{
+                        width: "100%",
+                        paddingTop: "32px",
+                        animation: `${entranceFull} 0.25s ease-in 0.25s forwards`,
+                    }}
+                >
+                    <Column />
+                    <Column style={{ alignItems: "flex-end" }}>
+                        <TitleText>Oni</TitleText>
+                        <SubtitleText>Modern Modal Editing</SubtitleText>
+                    </Column>
+                    <Column style={{ flex: "0 0" }}>
+                        <HeroImage src="images/oni-icon-no-border.svg" />
+                    </Column>
+                    <Column style={{ alignItems: "flex-start" }}>
+                        <SubtitleText>{"v" + this.state.version}</SubtitleText>
+                        <div>{"https://onivim.io"}</div>
+                    </Column>
+                    <Column />
+                </Row>
+                <Row style={{ width: "100%", marginTop: "64px", opacity: 1 }}>
+                    <Column />
+                    <Column>
+                        <div
+                            style={{
+                                width: "100%",
+                                animation: `${entranceFull} 0.25s ease-in 0.5s both`,
+                            }}
+                        >
+                            <SectionHeader>Learn</SectionHeader>
+                            <WelcomeButton
+                                title="Tutor"
+                                description="Learn VIM with an interactive tutorial."
+                                command="oni.tutor.open"
+                            />
+                            <WelcomeButton
+                                title="Documentation"
+                                description="Discover what Oni can do for you."
+                                command="oni.docs.open"
+                            />
+                        </div>
+                        <div
+                            style={{
+                                width: "100%",
+                                animation: `${entranceFull} 0.25s ease-in 0.75s both`,
+                            }}
+                        >
+                            <SectionHeader>Customize</SectionHeader>
+                            <WelcomeButton
+                                title="Configure"
+                                description="Make Oni work the way you want."
+                                command="oni.configuration.open"
+                            />
+                            <WelcomeButton
+                                title="Themes"
+                                description="Choose a theme that works for you."
+                                command="oni.themes.open"
+                            />
+                        </div>
+                        <div
+                            style={{
+                                width: "100%",
+                                animation: `${entranceFull} 0.25s ease-in 1s both`,
+                            }}
+                        >
+                            <SectionHeader>Quick Commands</SectionHeader>
+                            <WelcomeButton
+                                title="New File"
+                                description="Control + N"
+                                command="oni.configuration.open"
+                            />
+                            <WelcomeButton
+                                title="Open File / Folder"
+                                description="Control + O"
+                                command="oni.configuration.open"
+                            />
+                            <WelcomeButton
+                                title="Command Palette"
+                                description="Control + Shift + P"
+                                command="oni.configuration.open"
+                            />
+                            <WelcomeButton
+                                title="Vim Ex Commands"
+                                description=":"
+                                command="oni.openEx"
+                            />
+                        </div>
+                    </Column>
+                    <Column />
+                </Row>
+            </Column>
+        )
     }
 }

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -22,16 +22,12 @@ import { CompletionProviders } from "./../../Services/Completion"
 import { Configuration } from "./../../Services/Configuration"
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 
-import {
-    LanguageManager,
-} from "./../../Services/Language"
+import { LanguageManager } from "./../../Services/Language"
 
 import { MenuManager } from "./../../Services/Menu"
 import { OverlayManager } from "./../../Services/Overlay"
 
-import {
-    ISyntaxHighlighter,
-} from "./../../Services/SyntaxHighlighting"
+import { ISyntaxHighlighter } from "./../../Services/SyntaxHighlighting"
 
 import { Tasks } from "./../../Services/Tasks"
 import { ThemeManager } from "./../../Services/Themes"
@@ -49,12 +45,11 @@ import { NeovimEditor } from "./../NeovimEditor"
 const wrapReactComponentWithLayer = (id: string, component: JSX.Element): Oni.EditorLayer => {
     return {
         id,
-        render: (context: Oni.EditorLayerRenderContext) => context.isActive ? component : null,
+        render: (context: Oni.EditorLayerRenderContext) => (context.isActive ? component : null),
     }
 }
 
 export class OniEditor implements IEditor {
-
     private _neovimEditor: NeovimEditor
 
     public get mode(): string {
@@ -89,7 +84,7 @@ export class OniEditor implements IEditor {
         return this._neovimEditor.onBufferScrolled
     }
 
-    public /* override */ get activeBuffer(): Oni.Buffer {
+    public get /* override */ activeBuffer(): Oni.Buffer {
         return this._neovimEditor.activeBuffer
     }
 
@@ -103,27 +98,44 @@ export class OniEditor implements IEditor {
     }
 
     constructor(
-         colors: IColors,
-         completionProviders: CompletionProviders,
-         configuration: Configuration,
-         diagnostics: IDiagnosticsDataSource,
-         languageManager: LanguageManager,
-         menuManager: MenuManager,
-         overlayManager: OverlayManager,
-         pluginManager: PluginManager,
-         tasks: Tasks,
-         themeManager: ThemeManager,
-         workspace: Workspace,
+        colors: IColors,
+        completionProviders: CompletionProviders,
+        configuration: Configuration,
+        diagnostics: IDiagnosticsDataSource,
+        languageManager: LanguageManager,
+        menuManager: MenuManager,
+        overlayManager: OverlayManager,
+        pluginManager: PluginManager,
+        tasks: Tasks,
+        themeManager: ThemeManager,
+        workspace: Workspace,
     ) {
-        this._neovimEditor = new NeovimEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, overlayManager, pluginManager, tasks, themeManager, workspace)
+        this._neovimEditor = new NeovimEditor(
+            colors,
+            completionProviders,
+            configuration,
+            diagnostics,
+            languageManager,
+            menuManager,
+            overlayManager,
+            pluginManager,
+            tasks,
+            themeManager,
+            workspace,
+        )
 
-        this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.scrollbar", <BufferScrollBarContainer />))
-        this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.definition", <DefinitionContainer />))
-        this._neovimEditor.bufferLayers.addBufferLayer("*", (buf) => wrapReactComponentWithLayer("oni.layer.errors", <ErrorsContainer />))
+        this._neovimEditor.bufferLayers.addBufferLayer("*", buf =>
+            wrapReactComponentWithLayer("oni.layer.scrollbar", <BufferScrollBarContainer />),
+        )
+        this._neovimEditor.bufferLayers.addBufferLayer("*", buf =>
+            wrapReactComponentWithLayer("oni.layer.definition", <DefinitionContainer />),
+        )
+        this._neovimEditor.bufferLayers.addBufferLayer("*", buf =>
+            wrapReactComponentWithLayer("oni.layer.errors", <ErrorsContainer />),
+        )
     }
 
     public dispose(): void {
-
         if (this._neovimEditor) {
             this._neovimEditor.dispose()
             this._neovimEditor = null

--- a/browser/src/Editor/OniEditor/containers/BufferScrollBarContainer.ts
+++ b/browser/src/Editor/OniEditor/containers/BufferScrollBarContainer.ts
@@ -4,16 +4,18 @@ import { connect } from "react-redux"
 import { createSelector } from "reselect"
 
 import { getColorFromSeverity } from "./../../../Services/Errors"
-import { BufferScrollBar, IBufferScrollBarProps, IScrollBarMarker } from "./../../../UI/components/BufferScrollBar"
+import {
+    BufferScrollBar,
+    IBufferScrollBarProps,
+    IScrollBarMarker,
+} from "./../../../UI/components/BufferScrollBar"
 
 import * as Selectors from "./../../NeovimEditor/NeovimEditorSelectors"
 import * as State from "./../../NeovimEditor/NeovimEditorStore"
 
-export const getCurrentLine = createSelector(
-    [Selectors.getActiveWindow],
-    (activeWindow) => {
-        return activeWindow.line
-    })
+export const getCurrentLine = createSelector([Selectors.getActiveWindow], activeWindow => {
+    return activeWindow.line
+})
 
 const NoScrollBar: IBufferScrollBarProps = {
     windowId: null,
@@ -49,7 +51,8 @@ export const getMarkers = createSelector(
 
             return [...errorMarkers, cursorMarker]
         }
-    })
+    },
+)
 
 const mapStateToProps = (state: State.IState): IBufferScrollBarProps => {
     const visible = state.configuration["editor.scrollBar.visible"]

--- a/browser/src/Editor/OniEditor/containers/DefinitionContainer.ts
+++ b/browser/src/Editor/OniEditor/containers/DefinitionContainer.ts
@@ -7,15 +7,11 @@ import { Definition, IDefinitionProps } from "./../../../UI/components/Definitio
 import * as Selectors from "./../../NeovimEditor/NeovimEditorSelectors"
 import * as State from "./../../NeovimEditor/NeovimEditorStore"
 
-const emptyRange = types.Range.create(
-    types.Position.create(-1, -1),
-    types.Position.create(-1, -1),
-)
+const emptyRange = types.Range.create(types.Position.create(-1, -1), types.Position.create(-1, -1))
 
 const getActiveDefinition = (state: State.IState) => state.definition
 
 const mapStateToProps = (state: State.IState): IDefinitionProps => {
-
     const window = Selectors.getActiveWindow(state)
 
     const noop = (): any => null

--- a/browser/src/Editor/OniEditor/containers/ErrorsContainer.ts
+++ b/browser/src/Editor/OniEditor/containers/ErrorsContainer.ts
@@ -6,7 +6,6 @@ import * as Selectors from "./../../NeovimEditor/NeovimEditorSelectors"
 import * as State from "./../../NeovimEditor/NeovimEditorStore"
 
 const mapStateToProps = (state: State.IState): IErrorsProps => {
-
     const window = Selectors.getActiveWindow(state)
     const errors = Selectors.getErrorsForActiveFile(state)
 

--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -1,4 +1,5 @@
-export const FallbackFonts = "Consolas,Monaco,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace"
+export const FallbackFonts =
+    "Consolas,Monaco,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace"
 
 export interface IFontMeasurement {
     width: number

--- a/browser/src/Grid.ts
+++ b/browser/src/Grid.ts
@@ -29,7 +29,6 @@ export class Grid<T> {
     }
 
     public setCell(x: number, y: number, val: T | null) {
-
         let row = this._cells[y]
         row = row || {}
         row[x] = val
@@ -67,7 +66,6 @@ export class Grid<T> {
         let current = start
 
         while (current >= 0 && current < this._height) {
-
             const srcRow = current + rowsToShift
 
             for (let x = 0; x < this._width; x++) {
@@ -88,7 +86,13 @@ export class Grid<T> {
         }
     }
 
-    public setRegion(startX: number, startY: number, width: number, height: number, val?: T | null): void {
+    public setRegion(
+        startX: number,
+        startY: number,
+        width: number,
+        height: number,
+        val?: T | null,
+    ): void {
         const valToSet = typeof val === "undefined" ? null : val
         for (let x = startX; x < startX + width; x++) {
             for (let y = startY; y < startY + height; y++) {

--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -17,7 +17,8 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     const isVisualMode = () => editors.activeEditor.mode === "visual"
     const isNormalMode = () => editors.activeEditor.mode === "normal"
     const isNotInsertMode = () => editors.activeEditor.mode !== "insert"
-    const isInsertOrCommandMode = () => editors.activeEditor.mode === "insert" || editors.activeEditor.mode === "cmdline_normal"
+    const isInsertOrCommandMode = () =>
+        editors.activeEditor.mode === "insert" || editors.activeEditor.mode === "cmdline_normal"
 
     const isMenuOpen = () => menu.isMenuOpen()
 
@@ -60,13 +61,21 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     }
 
     input.bind("<f2>", "editor.rename", () => isNormalMode()),
-    input.bind("<esc>", "editor.rename.cancel")
+        input.bind("<esc>", "editor.rename.cancel")
     input.bind("<enter>", "editor.rename.commit")
 
     input.bind("<f3>", "language.format")
     input.bind(["<f12>"], "language.gotoDefinition", () => isNormalMode() && !menu.isMenuOpen())
-    input.bind(["<c-enter>", "<c-f12>"], "language.gotoDefinition.openVertical", () => isNormalMode() && !menu.isMenuOpen())
-    input.bind(["<s-enter>", "<s-f12>"], "language.gotoDefinition.openHorizontal", () => isNormalMode() && !menu.IsMenuOpen())
+    input.bind(
+        ["<c-enter>", "<c-f12>"],
+        "language.gotoDefinition.openVertical",
+        () => isNormalMode() && !menu.isMenuOpen(),
+    )
+    input.bind(
+        ["<s-enter>", "<s-f12>"],
+        "language.gotoDefinition.openHorizontal",
+        () => isNormalMode() && !menu.IsMenuOpen(),
+    )
     input.bind("<S-C-P>", "commands.show", isNormalMode)
     input.bind("<C-pageup>", "oni.process.cyclePrevious")
     input.bind("<C-pagedown>", "oni.process.cycleNext")
@@ -81,7 +90,11 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     input.bind(["<enter>", "<tab>"], "contextMenu.select")
     input.bind(["<down>", "<C-n>"], "contextMenu.next")
     input.bind(["<up>", "<C-p>"], "contextMenu.previous")
-    input.bind(["<esc>"], "contextMenu.close", isNotInsertMode /* In insert mode, the mode change will close the popupmenu anyway */)
+    input.bind(
+        ["<esc>"],
+        "contextMenu.close",
+        isNotInsertMode /* In insert mode, the mode change will close the popupmenu anyway */,
+    )
 
     // Menu
     input.bind(["<down>", "<C-n>"], "menu.next")

--- a/browser/src/Input/Keyboard/Keyboard.ts
+++ b/browser/src/Input/Keyboard/Keyboard.ts
@@ -1,7 +1,12 @@
 import * as Log from "./../../Log"
 
 import { KeyboardLayoutManager } from "./KeyboardLayout"
-import { createMetaKeyResolver, ignoreMetaKeyResolver, KeyResolver, remapResolver  } from "./Resolvers"
+import {
+    createMetaKeyResolver,
+    ignoreMetaKeyResolver,
+    KeyResolver,
+    remapResolver,
+} from "./Resolvers"
 
 let _keyEventToVimKey: (evt: KeyboardEvent) => string | null = null
 
@@ -35,7 +40,11 @@ export const getKeyEventToVimKey = () => {
         }, evt.key)
 
         if (Log.isDebugLoggingEnabled()) {
-            Log.debug(`[Key event] Code: ${evt.code} Key: ${evt.key} CtrlKey: ${evt.ctrlKey} ShiftKey: ${evt.shiftKey} AltKey: ${evt.altKey} | Resolution: ${mappedKey}`)
+            Log.debug(
+                `[Key event] Code: ${evt.code} Key: ${evt.key} CtrlKey: ${evt.ctrlKey} ShiftKey: ${
+                    evt.shiftKey
+                } AltKey: ${evt.altKey} | Resolution: ${mappedKey}`,
+            )
         }
 
         return mappedKey

--- a/browser/src/Input/Keyboard/KeyboardLayout.ts
+++ b/browser/src/Input/Keyboard/KeyboardLayout.ts
@@ -19,8 +19,8 @@ export interface IKeyInfo {
 const augmentKeyMap = (keyMap: IKeyMap, language: string): IKeyMap => {
     // Temporary hack to workaround atom/keyboard-layout#36
     if (Platform.isWindows() && language === "es-ES") {
+        // tslint:disable-next-line no-string-literal
         keyMap["BracketLeft"] = {
-            // tslint:disable-line no-string-literal
             unmodified: null,
             withShift: null,
             withAltGraph: "[",

--- a/browser/src/Input/Keyboard/KeyboardLayout.ts
+++ b/browser/src/Input/Keyboard/KeyboardLayout.ts
@@ -17,10 +17,10 @@ export interface IKeyInfo {
 // Helper method to augment the key mapping in cases
 // where it isn't accurate from `keyboard-layout`
 const augmentKeyMap = (keyMap: IKeyMap, language: string): IKeyMap => {
-
     // Temporary hack to workaround atom/keyboard-layout#36
     if (Platform.isWindows() && language === "es-ES") {
-        keyMap["BracketLeft"] = { // tslint:disable-line no-string-literal
+        keyMap["BracketLeft"] = {
+            // tslint:disable-line no-string-literal
             unmodified: null,
             withShift: null,
             withAltGraph: "[",

--- a/browser/src/Input/Keyboard/Resolvers.ts
+++ b/browser/src/Input/Keyboard/Resolvers.ts
@@ -22,7 +22,10 @@ const keysToIgnore = [
     "AudioVolumeDown",
 ]
 
-export const ignoreMetaKeyResolver = (evt: KeyboardEvent, previousResolution: string | null): string | null => {
+export const ignoreMetaKeyResolver = (
+    evt: KeyboardEvent,
+    previousResolution: string | null,
+): string | null => {
     if (keysToIgnore.indexOf(evt.key) >= 0) {
         return null
     } else {
@@ -31,24 +34,26 @@ export const ignoreMetaKeyResolver = (evt: KeyboardEvent, previousResolution: st
 }
 
 const keysToRemap: { [key: string]: string } = {
-    "Backspace": "bs",
-    "Escape": "esc",
-    "Enter": "enter",
-    "Tab": "tab",     // Tab
-    "ArrowLeft": "left",    // ArrowLeft
-    "ArrowUp": "up",      // ArrowUp
-    "ArrowRight": "right",   // ArrowRight
-    "ArrowDown": "down",    // ArrowDown
-    "Insert": "insert",
+    Backspace: "bs",
+    Escape: "esc",
+    Enter: "enter",
+    Tab: "tab", // Tab
+    ArrowLeft: "left", // ArrowLeft
+    ArrowUp: "up", // ArrowUp
+    ArrowRight: "right", // ArrowRight
+    ArrowDown: "down", // ArrowDown
+    Insert: "insert",
     " ": "space",
 }
 
-export const remapResolver = (evt: KeyboardEvent, previousResolution: string | null): string | null => {
+export const remapResolver = (
+    evt: KeyboardEvent,
+    previousResolution: string | null,
+): string | null => {
     return keysToRemap[evt.key] ? keysToRemap[evt.key] : previousResolution
 }
 
 export const createMetaKeyResolver = (keyMap: IKeyMap) => {
-
     return (evt: KeyboardEvent, previousResolution: string | null): null | string => {
         const isCharacterFromShiftKey = isShiftCharacter(keyMap, evt)
         const isCharacterFromAltGraphKey = isAltGraphCharacter(keyMap, evt)
@@ -93,7 +98,6 @@ export const createMetaKeyResolver = (keyMap: IKeyMap) => {
 }
 
 const isShiftCharacter = (keyMap: IKeyMap, evt: KeyboardEvent): boolean => {
-
     const { key, code } = evt
 
     const mappedKey: IKeyInfo = keyMap[code]

--- a/browser/src/Input/KeyboardInput.tsx
+++ b/browser/src/Input/KeyboardInput.tsx
@@ -61,7 +61,10 @@ export interface IKeyboardInputProps {
  *
  * Helper for managing state and sanitizing input from dead keys, IME, etc
  */
-export class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKeyboardInputViewState> {
+export class KeyboardInputView extends React.PureComponent<
+    IKeyboardInputViewProps,
+    IKeyboardInputViewState
+> {
     private _keyboardElement: HTMLInputElement
     private _disposables: IDisposable[] = []
 
@@ -131,19 +134,22 @@ export class KeyboardInputView extends React.PureComponent<IKeyboardInputViewPro
             width: this.state.compositionTextWidthInPixels + "px",
         }
 
-        return <div style={containerStyle}>
-            <div style={backgroundStyle} />
-            <input
-                style={inputStyle}
-                ref={(elem) => this._keyboardElement = elem}
-                type={"text"}
-                onKeyDown={(evt) => this._onKeyDown(evt)}
-                onKeyUp={(evt) => this._onKeyUp(evt)}
-                onCompositionEnd={(evt) => this._onCompositionEnd(evt)}
-                onCompositionUpdate={(evt) => this._onCompositionUpdate(evt)}
-                onCompositionStart={(evt) => this._onCompositionStart(evt)}
-                onInput={(evt) => this._onInput(evt)} />
-        </div>
+        return (
+            <div style={containerStyle}>
+                <div style={backgroundStyle} />
+                <input
+                    style={inputStyle}
+                    ref={elem => (this._keyboardElement = elem)}
+                    type={"text"}
+                    onKeyDown={evt => this._onKeyDown(evt)}
+                    onKeyUp={evt => this._onKeyUp(evt)}
+                    onCompositionEnd={evt => this._onCompositionEnd(evt)}
+                    onCompositionUpdate={evt => this._onCompositionUpdate(evt)}
+                    onCompositionStart={evt => this._onCompositionStart(evt)}
+                    onInput={evt => this._onInput(evt)}
+                />
+            </div>
+        )
     }
 
     private _onKeyUp(evt: React.KeyboardEvent<HTMLInputElement>) {
@@ -182,7 +188,6 @@ export class KeyboardInputView extends React.PureComponent<IKeyboardInputViewPro
             evt.preventDefault()
             return
         } else {
-
             if (this.props.typingPrediction) {
                 this.props.typingPrediction.addPrediction(key)
             }
@@ -205,7 +210,6 @@ export class KeyboardInputView extends React.PureComponent<IKeyboardInputViewPro
 
     private _onCompositionUpdate(evt: React.CompositionEvent<HTMLInputElement>) {
         if (this._keyboardElement) {
-
             const measurements = measureFont(this.props.fontSize, this.props.fontFamily, evt.data)
 
             // Add some padding for an extra character to the end of the input box
@@ -252,7 +256,10 @@ export class KeyboardInputView extends React.PureComponent<IKeyboardInputViewPro
     }
 }
 
-const mapStateToProps = (state: IState, originalProps: IKeyboardInputProps): IKeyboardInputViewProps => {
+const mapStateToProps = (
+    state: IState,
+    originalProps: IKeyboardInputProps,
+): IKeyboardInputViewProps => {
     return {
         ...originalProps,
         top: state.cursorPixelY,

--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -5,12 +5,9 @@ import { IScreen } from "./../neovim"
 // TODO
 // Handle modifier keys
 export class Mouse extends EventEmitter {
-
     private _isDragging = false
 
-    constructor(
-        private _editorElement: HTMLDivElement,
-        private _screen: IScreen) {
+    constructor(private _editorElement: HTMLDivElement, private _screen: IScreen) {
         super()
 
         this._editorElement.addEventListener("mousedown", (evt: MouseEvent) => {
@@ -56,7 +53,6 @@ export class Mouse extends EventEmitter {
             }
 
             this._isDragging = false
-
         })
     }
 

--- a/browser/src/Log.ts
+++ b/browser/src/Log.ts
@@ -29,11 +29,11 @@ export const verbose = (message: string): void => {
     }
 }
 
-export const info = (message: string): void  => {
+export const info = (message: string): void => {
     console.log(message) // tslint:disable-line no-console
 }
 
-export const warn = (message: string): void  => {
+export const warn = (message: string): void => {
     console.warn(message) // tslint:disable-line no-console
 }
 

--- a/browser/src/Performance.ts
+++ b/browser/src/Performance.ts
@@ -1,4 +1,3 @@
-
 /**
  * Thin wrapper around browser performance API
  */

--- a/browser/src/PeriodicJobs.ts
+++ b/browser/src/PeriodicJobs.ts
@@ -11,7 +11,6 @@ export interface IPeriodicJob {
 }
 
 export class PeriodicJobManager {
-
     private _currentScheduledJob: number = null
     private _pendingJobs: IPeriodicJob[] = []
 
@@ -45,7 +44,7 @@ export class PeriodicJobManager {
 
     private _executePendingJobs(): boolean {
         const completedJobs: IPeriodicJob[] = []
-        this._pendingJobs.forEach((job) => {
+        this._pendingJobs.forEach(job => {
             const completed = job.execute()
 
             if (completed) {
@@ -54,7 +53,7 @@ export class PeriodicJobManager {
         })
 
         // Remove completed jobs
-        this._pendingJobs = this._pendingJobs.filter((job) => completedJobs.indexOf(job) === -1)
+        this._pendingJobs = this._pendingJobs.filter(job => completedJobs.indexOf(job) === -1)
 
         if (this._pendingJobs.length === 0) {
             Log.verbose("[PeriodicJobManager] All jobs complete.")

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -8,34 +8,37 @@ export const isWindows = () => os.platform() === "win32"
 export const isMac = () => os.platform() === "darwin"
 export const isLinux = () => os.platform() === "linux"
 
-export const getUserHome = () =>
-    isWindows() ? process.env["APPDATA"] : process.env["HOME"] // tslint:disable-line no-string-literal
+export const getUserHome = () => (isWindows() ? process.env["APPDATA"] : process.env["HOME"]) // tslint:disable-line no-string-literal
 
-export const getLinkPath = () => isMac() ? "/usr/local/bin/oni" : "" // TODO: windows + linux
+export const getLinkPath = () => (isMac() ? "/usr/local/bin/oni" : "") // TODO: windows + linux
 export const isAddedToPath = () => {
-  if (isMac()) {
-    try { fs.lstatSync(getLinkPath()) } catch (_) { return false }
-    return true
-  }
+    if (isMac()) {
+        try {
+            fs.lstatSync(getLinkPath())
+        } catch (_) {
+            return false
+        }
+        return true
+    }
 
-  return false
+    return false
 }
-export const removeFromPath = () => isMac () ? fs.unlinkSync(getLinkPath()) : false // TODO: windows + other
+export const removeFromPath = () => (isMac() ? fs.unlinkSync(getLinkPath()) : false) // TODO: windows + other
 
 export const addToPath = async () => {
-  if (isMac()) {
-    const appDirectory = path.join(path.dirname(process.mainModule.filename), "..", "..")
-    const options = {name: "Oni", icns: path.join(appDirectory, "Resources", "Oni.icns")}
-    const linkPath = path.join(appDirectory, "Resources", "app", "oni.sh")
-    await _runSudoCommand(`ln -s ${linkPath} ${getLinkPath()}`, options)
-  }
+    if (isMac()) {
+        const appDirectory = path.join(path.dirname(process.mainModule.filename), "..", "..")
+        const options = { name: "Oni", icns: path.join(appDirectory, "Resources", "Oni.icns") }
+        const linkPath = path.join(appDirectory, "Resources", "app", "oni.sh")
+        await _runSudoCommand(`ln -s ${linkPath} ${getLinkPath()}`, options)
+    }
 }
 
 const _runSudoCommand = async (command: string, options: any) => {
-  const sudo = await import("sudo-prompt")
-  return new Promise(resolve => {
-    sudo.exec(command, options, (error: Error, stdout: string, stderr: string) => {
-      resolve({error, stdout, stderr})
+    const sudo = await import("sudo-prompt")
+    return new Promise(resolve => {
+        sudo.exec(command, options, (error: Error, stdout: string, stderr: string) => {
+            resolve({ error, stdout, stderr })
+        })
     })
-  })
 }

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -40,11 +40,13 @@ export interface ServerCapabilities {
 
 export const wrapPathInFileUri = (path: string) => getFilePrefix() + Utility.normalizePath(path)
 
-export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split(getFilePrefix())[1])
+export const unwrapFileUriPath = (uri: string) => decodeURIComponent(uri.split(getFilePrefix())[1])
 
-export const getTextFromContents = (contents: types.MarkedString | types.MarkedString[]): string[] => {
+export const getTextFromContents = (
+    contents: types.MarkedString | types.MarkedString[],
+): string[] => {
     if (contents instanceof Array) {
-        return flatMap(contents, (markedString) => getTextFromMarkedString(markedString))
+        return flatMap(contents, markedString => getTextFromMarkedString(markedString))
     } else {
         return getTextFromMarkedString(contents)
     }
@@ -56,7 +58,12 @@ export const pathToTextDocumentIdentifierParms = (path: string) => ({
     },
 })
 
-export const pathToTextDocumentItemParams = (path: string, language: string, text: string, version: number) => ({
+export const pathToTextDocumentItemParams = (
+    path: string,
+    language: string,
+    text: string,
+    version: number,
+) => ({
     textDocument: {
         uri: wrapPathInFileUri(path),
         languageId: language,
@@ -76,7 +83,11 @@ export const eventContextToCodeActionParams = (filePath: string, range: types.Ra
     }
 }
 
-export const createTextDocumentPositionParams = (filePath: string, line: number, column: number) => ({
+export const createTextDocumentPositionParams = (
+    filePath: string,
+    line: number,
+    column: number,
+) => ({
     textDocument: {
         uri: wrapPathInFileUri(filePath),
     },
@@ -87,10 +98,18 @@ export const createTextDocumentPositionParams = (filePath: string, line: number,
 })
 
 export const bufferToTextDocumentPositionParams = (buffer: Oni.Buffer) => {
-    return createTextDocumentPositionParams(buffer.filePath, buffer.cursor.line, buffer.cursor.column)
+    return createTextDocumentPositionParams(
+        buffer.filePath,
+        buffer.cursor.line,
+        buffer.cursor.column,
+    )
 }
 
-export const createDidChangeTextDocumentParams = (bufferFullPath: string, lines: string[], version: number) => {
+export const createDidChangeTextDocumentParams = (
+    bufferFullPath: string,
+    lines: string[],
+    version: number,
+) => {
     const text = lines.join(os.EOL)
 
     return {
@@ -98,9 +117,11 @@ export const createDidChangeTextDocumentParams = (bufferFullPath: string, lines:
             uri: wrapPathInFileUri(bufferFullPath),
             version,
         },
-        contentChanges: [{
-            text,
-        }],
+        contentChanges: [
+            {
+                text,
+            },
+        ],
     }
 }
 
@@ -115,7 +136,8 @@ const getTextFromMarkedString = (markedString: types.MarkedString): string[] => 
 
 const splitByNewlines = (str: string) => {
     // Remove '/r'
-    return str.split("\r")
+    return str
+        .split("\r")
         .join("")
         .split("\n")
 }
@@ -126,4 +148,4 @@ const getFilePrefix = () => {
     } else {
         return "file://"
     }
- }
+}

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -83,7 +83,6 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
 
     public get completions(): any {
         return getCompletionProvidersInstance()
-
     }
 
     public get configuration(): OniApi.Configuration {
@@ -163,8 +162,15 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
         this._services = new Services()
     }
 
-    public async execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): Promise<ChildProcess.ChildProcess> {
-        Log.warn("WARNING: `OniApi.execNodeScript` is deprecated. Please use `OniApi.process.execNodeScript` instead")
+    public async execNodeScript(
+        scriptPath: string,
+        args: string[] = [],
+        options: ChildProcess.ExecOptions = {},
+        callback: (err: any, stdout: string, stderr: string) => void,
+    ): Promise<ChildProcess.ChildProcess> {
+        Log.warn(
+            "WARNING: `OniApi.execNodeScript` is deprecated. Please use `OniApi.process.execNodeScript` instead",
+        )
 
         return await Process.execNodeScript(scriptPath, args, options, callback)
     }
@@ -172,9 +178,14 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
     /**
      * Wrapper around `child_process.exec` to run using electron as opposed to node
      */
-    public async spawnNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> {
-
-        Log.warn("WARNING: `OniApi.spawnNodeScript` is deprecated. Please use `OniApi.process.spawnNodeScript` instead")
+    public async spawnNodeScript(
+        scriptPath: string,
+        args: string[] = [],
+        options: ChildProcess.SpawnOptions = {},
+    ): Promise<ChildProcess.ChildProcess> {
+        Log.warn(
+            "WARNING: `OniApi.spawnNodeScript` is deprecated. Please use `OniApi.process.spawnNodeScript` instead",
+        )
 
         return await Process.spawnNodeScript(scriptPath, args, options)
     }

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -22,7 +22,9 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
     return currentPath + separator + joinedPathsToAdd
 }
 
-const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): Promise<any> => {
+const mergeSpawnOptions = async (
+    originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions,
+): Promise<any> => {
     let existingPath: string
 
     try {
@@ -41,7 +43,10 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
         },
     }
 
-    requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, configuration.getValue("environment.additionalPaths"))
+    requiredOptions.env.PATH = mergePathEnvironmentVariable(
+        existingPath,
+        configuration.getValue("environment.additionalPaths"),
+    )
 
     return {
         ...originalSpawnOptions,
@@ -53,12 +58,17 @@ const mergeSpawnOptions = async (originalSpawnOptions: ChildProcess.ExecOptions 
  * API surface area responsible for handling process-related tasks
  * (spawning processes, managing running process, etc)
  */
-export const execNodeScript = async (scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): Promise<ChildProcess.ChildProcess> => {
+export const execNodeScript = async (
+    scriptPath: string,
+    args: string[] = [],
+    options: ChildProcess.ExecOptions = {},
+    callback: (err: any, stdout: string, stderr: string) => void,
+): Promise<ChildProcess.ChildProcess> => {
     const spawnOptions = await mergeSpawnOptions(options)
     spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
 
     const execOptions = [process.execPath, scriptPath].concat(args)
-    const execString = execOptions.map((s) => `"${s}"`).join(" ")
+    const execString = execOptions.map(s => `"${s}"`).join(" ")
 
     const proc = ChildProcess.exec(execString, spawnOptions, callback)
     _spawnedProcessIds.push(proc.pid)
@@ -75,7 +85,11 @@ export const getPIDs = (): number[] => {
 /**
  * Wrapper around `child_process.exec` to run using electron as opposed to node
  */
-export const spawnNodeScript = async (scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> => {
+export const spawnNodeScript = async (
+    scriptPath: string,
+    args: string[] = [],
+    options: ChildProcess.SpawnOptions = {},
+): Promise<ChildProcess.ChildProcess> => {
     const spawnOptions = await mergeSpawnOptions(options)
     spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
 
@@ -89,7 +103,11 @@ export const spawnNodeScript = async (scriptPath: string, args: string[] = [], o
 /**
  * Spawn process - wrapper around `child_process.spawn`
  */
-export const spawnProcess = async (startCommand: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): Promise<ChildProcess.ChildProcess> => {
+export const spawnProcess = async (
+    startCommand: string,
+    args: string[] = [],
+    options: ChildProcess.SpawnOptions = {},
+): Promise<ChildProcess.ChildProcess> => {
     const spawnOptions = await mergeSpawnOptions(options)
 
     const proc = ChildProcess.spawn(startCommand, args, spawnOptions)
@@ -99,4 +117,4 @@ export const spawnProcess = async (startCommand: string, args: string[] = [], op
     })
 
     return proc
-    }
+}

--- a/browser/src/Plugins/Api/Ui.ts
+++ b/browser/src/Plugins/Api/Ui.ts
@@ -1,8 +1,7 @@
 import { Icon, IconProps, IconSize } from "../../UI/Icon"
 
 export class Ui {
-    constructor(private _react: any) {
-    }
+    constructor(private _react: any) {}
 
     public createIcon(props: IconProps): any {
         return this._react.createElement(Icon, props)

--- a/browser/src/Plugins/PackageMetadataParser.ts
+++ b/browser/src/Plugins/PackageMetadataParser.ts
@@ -11,15 +11,22 @@ import * as Capabilities from "./Api/Capabilities"
 
 import * as Log from "./../Log"
 
-const remapToAbsolutePaths = (packageRoot: string, contributes: Capabilities.IContributions): Capabilities.IContributions => {
-    const remapThemePath = (themes: Capabilities.IThemeContribution): Capabilities.IThemeContribution => {
+const remapToAbsolutePaths = (
+    packageRoot: string,
+    contributes: Capabilities.IContributions,
+): Capabilities.IContributions => {
+    const remapThemePath = (
+        themes: Capabilities.IThemeContribution,
+    ): Capabilities.IThemeContribution => {
         return {
             ...themes,
             path: path.join(packageRoot, themes.path),
         }
     }
 
-    const remapIconPath = (iconThemes: Capabilities.IIconThemeContribution): Capabilities.IIconThemeContribution => {
+    const remapIconPath = (
+        iconThemes: Capabilities.IIconThemeContribution,
+    ): Capabilities.IIconThemeContribution => {
         return {
             ...iconThemes,
             path: path.join(packageRoot, iconThemes.path),
@@ -28,13 +35,12 @@ const remapToAbsolutePaths = (packageRoot: string, contributes: Capabilities.ICo
 
     return {
         ...contributes,
-        themes: contributes.themes.map((t) => remapThemePath(t)),
-        iconThemes: contributes.iconThemes.map((it) => remapIconPath(it)),
+        themes: contributes.themes.map(t => remapThemePath(t)),
+        iconThemes: contributes.iconThemes.map(it => remapIconPath(it)),
     }
 }
 
 export const readMetadata = (packagePath: string): Capabilities.IPluginMetadata | null => {
-
     const packageContents = fs.readFileSync(packagePath, "utf8")
 
     let metadata: Capabilities.IPluginMetadata = null
@@ -48,7 +54,8 @@ export const readMetadata = (packagePath: string): Capabilities.IPluginMetadata 
         return null
     }
 
-    if (!metadata.engines || !metadata.engines["oni"]) { // tslint:disable-line no-string-literal
+    if (!metadata.engines || !metadata.engines["oni"]) {
+        // tslint:disable-line no-string-literal
         Log.warn("Aborting plugin load as Oni engine version not specified")
         return null
     }

--- a/browser/src/Plugins/PackageMetadataParser.ts
+++ b/browser/src/Plugins/PackageMetadataParser.ts
@@ -54,8 +54,8 @@ export const readMetadata = (packagePath: string): Capabilities.IPluginMetadata 
         return null
     }
 
+    // tslint:disable-next-line no-string-literal
     if (!metadata.engines || !metadata.engines["oni"]) {
-        // tslint:disable-line no-string-literal
         Log.warn("Aborting plugin load as Oni engine version not specified")
         return null
     }

--- a/browser/src/Plugins/Plugin.ts
+++ b/browser/src/Plugins/Plugin.ts
@@ -16,9 +16,7 @@ export class Plugin {
         return this._oniPluginMetadata
     }
 
-    constructor(
-        private _pluginRootDirectory: string,
-    ) {
+    constructor(private _pluginRootDirectory: string) {
         const packageJsonPath = path.join(this._pluginRootDirectory, "package.json")
 
         if (fs.existsSync(packageJsonPath)) {
@@ -27,7 +25,6 @@ export class Plugin {
     }
 
     public activate(): void {
-
         if (!this._oniPluginMetadata || !this._oniPluginMetadata.main) {
             return
         }
@@ -36,15 +33,20 @@ export class Plugin {
         const vm = require("vm")
         Log.info(`[PLUGIN] Activating: ${this._oniPluginMetadata.name}`)
 
-        let moduleEntryPoint = path.normalize(path.join(this._pluginRootDirectory, this._oniPluginMetadata.main))
+        let moduleEntryPoint = path.normalize(
+            path.join(this._pluginRootDirectory, this._oniPluginMetadata.main),
+        )
         moduleEntryPoint = moduleEntryPoint.split("\\").join("/")
 
         try {
-            vm.runInNewContext(`debugger; const pluginEntryPoint = require('${moduleEntryPoint}').activate; if (!pluginEntryPoint) { console.warn('No activate method found for: ${moduleEntryPoint}'); } else { pluginEntryPoint(Oni); } `, {
-                Oni: this._oni,
-                require: window["require"], // tslint:disable-line no-string-literal
-                console,
-            })
+            vm.runInNewContext(
+                `debugger; const pluginEntryPoint = require('${moduleEntryPoint}').activate; if (!pluginEntryPoint) { console.warn('No activate method found for: ${moduleEntryPoint}'); } else { pluginEntryPoint(Oni); } `,
+                {
+                    Oni: this._oni,
+                    require: window["require"], // tslint:disable-line no-string-literal
+                    console,
+                },
+            )
             Log.info(`[PLUGIN] Activation successful.`)
         } catch (ex) {
             Log.error(`[PLUGIN] Failed to load plugin: ${this._oniPluginMetadata.name}`, ex)

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -21,9 +21,7 @@ export class PluginManager {
         return this._plugins
     }
 
-    constructor(
-        private _config: Configuration,
-    ) { }
+    constructor(private _config: Configuration) {}
 
     public discoverPlugins(): void {
         this._rootPluginPaths.push(corePluginsRoot)
@@ -37,14 +35,15 @@ export class PluginManager {
         this._rootPluginPaths.push(path.join(getUserConfigFolderPath(), "plugins"))
 
         const allPluginPaths = this._getAllPluginPaths()
-        this._plugins = allPluginPaths.map((pluginRootDirectory) => this._createPlugin(pluginRootDirectory))
+        this._plugins = allPluginPaths.map(pluginRootDirectory =>
+            this._createPlugin(pluginRootDirectory),
+        )
 
         this._anonymousPlugin = new AnonymousPlugin()
     }
 
     public startApi(): Oni.Plugin.Api {
-
-        this._plugins.forEach((plugin) => {
+        this._plugins.forEach(plugin => {
             plugin.activate()
         })
 
@@ -63,7 +62,7 @@ export class PluginManager {
 
     private _getAllPluginPaths(): string[] {
         const paths: string[] = []
-        this._rootPluginPaths.forEach((rp) => {
+        this._rootPluginPaths.forEach(rp => {
             const subPaths = getDirectories(rp)
             paths.push(...subPaths)
         })
@@ -85,7 +84,8 @@ function getDirectories(rootPath: string): string[] {
         return []
     }
 
-    return fs.readdirSync(rootPath)
-        .map((f) => path.join(rootPath.toString(), f))
-        .filter((f) => fs.statSync(f).isDirectory())
+    return fs
+        .readdirSync(rootPath)
+        .map(f => path.join(rootPath.toString(), f))
+        .filter(f => fs.statSync(f).isDirectory())
 }

--- a/browser/src/ProjectConfig.ts
+++ b/browser/src/ProjectConfig.ts
@@ -1,4 +1,3 @@
-
 /**
  * The conventions for project configuration are inspired from the VSCode launch.json:
  * https://code.visualstudio.com/Docs/editor/debugging
@@ -17,7 +16,7 @@ export interface ILaunchConfiguration {
     name: string
     program: string
     args: string[]
-    cwd: string,
+    cwd: string
     dependentCommands: string[]
 }
 
@@ -25,7 +24,7 @@ export interface ILaunchConfiguration {
  * Per-project configuration options
  */
 export interface IProjectConfiguration {
-    launchConfigurations: ILaunchConfiguration[],
+    launchConfigurations: ILaunchConfiguration[]
 }
 
 const DefaultConfiguration: IProjectConfiguration = {
@@ -37,8 +36,7 @@ const DefaultConfiguration: IProjectConfiguration = {
  * Search upward for the relevant .oni folder
  */
 export function getProjectConfiguration(filePath: string): Promise<IProjectConfiguration> {
-    return findUp(".oni", { cwd: filePath })
-    .then((oniDir: string) => {
+    return findUp(".oni", { cwd: filePath }).then((oniDir: string) => {
         if (!oniDir) {
             return DefaultConfiguration
         }
@@ -47,17 +45,19 @@ export function getProjectConfiguration(filePath: string): Promise<IProjectConfi
 }
 
 function loadConfigurationFromFolder(folder: string): IProjectConfiguration {
-
     const launchPath = path.join(folder, "launch.json")
 
     if (!fs.existsSync(launchPath)) {
         return DefaultConfiguration
     } else {
-       const launchInfo: ILaunchConfiguration = JSON.parse(fs.readFileSync(launchPath, "utf8"))
-       const config = {...DefaultConfiguration, ...{
-           launchConfigurations: [launchInfo],
-       }}
+        const launchInfo: ILaunchConfiguration = JSON.parse(fs.readFileSync(launchPath, "utf8"))
+        const config = {
+            ...DefaultConfiguration,
+            ...{
+                launchConfigurations: [launchInfo],
+            },
+        }
 
-       return config
+        return config
     }
 }

--- a/browser/src/Redux/LoggingMiddleware.ts
+++ b/browser/src/Redux/LoggingMiddleware.ts
@@ -8,7 +8,9 @@ import { Store } from "redux"
 
 import * as Log from "./../Log"
 
-export const createLoggingMiddleware = (storeName: string) => (store: Store<any>) => (next: any) => (action: any): any => {
+export const createLoggingMiddleware = (storeName: string) => (store: Store<any>) => (
+    next: any,
+) => (action: any): any => {
     Log.verbose("[REDUX - " + storeName + "][ACTION] " + action.type)
 
     const result = next(action)

--- a/browser/src/Redux/createStore.ts
+++ b/browser/src/Redux/createStore.ts
@@ -28,10 +28,11 @@ export const createStore = <TState>(
     defaultState: TState,
     optionalMiddleware: Middleware[] = [],
 ): Store<TState> => {
+    // tslinst:disable-next-line no-string-literal
+    const composeFunction: any = window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
+
     const composeEnhancers =
-        typeof window === "object" && window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] // tslint:disable-line no-string-literal
-            ? window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({ name })
-            : compose // tslint:disable-line no-string-literal
+        typeof window === "object" && composeFunction ? composeFunction({ name }) : compose // tslint:disable-line no-string-literal
 
     const loggingMiddleware: Middleware = createLoggingMiddleware(name)
 

--- a/browser/src/Redux/createStore.ts
+++ b/browser/src/Redux/createStore.ts
@@ -28,7 +28,7 @@ export const createStore = <TState>(
     defaultState: TState,
     optionalMiddleware: Middleware[] = [],
 ): Store<TState> => {
-    // tslinst:disable-next-line no-string-literal
+    // tslint:disable-next-line no-string-literal
     const composeFunction: any = window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
 
     const composeEnhancers =

--- a/browser/src/Redux/createStore.ts
+++ b/browser/src/Redux/createStore.ts
@@ -8,18 +8,30 @@
  * - Throttled subscriptions
  */
 
-import { applyMiddleware, compose, createStore as reduxCreateStore, Middleware, Reducer, Store } from "redux"
+import {
+    applyMiddleware,
+    compose,
+    createStore as reduxCreateStore,
+    Middleware,
+    Reducer,
+    Store,
+} from "redux"
 import { batchedSubscribe } from "redux-batched-subscribe"
 
 import { createLoggingMiddleware } from "./LoggingMiddleware"
 
 import { RequestAnimationFrameNotifyBatcher } from "./RequestAnimationFrameNotifyBatcher"
 
-export const createStore = <TState>(name: string, reducer: Reducer<TState>, defaultState: TState, optionalMiddleware: Middleware[] = []): Store<TState> => {
-
-    const composeEnhancers = typeof window === "object" &&
-        window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] ? // tslint:disable-line no-string-literal
-        window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({ name }) : compose // tslint:disable-line no-string-literal
+export const createStore = <TState>(
+    name: string,
+    reducer: Reducer<TState>,
+    defaultState: TState,
+    optionalMiddleware: Middleware[] = [],
+): Store<TState> => {
+    const composeEnhancers =
+        typeof window === "object" && window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] // tslint:disable-line no-string-literal
+            ? window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]({ name })
+            : compose // tslint:disable-line no-string-literal
 
     const loggingMiddleware: Middleware = createLoggingMiddleware(name)
 

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -266,15 +266,7 @@ export class CanvasRenderer implements INeovimRenderer {
             return
         }
 
-        const {
-            backgroundColor,
-            foregroundColor,
-            bold,
-            italic,
-            /* underline ,*/ text,
-            startX,
-            y,
-        } = state
+        const { backgroundColor, foregroundColor, bold, italic, text, startX, y } = state
 
         const { fontWidthInPixels, fontHeightInPixels, linePaddingInPixels } = screenInfo
 

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -26,13 +26,15 @@ const cellsAreSameColor = (cell1: ICell, cell2: ICell): boolean => {
         return false
     }
 
-    return cell1.backgroundColor === cell2.backgroundColor
-        && cell1.foregroundColor === cell2.foregroundColor
-        && cell1.characterWidth === 1 && cell2.characterWidth === 1
+    return (
+        cell1.backgroundColor === cell2.backgroundColor &&
+        cell1.foregroundColor === cell2.foregroundColor &&
+        cell1.characterWidth === 1 &&
+        cell2.characterWidth === 1
+    )
 }
 
 const cellsAreEqual = (cell1: ICell, cell2: ICell): boolean => {
-
     if (cell1 === cell2) {
         return true
     }
@@ -86,7 +88,7 @@ export class CanvasRenderer implements INeovimRenderer {
             for (let y = 0; y < screenInfo.height; y++) {
                 const cell = screenInfo.getCell(x, y)
                 cellsToUpdate.push({ x, y })
-                this._lastRenderGrid.setCell(x, y , cell)
+                this._lastRenderGrid.setCell(x, y, cell)
             }
         }
 
@@ -97,12 +99,11 @@ export class CanvasRenderer implements INeovimRenderer {
         const cellsToUpdate: IPosition[] = []
         for (let x = 0; x < screenInfo.width; x++) {
             for (let y = 0; y < screenInfo.height; y++) {
-
                 const lastCell = this._lastRenderGrid.getCell(x, y)
                 const currentCell = screenInfo.getCell(x, y)
 
                 if (!cellsAreEqual(lastCell, currentCell)) {
-                    cellsToUpdate.push({ x, y})
+                    cellsToUpdate.push({ x, y })
                     this._lastRenderGrid.setCell(x, y, currentCell)
                 }
             }
@@ -207,12 +208,19 @@ export class CanvasRenderer implements INeovimRenderer {
         this._renderText(prevState, screenInfo)
     }
 
-    private _getNextRenderState(cell: ICell, x: number, y: number, currentState: IRenderState): IRenderState {
+    private _getNextRenderState(
+        cell: ICell,
+        x: number,
+        y: number,
+        currentState: IRenderState,
+    ): IRenderState {
         const isCurrentCellWhiteSpace = isWhiteSpace(cell.character)
-        if (cell.foregroundColor !== currentState.foregroundColor
-            || cell.backgroundColor !== currentState.backgroundColor
-            || isCurrentCellWhiteSpace !== currentState.isWhitespace
-            || cell.characterWidth > 1) {
+        if (
+            cell.foregroundColor !== currentState.foregroundColor ||
+            cell.backgroundColor !== currentState.backgroundColor ||
+            isCurrentCellWhiteSpace !== currentState.isWhitespace ||
+            cell.characterWidth > 1
+        ) {
             return {
                 isWhitespace: isCurrentCellWhiteSpace,
                 foregroundColor: cell.foregroundColor,
@@ -226,7 +234,6 @@ export class CanvasRenderer implements INeovimRenderer {
                 y,
             }
         } else {
-
             const adjustedCharacterWidth = isCurrentCellWhiteSpace ? 1 : cell.characterWidth
 
             // Not using spread (...) operator, which would simplify this,
@@ -252,7 +259,6 @@ export class CanvasRenderer implements INeovimRenderer {
     }
 
     private _renderText(state: IRenderState, screenInfo: IScreen): void {
-
         // Spans can have a width of 0 if they are placeholders for cells
         // after a multibyte character. In this case, we don't need to bother
         // rendering or clearing, because that occurs with the multibyte character.
@@ -260,7 +266,15 @@ export class CanvasRenderer implements INeovimRenderer {
             return
         }
 
-        const { backgroundColor, foregroundColor, bold, italic,  /* underline ,*/ text, startX, y } = state
+        const {
+            backgroundColor,
+            foregroundColor,
+            bold,
+            italic,
+            /* underline ,*/ text,
+            startX,
+            y,
+        } = state
 
         const { fontWidthInPixels, fontHeightInPixels, linePaddingInPixels } = screenInfo
 
@@ -286,9 +300,19 @@ export class CanvasRenderer implements INeovimRenderer {
         this._canvasContext.fillStyle = backgroundColor || screenInfo.backgroundColor
 
         if (this._isOpaque || (backgroundColor && backgroundColor !== screenInfo.backgroundColor)) {
-            this._canvasContext.fillRect(normalizedBoundsStartX, normalizedHeight, normalizedBoundsWidth, fontHeightInPixels)
+            this._canvasContext.fillRect(
+                normalizedBoundsStartX,
+                normalizedHeight,
+                normalizedBoundsWidth,
+                fontHeightInPixels,
+            )
         } else {
-            this._canvasContext.clearRect(normalizedBoundsStartX, normalizedHeight, normalizedBoundsWidth, fontHeightInPixels)
+            this._canvasContext.clearRect(
+                normalizedBoundsStartX,
+                normalizedHeight,
+                normalizedBoundsWidth,
+                fontHeightInPixels,
+            )
         }
 
         if (!state.isWhitespace) {
@@ -300,7 +324,11 @@ export class CanvasRenderer implements INeovimRenderer {
             if (italic) {
                 this._canvasContext.font = `italic ${this._canvasContext.font}`
             }
-            this._canvasContext.fillText(text, boundsStartX, y * fontHeightInPixels + linePaddingInPixels / 2)
+            this._canvasContext.fillText(
+                text,
+                boundsStartX,
+                y * fontHeightInPixels + linePaddingInPixels / 2,
+            )
             this._canvasContext.font = lastFontStyle
         }
 
@@ -326,10 +354,15 @@ export class CanvasRenderer implements INeovimRenderer {
 
         this._editorElement.appendChild(this._canvasElement)
 
-        this._width = this._canvasElement.width = this._canvasElement.offsetWidth * this._devicePixelRatio
-        this._height = this._canvasElement.height = this._canvasElement.offsetHeight * this._devicePixelRatio
+        this._width = this._canvasElement.width =
+            this._canvasElement.offsetWidth * this._devicePixelRatio
+        this._height = this._canvasElement.height =
+            this._canvasElement.offsetHeight * this._devicePixelRatio
 
-        if (configuration.getValue("editor.backgroundImageUrl") && configuration.getValue("editor.backgroundOpacity") < 1.0) {
+        if (
+            configuration.getValue("editor.backgroundImageUrl") &&
+            configuration.getValue("editor.backgroundOpacity") < 1.0
+        ) {
             this._canvasContext = this._canvasElement.getContext("2d", { alpha: true })
             this._isOpaque = false
         } else {

--- a/browser/src/Renderer/Span.ts
+++ b/browser/src/Renderer/Span.ts
@@ -6,15 +6,17 @@ export interface ISpan {
 }
 
 export interface IPosition {
-    x: number,
+    x: number
     y: number
 }
 
-export interface RowMap { [key: number]: ISpan[] }
+export interface RowMap {
+    [key: number]: ISpan[]
+}
 
 export function getSpansToEdit(grid: Grid<ISpan>, cells: IPosition[]): RowMap {
     const rowToSpans: RowMap = {}
-    cells.forEach((cell) => {
+    cells.forEach(cell => {
         const { x, y } = cell
 
         const info = grid.getCell(x, y)
@@ -62,10 +64,13 @@ export function flattenSpansToArray(spans: ISpan[]): any[] {
         return []
     }
 
-    const bounds = spans.reduce((prev, cur) => ({
-        startX: Math.min(prev.startX, cur.startX),
-        endX: Math.max(prev.endX, cur.endX),
-    }), { startX: spans[0].startX, endX: spans[0].endX })
+    const bounds = spans.reduce(
+        (prev, cur) => ({
+            startX: Math.min(prev.startX, cur.startX),
+            endX: Math.max(prev.endX, cur.endX),
+        }),
+        { startX: spans[0].startX, endX: spans[0].endX },
+    )
 
     const array: any[] = []
 
@@ -77,7 +82,7 @@ export function flattenSpansToArray(spans: ISpan[]): any[] {
         array.push(false)
     }
 
-    spans.forEach((s) => {
+    spans.forEach(s => {
         for (let i = s.startX; i < s.endX; i++) {
             array[i] = true
         }
@@ -87,7 +92,6 @@ export function flattenSpansToArray(spans: ISpan[]): any[] {
 }
 
 export function expandArrayToSpans(array: any[]): ISpan[] {
-
     if (!array || !array.length) {
         return []
     }
@@ -102,7 +106,6 @@ export function expandArrayToSpans(array: any[]): ISpan[] {
 
     let x = 0
     while (x < array.length) {
-
         if (array[x]) {
             if (currentSpan === null) {
                 currentSpan = {

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -21,8 +21,12 @@ export interface IAutoClosingPair {
     // TODO: Support `notIn` equivalent
 }
 
-export const activate = (configuration: Configuration, editorManager: EditorManager, inputManager: InputManager, languageManager: LanguageManager) => {
-
+export const activate = (
+    configuration: Configuration,
+    editorManager: EditorManager,
+    inputManager: InputManager,
+    languageManager: LanguageManager,
+) => {
     const insertModeFilter = () => editorManager.activeEditor.mode === "insert"
 
     let subscriptions: Oni.DisposeFunction[] = []
@@ -45,15 +49,16 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         const neovim: NeovimInstance = editor.neovim as any
         neovim.blockInput(async (inputFunc: any) => {
             const activeBuffer = editor.activeBuffer
-            const lines = await activeBuffer.getLines(activeBuffer.cursor.line, activeBuffer.cursor.line + 1)
+            const lines = await activeBuffer.getLines(
+                activeBuffer.cursor.line,
+                activeBuffer.cursor.line + 1,
+            )
             const line = lines[0]
 
             const { column } = activeBuffer.cursor
 
-            const matchingPair = pairs.find((p) => {
-                return column >= 1
-                    && line[column] === p.close
-                    && line[column - 1] === p.open
+            const matchingPair = pairs.find(p => {
+                return column >= 1 && line[column] === p.close && line[column - 1] === p.open
             })
 
             if (matchingPair) {
@@ -65,7 +70,11 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
                 const [, oneBasedLine, oneBasedColumn] = pos
                 await editor.activeBuffer.setCursorPosition(oneBasedLine - 1, oneBasedColumn - 2)
 
-                await activeBuffer.setLines(activeBuffer.cursor.line, activeBuffer.cursor.line + 1, [beforePair + afterPair])
+                await activeBuffer.setLines(
+                    activeBuffer.cursor.line,
+                    activeBuffer.cursor.line + 1,
+                    [beforePair + afterPair],
+                )
             } else {
                 await inputFunc("<bs>")
             }
@@ -79,15 +88,17 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         neovim.blockInput(async (inputFunc: any) => {
             const activeBuffer = editor.activeBuffer
 
-            const lines = await (activeBuffer as any).getLines(activeBuffer.cursor.line, activeBuffer.cursor.line + 1, false)
+            const lines = await (activeBuffer as any).getLines(
+                activeBuffer.cursor.line,
+                activeBuffer.cursor.line + 1,
+                false,
+            )
             const line = lines[0]
 
             const { column } = activeBuffer.cursor
 
-            const matchingPair = pairs.find((p) => {
-                return column >= 1
-                    && line[column] === p.close
-                    && line[column - 1] === p.open
+            const matchingPair = pairs.find(p => {
+                return column >= 1 && line[column] === p.close && line[column - 1] === p.open
             })
 
             if (matchingPair) {
@@ -96,11 +107,14 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
                 const afterPair = line.substring(column, line.length)
 
                 const pos = await neovim.callFunction("getpos", ["."])
-                const [, oneBasedLine ] = pos
-                await activeBuffer.setLines(activeBuffer.cursor.line, activeBuffer.cursor.line + 1, [beforePair, whiteSpacePrefix, whiteSpacePrefix + afterPair])
+                const [, oneBasedLine] = pos
+                await activeBuffer.setLines(
+                    activeBuffer.cursor.line,
+                    activeBuffer.cursor.line + 1,
+                    [beforePair, whiteSpacePrefix, whiteSpacePrefix + afterPair],
+                )
                 await activeBuffer.setCursorPosition(oneBasedLine, whiteSpacePrefix.length)
                 await inputFunc("<tab>")
-
             } else {
                 await inputFunc("<enter>")
             }
@@ -113,10 +127,17 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         const neovim: any = editor.neovim
         neovim.blockInput(async (inputFunc: any) => {
             const activeBuffer = editor.activeBuffer
-            const lines = await (activeBuffer as any).getLines(activeBuffer.cursor.line, activeBuffer.cursor.line + 1, false)
+            const lines = await (activeBuffer as any).getLines(
+                activeBuffer.cursor.line,
+                activeBuffer.cursor.line + 1,
+                false,
+            )
             const line = lines[0]
             if (line[activeBuffer.cursor.column] === pair.close) {
-                await activeBuffer.setCursorPosition(activeBuffer.cursor.line, activeBuffer.cursor.column + 1)
+                await activeBuffer.setCursorPosition(
+                    activeBuffer.cursor.line,
+                    activeBuffer.cursor.column + 1,
+                )
             } else {
                 await inputFunc(pair.close)
             }
@@ -126,28 +147,50 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
     }
 
     const onBufferEnter = (newBuffer: Oni.Buffer) => {
-
         if (!configuration.getValue("autoClosingPairs.enabled")) {
             Log.verbose("[Auto Closing Pairs] Not enabled.")
             return
         }
 
         if (subscriptions && subscriptions.length) {
-            subscriptions.forEach((df) => df())
+            subscriptions.forEach(df => df())
         }
 
         subscriptions = []
 
         const autoClosingPairs = getAutoClosingPairs(configuration, newBuffer.language)
 
-        autoClosingPairs.forEach((pair) => {
-            subscriptions.push(inputManager.bind(pair.open, handleOpenCharacter(pair, editorManager.activeEditor), insertModeFilter))
-            subscriptions.push(inputManager.bind(pair.close, handleCloseCharacter(pair, editorManager.activeEditor), insertModeFilter))
+        autoClosingPairs.forEach(pair => {
+            subscriptions.push(
+                inputManager.bind(
+                    pair.open,
+                    handleOpenCharacter(pair, editorManager.activeEditor),
+                    insertModeFilter,
+                ),
+            )
+            subscriptions.push(
+                inputManager.bind(
+                    pair.close,
+                    handleCloseCharacter(pair, editorManager.activeEditor),
+                    insertModeFilter,
+                ),
+            )
         })
 
-        subscriptions.push(inputManager.bind("<bs>", handleBackspaceCharacter(autoClosingPairs, editorManager.activeEditor), insertModeFilter))
-        subscriptions.push(inputManager.bind("<enter>", handleEnterCharacter(autoClosingPairs, editorManager.activeEditor), insertModeFilter))
-
+        subscriptions.push(
+            inputManager.bind(
+                "<bs>",
+                handleBackspaceCharacter(autoClosingPairs, editorManager.activeEditor),
+                insertModeFilter,
+            ),
+        )
+        subscriptions.push(
+            inputManager.bind(
+                "<enter>",
+                handleEnterCharacter(autoClosingPairs, editorManager.activeEditor),
+                insertModeFilter,
+            ),
+        )
     }
 
     editorManager.activeEditor.onBufferEnter.subscribe(onBufferEnter)
@@ -170,7 +213,10 @@ export const getWhiteSpacePrefix = (str: string): string => {
     }
 }
 
-const getAutoClosingPairs = (configuration: Configuration, language: string): IAutoClosingPair[] => {
+const getAutoClosingPairs = (
+    configuration: Configuration,
+    language: string,
+): IAutoClosingPair[] => {
     const languagePairs = configuration.getValue(`language.${language}.autoClosingPairs`)
 
     if (languagePairs) {

--- a/browser/src/Services/AutoUpdate.ts
+++ b/browser/src/Services/AutoUpdate.ts
@@ -22,9 +22,8 @@ export interface IAutoUpdater {
 }
 
 export const constructFeedUrl = async (baseUrl: string) => {
-
     const plat = os.platform()
-    const { version }  = await getMetadata()
+    const { version } = await getMetadata()
 
     const isDevelopment = process.env["NODE_ENV"] === "development" // tslint:disable-line no-string-literal
     const channel = isDevelopment ? "development" : "release"
@@ -48,15 +47,13 @@ export class AutoUpdater implements IAutoUpdater {
             return
         }
 
-        fetch(url)
-            .then((response) => {
-
-                if (response.status === 204) {
-                    this._onUpdateNotAvailable.next()
-                } else {
-                    this._onUpdateAvailable.next()
-                }
-            })
+        fetch(url).then(response => {
+            if (response.status === 204) {
+                this._onUpdateNotAvailable.next()
+            } else {
+                this._onUpdateAvailable.next()
+            }
+        })
     }
 }
 

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -26,7 +26,6 @@ export interface ITestResult {
 import { Oni } from "./../Plugins/Api/Oni"
 
 export class Automation implements OniApi.Automation.Api {
-
     public sendKeys(keys: string): void {
         Log.info("[AUTOMATION] Sending keys: " + keys)
 
@@ -39,11 +38,16 @@ export class Automation implements OniApi.Automation.Api {
 
     public async sleep(time: number = 1000): Promise<void> {
         Log.info("[AUTOMATION] Sleeping for " + time + "ms")
-        return new Promise<void>((r) => window.setTimeout(() => r(), time))
+        return new Promise<void>(r => window.setTimeout(() => r(), time))
     }
 
     public async waitFor(condition: () => boolean, timeout: number = 10000): Promise<void> {
-        Log.info("[AUTOMATION] Starting wait - limit: " + timeout + " condition: " + condition.toString())
+        Log.info(
+            "[AUTOMATION] Starting wait - limit: " +
+                timeout +
+                " condition: " +
+                condition.toString(),
+        )
         let time = 0
         const interval = 1000
 
@@ -77,11 +81,19 @@ export class Automation implements OniApi.Automation.Api {
         Log.info("[AUTOMATION] Startup complete!")
 
         Log.info("[AUTOMATION] Waiting for neovim to attach to editor...")
-        await this.waitFor(() => editorManager.activeEditor.neovim && (editorManager.activeEditor as any).neovim.isInitialized, 30000)
+        await this.waitFor(
+            () =>
+                editorManager.activeEditor.neovim &&
+                (editorManager.activeEditor as any).neovim.isInitialized,
+            30000,
+        )
         Log.info("[AUTOMATION] Neovim initialized!")
 
         Log.info("[AUTOMATION] Waiting for shared neovim instance...")
-        await this.waitFor(() => getSharedNeovimInstance() && getSharedNeovimInstance().isInitialized, 30000)
+        await this.waitFor(
+            () => getSharedNeovimInstance() && getSharedNeovimInstance().isInitialized,
+            30000,
+        )
         Log.info("[AUTOMATION] Shared neovim instance initialized!")
     }
 
@@ -138,7 +150,10 @@ export class Automation implements OniApi.Automation.Api {
     }
 
     private _reportResult(passed: boolean, exception?: any): void {
-        const resultElement = this._createElement("automated-test-result", this._getOrCreateTestContainer("automated-test-container"))
+        const resultElement = this._createElement(
+            "automated-test-result",
+            this._getOrCreateTestContainer("automated-test-container"),
+        )
 
         resultElement.textContent = JSON.stringify({
             passed,

--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -22,18 +22,22 @@ export const activate = (configuration: Configuration, colors: Colors) => {
         // TODO: Read from 'persisted setting' instead
         const backgroundColor = colors.getColor("background")
         if (backgroundColor) {
-            const background: string = Color(backgroundColor).lighten(0.1).hex().toString();
-            (browserWindow as any).setBackgroundColor(background)
+            const background: string = Color(backgroundColor)
+                .lighten(0.1)
+                .hex()
+                .toString()
+            ;(browserWindow as any).setBackgroundColor(background)
         }
     }
 
     colors.onColorsChanged.subscribe(() => onColorsChanged())
 
     const onConfigChanged = (newConfigValues: Partial<IConfigurationValues>) => {
-
         document.body.style.fontFamily = configuration.getValue("ui.fontFamily")
         document.body.style.fontSize = addDefaultUnitIfNeeded(configuration.getValue("ui.fontSize"))
-        document.body.style.fontVariant = configuration.getValue("editor.fontLigatures") ? "normal" : "none"
+        document.body.style.fontVariant = configuration.getValue("editor.fontLigatures")
+            ? "normal"
+            : "none"
 
         const fontSmoothing = configuration.getValue("ui.fontSmoothing")
 

--- a/browser/src/Services/Colors.ts
+++ b/browser/src/Services/Colors.ts
@@ -14,7 +14,9 @@ import * as PersistentSettings from "./Configuration/PersistentSettings"
 
 import { ThemeManager } from "./Themes"
 
-export interface ColorsDictionary { [colorName: string]: string}
+export interface ColorsDictionary {
+    [colorName: string]: string
+}
 
 let _colors: Colors = null
 
@@ -32,7 +34,6 @@ export interface IColors extends OniApi.IColors {
 }
 
 export class Colors implements OniApi.IColors, IDisposable {
-
     private _subscriptions: IDisposable[] = []
     private _colors: ColorsDictionary = {}
     private _onColorsChangedEvent: Event<void> = new Event<void>()
@@ -41,23 +42,22 @@ export class Colors implements OniApi.IColors, IDisposable {
         return this._onColorsChangedEvent
     }
 
-    constructor(
-        private _configuration: Configuration,
-        private _themeManager: ThemeManager,
-    ) {
-
+    constructor(private _configuration: Configuration, private _themeManager: ThemeManager) {
         const sub1 = this._themeManager.onThemeChanged.subscribe(() => {
             this._updateColorsFromConfig()
         })
 
-        const sub2 = this._configuration.onConfigurationChanged.subscribe((newValues: Partial<IConfigurationValues>) => {
+        const sub2 = this._configuration.onConfigurationChanged.subscribe(
+            (newValues: Partial<IConfigurationValues>) => {
+                const anyColorsChanged = Object.keys(newValues).filter(
+                    color => color.indexOf("colors.") >= 0,
+                )
 
-            const anyColorsChanged = Object.keys(newValues).filter((color) => color.indexOf("colors.") >= 0)
-
-            if (anyColorsChanged.length > 0) {
-                this._updateColorsFromConfig()
-            }
-        })
+                if (anyColorsChanged.length > 0) {
+                    this._updateColorsFromConfig()
+                }
+            },
+        )
 
         this._subscriptions = [sub1, sub2]
         this._updateColorsFromConfig()
@@ -73,13 +73,12 @@ export class Colors implements OniApi.IColors, IDisposable {
 
     public dispose(): void {
         if (this._subscriptions && this._subscriptions.length) {
-            this._subscriptions.forEach((disposable) => disposable.dispose())
+            this._subscriptions.forEach(disposable => disposable.dispose())
             this._subscriptions = null
         }
     }
 
     private _updateColorsFromConfig(): void {
-
         if (!this._themeManager.activeTheme) {
             return
         }
@@ -87,16 +86,18 @@ export class Colors implements OniApi.IColors, IDisposable {
         const currentThemeColors = this._themeManager.getColors()
         this._colors = {}
 
-        Object.keys(currentThemeColors).forEach((themeColor) => {
-
+        Object.keys(currentThemeColors).forEach(themeColor => {
             const configurationName = this._getConfigurationNameForColor(themeColor)
 
             const colorFromConfiguration = this._configuration.getValue(configurationName)
 
-            this._colors[themeColor] = colorFromConfiguration ? colorFromConfiguration : currentThemeColors[themeColor]
+            this._colors[themeColor] = colorFromConfiguration
+                ? colorFromConfiguration
+                : currentThemeColors[themeColor]
         })
 
-        const lastBackgroundColor = this._colors.background || this._colors["editor.background"] || "#1E2127"
+        const lastBackgroundColor =
+            this._colors.background || this._colors["editor.background"] || "#1E2127"
         PersistentSettings.set("_internal.lastBackgroundColor", lastBackgroundColor)
 
         this._onColorsChangedEvent.dispatch()

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -21,18 +21,18 @@ export class CallbackCommand implements Oni.Commands.ICommand {
         public name: string,
         public detail: string,
         public execute: Oni.Commands.CommandCallback,
-        public enabled?: Oni.Commands.CommandEnabledCallback) {
-    }
+        public enabled?: Oni.Commands.CommandEnabledCallback,
+    ) {}
 }
 
 export class VimCommand implements Oni.Commands.ICommand {
     constructor(
         public command: string,
-        public name: string, public detail: string,
+        public name: string,
+        public detail: string,
         private _vimCommand: string,
-        private _neovimInstance: INeovimInstance) {
-
-    }
+        private _neovimInstance: INeovimInstance,
+    ) {}
 
     public execute(): void {
         this._neovimInstance.command(this._vimCommand)
@@ -40,7 +40,6 @@ export class VimCommand implements Oni.Commands.ICommand {
 }
 
 export class CommandManager implements ITaskProvider {
-
     private _commandDictionary: { [key: string]: Oni.Commands.ICommand } = {}
 
     public clearCommands(): void {
@@ -61,7 +60,6 @@ export class CommandManager implements ITaskProvider {
     }
 
     public executeCommand(name: string, args?: any): boolean | void {
-
         const command = this._commandDictionary[name]
 
         if (!command) {
@@ -86,11 +84,11 @@ export class CommandManager implements ITaskProvider {
     }
 
     public getTasks(): Promise<ITask[]> {
-        const commands =
-            values(this._commandDictionary)
-                .filter((c: Oni.Commands.ICommand) => !c.enabled || (c.enabled()))
+        const commands = values(this._commandDictionary).filter(
+            (c: Oni.Commands.ICommand) => !c.enabled || c.enabled(),
+        )
 
-        const tasks = commands.map((c) => ({
+        const tasks = commands.map(c => ({
             name: c.name,
             detail: c.detail,
             command: c.command,

--- a/browser/src/Services/Commands/GlobalCommands.ts
+++ b/browser/src/Services/Commands/GlobalCommands.ts
@@ -21,8 +21,11 @@ import { CallbackCommand, CommandManager } from "./../CommandManager"
 
 import * as Platform from "./../../Platform"
 
-export const activate = (commandManager: CommandManager, menuManager: MenuManager, tasks: Tasks) => {
-
+export const activate = (
+    commandManager: CommandManager,
+    menuManager: MenuManager,
+    tasks: Tasks,
+) => {
     const popupMenuCommand = (innerCommand: Oni.Commands.CommandCallback) => {
         return () => {
             if (menuManager.isMenuOpen()) {
@@ -39,23 +42,54 @@ export const activate = (commandManager: CommandManager, menuManager: MenuManage
     const popupMenuSelect = popupMenuCommand(() => menuManager.selectMenuItem())
 
     const commands = [
-
         new CallbackCommand("oni.about", null, null, () => showAboutMessage()),
 
         new CallbackCommand("oni.quit", null, null, () => remote.app.quit()),
 
         // Debug
-        new CallbackCommand("oni.debug.openDevTools", "Open DevTools", "Debug Oni and any running plugins using the Chrome developer tools", () => remote.getCurrentWindow().webContents.openDevTools()),
-        new CallbackCommand("oni.debug.reload", "Reload Oni", "Reloads the Oni instance. You will lose all unsaved changes", () => remote.getCurrentWindow().reload()),
+        new CallbackCommand(
+            "oni.debug.openDevTools",
+            "Open DevTools",
+            "Debug Oni and any running plugins using the Chrome developer tools",
+            () => remote.getCurrentWindow().webContents.openDevTools(),
+        ),
+        new CallbackCommand(
+            "oni.debug.reload",
+            "Reload Oni",
+            "Reloads the Oni instance. You will lose all unsaved changes",
+            () => remote.getCurrentWindow().reload(),
+        ),
 
-        new CallbackCommand("oni.editor.maximize", "Maximize Window", "Maximize the current window", () => remote.getCurrentWindow().maximize()),
+        new CallbackCommand(
+            "oni.editor.maximize",
+            "Maximize Window",
+            "Maximize the current window",
+            () => remote.getCurrentWindow().maximize(),
+        ),
 
-        new CallbackCommand("oni.editor.minimize", "Minimize Window", "Minimize the current window", () => remote.getCurrentWindow().minimize()),
+        new CallbackCommand(
+            "oni.editor.minimize",
+            "Minimize Window",
+            "Minimize the current window",
+            () => remote.getCurrentWindow().minimize(),
+        ),
 
-        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () => remote.app.hide()),
+        new CallbackCommand("oni.editor.hide", "Hide Window", "Hide the current window", () =>
+            remote.app.hide(),
+        ),
 
-        new CallbackCommand("oni.process.cycleNext", "Focus Next Oni", "Switch to the next running instance of Oni", () => multiProcess.focusNextInstance()),
-        new CallbackCommand("oni.process.cyclePrevious", "Focus Previous Oni", "Switch to the previous running instance of Oni", () => multiProcess.focusPreviousInstance()),
+        new CallbackCommand(
+            "oni.process.cycleNext",
+            "Focus Next Oni",
+            "Switch to the next running instance of Oni",
+            () => multiProcess.focusNextInstance(),
+        ),
+        new CallbackCommand(
+            "oni.process.cyclePrevious",
+            "Focus Previous Oni",
+            "Switch to the previous running instance of Oni",
+            () => multiProcess.focusPreviousInstance(),
+        ),
 
         new CallbackCommand("commands.show", null, null, () => tasks.show()),
 
@@ -78,15 +112,27 @@ export const activate = (commandManager: CommandManager, menuManager: MenuManage
 
     // TODO: once implementations of this command work on all platforms, remove the exclusive check for OSX
     if (Platform.isMac()) {
-        const addToPathCommand = new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath, () => Platform.isAddedToPath())
+        const addToPathCommand = new CallbackCommand(
+            "oni.editor.removeFromPath",
+            "Remove from PATH",
+            "Disable executing 'oni' from terminal",
+            Platform.removeFromPath,
+            () => Platform.isAddedToPath(),
+        )
         addToPathCommand.messageSuccess = "Oni has been removed from the $PATH"
 
-        const removeFromPathCommand = new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath, () => !Platform.isAddedToPath())
+        const removeFromPathCommand = new CallbackCommand(
+            "oni.editor.addToPath",
+            "Add to PATH",
+            "Enable executing 'oni' from terminal",
+            Platform.addToPath,
+            () => !Platform.isAddedToPath(),
+        )
         removeFromPathCommand.messageSuccess = "Oni has been added to the $PATH"
 
         commands.push(addToPathCommand)
         commands.push(removeFromPathCommand)
     }
 
-    commands.forEach((c) => commandManager.registerCommand(c))
+    commands.forEach(c => commandManager.registerCommand(c))
 }

--- a/browser/src/Services/Completion/Completion.ts
+++ b/browser/src/Services/Completion/Completion.ts
@@ -25,26 +25,33 @@ export interface ICompletionShowEventArgs {
 }
 
 export class TestRequestor implements ICompletionsRequestor {
-    public async getCompletions(language: string, filePath: string, line: number, column: number): Promise<types.CompletionItem[]> {
-        return [
-            types.CompletionItem.create("test1"),
-            types.CompletionItem.create("test2"),
-        ]
+    public async getCompletions(
+        language: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<types.CompletionItem[]> {
+        return [types.CompletionItem.create("test1"), types.CompletionItem.create("test2")]
     }
 
-    public async getCompletionDetails(language: string, filePath: string, completionItem: types.CompletionItem): Promise<types.CompletionItem> {
+    public async getCompletionDetails(
+        language: string,
+        filePath: string,
+        completionItem: types.CompletionItem,
+    ): Promise<types.CompletionItem> {
         return completionItem
     }
 }
 
 export class Completion implements IDisposable {
-
     private _lastCursorPosition: Oni.Cursor
     private _store: Store<ICompletionState>
     private _storeUnsubscribe: Unsubscribe = null
     private _subscriptions: IDisposable[]
 
-    private _onShowCompletionItemsEvent: Event<ICompletionShowEventArgs> = new Event<ICompletionShowEventArgs>()
+    private _onShowCompletionItemsEvent: Event<ICompletionShowEventArgs> = new Event<
+        ICompletionShowEventArgs
+    >()
     private _onHideCompletionItemsEvent: Event<void> = new Event<void>()
 
     public get onShowCompletionItems(): IEvent<ICompletionShowEventArgs> {
@@ -62,15 +69,22 @@ export class Completion implements IDisposable {
         private _languageManager: LanguageManager,
     ) {
         this._completionsRequestor = this._completionsRequestor
-        this._store = createStore(this._editor, this._languageManager, this._configuration, this._completionsRequestor)
+        this._store = createStore(
+            this._editor,
+            this._languageManager,
+            this._configuration,
+            this._completionsRequestor,
+        )
 
         const sub1 = this._editor.onBufferEnter.subscribe((buf: Oni.Buffer) => {
             this._onBufferEnter(buf)
         })
 
-        const sub2 = this._editor.onBufferChanged.subscribe((buf: Oni.EditorBufferChangedEventArgs) => {
-            this._onBufferUpdate(buf)
-        })
+        const sub2 = this._editor.onBufferChanged.subscribe(
+            (buf: Oni.EditorBufferChangedEventArgs) => {
+                this._onBufferUpdate(buf)
+            },
+        )
 
         const sub3 = this._editor.onModeChanged.subscribe((newMode: string) => {
             this._onModeChanged(newMode)
@@ -81,7 +95,9 @@ export class Completion implements IDisposable {
         })
 
         this._subscriptions = [sub1, sub2, sub3, sub4]
-        this._storeUnsubscribe = this._store.subscribe(() => this._onStateChanged(this._store.getState()))
+        this._storeUnsubscribe = this._store.subscribe(() =>
+            this._onStateChanged(this._store.getState()),
+        )
     }
 
     public resolveItem(completionItem: types.CompletionItem): void {
@@ -103,7 +119,7 @@ export class Completion implements IDisposable {
 
     public dispose(): void {
         if (this._subscriptions) {
-            this._subscriptions.forEach((disposable) => disposable.dispose())
+            this._subscriptions.forEach(disposable => disposable.dispose())
             this._subscriptions = null
         }
 
@@ -114,7 +130,6 @@ export class Completion implements IDisposable {
     }
 
     private _onStateChanged(newState: ICompletionState): void {
-
         const filteredCompletions = getFilteredCompletions(newState)
 
         if (filteredCompletions && filteredCompletions.length) {
@@ -140,7 +155,6 @@ export class Completion implements IDisposable {
     }
 
     private _onBufferUpdate(bufferUpdate: Oni.EditorBufferChangedEventArgs): void {
-
         // Ignore if this is a full update
         const firstChange = bufferUpdate.contentChanges[0]
 
@@ -171,9 +185,11 @@ export class Completion implements IDisposable {
     }
 
     private async _onModeChanged(newMode: string): Promise<void> {
-       if (newMode === "insert" && this._lastCursorPosition) {
-
-            const [latestLine] = await this._editor.activeBuffer.getLines(this._lastCursorPosition.line, this._lastCursorPosition.line + 1)
+        if (newMode === "insert" && this._lastCursorPosition) {
+            const [latestLine] = await this._editor.activeBuffer.getLines(
+                this._lastCursorPosition.line,
+                this._lastCursorPosition.line + 1,
+            )
 
             this._store.dispatch({
                 type: "CURSOR_MOVED",
@@ -183,7 +199,7 @@ export class Completion implements IDisposable {
             })
         }
 
-       this._store.dispatch({
+        this._store.dispatch({
             type: "MODE_CHANGED",
             mode: newMode,
         })

--- a/browser/src/Services/Completion/CompletionProviders.ts
+++ b/browser/src/Services/Completion/CompletionProviders.ts
@@ -27,12 +27,17 @@ export class CompletionProviders implements ICompletionsRequestor {
         })
     }
 
-    public async getCompletions(language: string, filePath: string, line: number, column: number): Promise<types.CompletionItem[]> {
-        const completionItemsPromise = this._completionProviders.map(async (prov) => {
+    public async getCompletions(
+        language: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<types.CompletionItem[]> {
+        const completionItemsPromise = this._completionProviders.map(async prov => {
             const items = await prov.provider.getCompletions(language, filePath, line, column)
 
             // Tag the items with the provider id, so we know who to ask for details
-            const augmentedItems = items.map((item) => {
+            const augmentedItems = items.map(item => {
                 return {
                     ...item,
                     __provider: prov.id,
@@ -44,14 +49,21 @@ export class CompletionProviders implements ICompletionsRequestor {
 
         const allItems = await Promise.all(completionItemsPromise)
 
-        const flattenedItems = allItems.reduce((prev: ICompletionInfoWithProvider[], current: ICompletionInfoWithProvider[]) => {
+        const flattenedItems = allItems.reduce(
+            (prev: ICompletionInfoWithProvider[], current: ICompletionInfoWithProvider[]) => {
                 return [...prev, ...current]
-        }, [] as ICompletionInfoWithProvider[])
+            },
+            [] as ICompletionInfoWithProvider[],
+        )
 
         return flattenedItems
     }
 
-    public async getCompletionDetails(language: string, filePath: string, completionItem: ICompletionInfoWithProvider): Promise<types.CompletionItem> {
+    public async getCompletionDetails(
+        language: string,
+        filePath: string,
+        completionItem: ICompletionInfoWithProvider,
+    ): Promise<types.CompletionItem> {
         if (completionItem.__provider) {
             const prov = this._getProviderById(completionItem.__provider)
 
@@ -64,7 +76,7 @@ export class CompletionProviders implements ICompletionsRequestor {
     }
 
     private _getProviderById(id: string): ICompletionsRequestor {
-        const providersMatchingId = this._completionProviders.filter((prov) => prov.id === id)
+        const providersMatchingId = this._completionProviders.filter(prov => prov.id === id)
 
         return providersMatchingId.length > 0 ? providersMatchingId[0].provider : null
     }
@@ -77,7 +89,10 @@ export const activate = (languageManager: LanguageManager) => {
 
     const languageServiceCompletion = new LanguageServiceCompletionsRequestor(languageManager)
 
-    _completionProviders.registerCompletionProvider("oni.completions.language-server", languageServiceCompletion)
+    _completionProviders.registerCompletionProvider(
+        "oni.completions.language-server",
+        languageServiceCompletion,
+    )
 }
 
 export const getInstance = (): CompletionProviders => {

--- a/browser/src/Services/Completion/CompletionSelectors.ts
+++ b/browser/src/Services/Completion/CompletionSelectors.ts
@@ -13,7 +13,6 @@ const EmptyCompletions: types.CompletionItem[] = []
 import * as CompletionUtility from "./CompletionUtility"
 
 export const getFilteredCompletions = (state: ICompletionState): types.CompletionItem[] => {
-
     if (!state.completionResults.completions || !state.completionResults.completions.length) {
         return EmptyCompletions
     }
@@ -24,17 +23,21 @@ export const getFilteredCompletions = (state: ICompletionState): types.Completio
 
     // If the completions were for a different meet line/position, we probably
     // shouldn't show them...
-    if (state.meetInfo.meetLine !== state.completionResults.meetLine
-        || state.meetInfo.meetPosition !== state.completionResults.meetPosition) {
-            return EmptyCompletions
-        }
+    if (
+        state.meetInfo.meetLine !== state.completionResults.meetLine ||
+        state.meetInfo.meetPosition !== state.completionResults.meetPosition
+    ) {
+        return EmptyCompletions
+    }
 
     // If we had previously accepted this completion, don't show it either
-    if (state.meetInfo.meetLine === state.lastCompletionInfo.meetLine
-        && state.meetInfo.meetPosition === state.lastCompletionInfo.meetPosition
-        && state.meetInfo.meetBase === state.lastCompletionInfo.completedText) {
-            return EmptyCompletions
-        }
+    if (
+        state.meetInfo.meetLine === state.lastCompletionInfo.meetLine &&
+        state.meetInfo.meetPosition === state.lastCompletionInfo.meetPosition &&
+        state.meetInfo.meetBase === state.lastCompletionInfo.completedText
+    ) {
+        return EmptyCompletions
+    }
 
     const completions = state.completionResults.completions
 
@@ -46,15 +49,20 @@ export const getFilteredCompletions = (state: ICompletionState): types.Completio
 
     // If there is only one element, and it matches our base,
     // don't bother showing it..
-    if (CompletionUtility.getInsertText(filteredCompletions[0]) === state.meetInfo.meetBase
-        && filteredCompletions.length === 1) {
+    if (
+        CompletionUtility.getInsertText(filteredCompletions[0]) === state.meetInfo.meetBase &&
+        filteredCompletions.length === 1
+    ) {
         return EmptyCompletions
     }
 
     return filteredCompletions
 }
 
-export const filterCompletionOptions = (items: types.CompletionItem[], searchText: string): types.CompletionItem[] => {
+export const filterCompletionOptions = (
+    items: types.CompletionItem[],
+    searchText: string,
+): types.CompletionItem[] => {
     if (!searchText) {
         return items
     }
@@ -65,18 +73,17 @@ export const filterCompletionOptions = (items: types.CompletionItem[], searchTex
 
     const filterRegEx = new RegExp("^" + searchText.split("").join(".*") + ".*")
 
-    const filteredOptions = items.filter((f) => {
+    const filteredOptions = items.filter(f => {
         const textToFilterOn = f.filterText || f.label
         return textToFilterOn.match(filterRegEx)
     })
 
     return filteredOptions.sort((itemA, itemB) => {
-
         const itemAFilterText = itemA.filterText || itemA.label
         const itemBFilterText = itemB.filterText || itemB.label
 
-        const indexOfA = itemAFilterText.indexOf((searchText))
-        const indexOfB = itemBFilterText.indexOf((searchText))
+        const indexOfA = itemAFilterText.indexOf(searchText)
+        const indexOfB = itemBFilterText.indexOf(searchText)
 
         return indexOfB - indexOfA
     })

--- a/browser/src/Services/Completion/CompletionUtility.ts
+++ b/browser/src/Services/Completion/CompletionUtility.ts
@@ -7,7 +7,12 @@
 import * as Oni from "oni-api"
 import * as types from "vscode-languageserver-types"
 
-export const commitCompletion = async (buffer: Oni.Buffer, line: number, base: number, completion: string) => {
+export const commitCompletion = async (
+    buffer: Oni.Buffer,
+    line: number,
+    base: number,
+    completion: string,
+) => {
     const currentLines = await buffer.getLines(line, line + 1)
 
     const column = buffer.cursor.column
@@ -24,13 +29,15 @@ export const commitCompletion = async (buffer: Oni.Buffer, line: number, base: n
     await buffer.setCursorPosition(line, column + cursorOffset)
 }
 
-export function getCompletionStart(bufferLine: string, cursorColumn: number, completion: string): number {
-
+export function getCompletionStart(
+    bufferLine: string,
+    cursorColumn: number,
+    completion: string,
+): number {
     cursorColumn = Math.min(cursorColumn, bufferLine.length)
 
     let x = cursorColumn
     while (x >= 0) {
-
         const subWord = bufferLine.substring(x, cursorColumn + 1)
 
         if (completion.indexOf(subWord) === -1) {
@@ -47,7 +54,12 @@ export const getInsertText = (completionItem: types.CompletionItem): string => {
     return completionItem.insertText || completionItem.label
 }
 
-export function replacePrefixWithCompletion(bufferLine: string, basePosition: number, cursorColumn: number, completion: string): string {
+export function replacePrefixWithCompletion(
+    bufferLine: string,
+    basePosition: number,
+    cursorColumn: number,
+    completion: string,
+): string {
     const startPosition = basePosition
 
     const before = bufferLine.substring(0, startPosition)
@@ -70,15 +82,22 @@ export interface CompletionMeetResult {
     shouldExpandCompletions: boolean
 }
 
-export const doesCharacterMatchTriggerCharacters = (character: string, triggerCharacters: string[]): boolean => {
+export const doesCharacterMatchTriggerCharacters = (
+    character: string,
+    triggerCharacters: string[],
+): boolean => {
     return triggerCharacters.indexOf(character) >= 0
 }
 
 /**
  * Returns the start of the 'completion meet' along with the current base for completion
  */
-export function getCompletionMeet(line: string, cursorColumn: number, characterMatchRegex: RegExp, completionTriggerCharacters: string[]): CompletionMeetResult {
-
+export function getCompletionMeet(
+    line: string,
+    cursorColumn: number,
+    characterMatchRegex: RegExp,
+    completionTriggerCharacters: string[],
+): CompletionMeetResult {
     // Clamp column to within string bounds
     let col = Math.max(cursorColumn - 1, 0)
     col = Math.min(col, line.length - 1)
@@ -88,7 +107,10 @@ export function getCompletionMeet(line: string, cursorColumn: number, characterM
     while (col >= 0 && col < line.length) {
         const currentCharacter = line[col]
 
-        if (!currentCharacter.match(characterMatchRegex) || doesCharacterMatchTriggerCharacters(currentCharacter, completionTriggerCharacters)) {
+        if (
+            !currentCharacter.match(characterMatchRegex) ||
+            doesCharacterMatchTriggerCharacters(currentCharacter, completionTriggerCharacters)
+        ) {
             break
         }
 
@@ -98,11 +120,16 @@ export function getCompletionMeet(line: string, cursorColumn: number, characterM
 
     const basePos = col + 1
 
-    const isFromTriggerCharacter = doesCharacterMatchTriggerCharacters(line[basePos - 1], completionTriggerCharacters)
+    const isFromTriggerCharacter = doesCharacterMatchTriggerCharacters(
+        line[basePos - 1],
+        completionTriggerCharacters,
+    )
 
-    const isCharacterAfterCursor = (cursorColumn < line.length) && line[cursorColumn].match(characterMatchRegex)
+    const isCharacterAfterCursor =
+        cursorColumn < line.length && line[cursorColumn].match(characterMatchRegex)
 
-    const shouldExpandCompletions = (currentPrefix.length > 0 || isFromTriggerCharacter) && !isCharacterAfterCursor
+    const shouldExpandCompletions =
+        (currentPrefix.length > 0 || isFromTriggerCharacter) && !isCharacterAfterCursor
 
     const positionToQuery = isFromTriggerCharacter ? basePos : basePos + 1
 
@@ -115,7 +142,6 @@ export function getCompletionMeet(line: string, cursorColumn: number, characterM
 }
 
 export const convertKindToIconName = (completionKind: types.CompletionItemKind) => {
-
     switch (completionKind) {
         case types.CompletionItemKind.Class:
             return "cube"

--- a/browser/src/Services/Completion/CompletionsRequestor.ts
+++ b/browser/src/Services/Completion/CompletionsRequestor.ts
@@ -14,17 +14,28 @@ import { LanguageManager } from "./../Language"
 import * as CompletionUtility from "./CompletionUtility"
 
 export interface ICompletionsRequestor {
-    getCompletions(fileLanguage: string, filePath: string, line: number, column: number): Promise<types.CompletionItem[]>
-    getCompletionDetails(fileLanguage: string, filePath: string, completionItem: types.CompletionItem): Promise<types.CompletionItem>
+    getCompletions(
+        fileLanguage: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<types.CompletionItem[]>
+    getCompletionDetails(
+        fileLanguage: string,
+        filePath: string,
+        completionItem: types.CompletionItem,
+    ): Promise<types.CompletionItem>
 }
 
 export class LanguageServiceCompletionsRequestor implements ICompletionsRequestor {
+    constructor(private _languageManager: LanguageManager) {}
 
-    constructor(
-        private _languageManager: LanguageManager,
-    ) { }
-
-    public async getCompletions(language: string, filePath: string, line: number, column: number): Promise<types.CompletionItem[]> {
+    public async getCompletions(
+        language: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<types.CompletionItem[]> {
         if (Log.isDebugLoggingEnabled()) {
             Log.debug(`[COMPLETION] Requesting completions at line ${line} and character ${column}`)
         }
@@ -40,7 +51,12 @@ export class LanguageServiceCompletionsRequestor implements ICompletionsRequesto
         }
         let result = null
         try {
-            result = await this._languageManager.sendLanguageServerRequest(language, filePath, "textDocument/completion", args)
+            result = await this._languageManager.sendLanguageServerRequest(
+                language,
+                filePath,
+                "textDocument/completion",
+                args,
+            )
         } catch (ex) {
             Log.verbose(ex)
         }
@@ -59,15 +75,24 @@ export class LanguageServiceCompletionsRequestor implements ICompletionsRequesto
             Log.debug(`[COMPLETION] Got completions: ${items.length}`)
         }
 
-        const completions = items.map((i) => _convertCompletionForContextMenu(i))
+        const completions = items.map(i => _convertCompletionForContextMenu(i))
 
         return completions
     }
 
-    public async getCompletionDetails(language: string, filePath: string, completionItem: types.CompletionItem): Promise<types.CompletionItem> {
+    public async getCompletionDetails(
+        language: string,
+        filePath: string,
+        completionItem: types.CompletionItem,
+    ): Promise<types.CompletionItem> {
         let result
         try {
-            result = await this._languageManager.sendLanguageServerRequest(language, filePath, "completionItem/resolve", completionItem)
+            result = await this._languageManager.sendLanguageServerRequest(
+                language,
+                filePath,
+                "completionItem/resolve",
+                completionItem,
+            )
         } catch (ex) {
             Log.verbose(ex)
         }
@@ -102,7 +127,9 @@ const getCompletionDocumentation = (item: types.CompletionItem): string | null =
     }
 }
 
-const getCompletionItems = (items: types.CompletionItem[] | types.CompletionList): types.CompletionItem[] => {
+const getCompletionItems = (
+    items: types.CompletionItem[] | types.CompletionList,
+): types.CompletionItem[] => {
     if (!items) {
         return []
     }

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -13,10 +13,20 @@ import * as Platform from "./../../Platform"
 import { IConfigurationValues } from "./IConfigurationValues"
 import { ocamlAndReasonConfiguration, ocamlLanguageServerPath } from "./ReasonConfiguration"
 
-const noop = () => { } // tslint:disable-line no-empty
+const noop = () => {} // tslint:disable-line no-empty
 
-const cssLanguageServerPath = path.join(__dirname, "node_modules", "vscode-css-languageserver-bin", "cssServerMain.js")
-const htmlLanguageServerPath = path.join(__dirname, "node_modules", "vscode-html-languageserver-bin", "htmlServerMain.js")
+const cssLanguageServerPath = path.join(
+    __dirname,
+    "node_modules",
+    "vscode-css-languageserver-bin",
+    "cssServerMain.js",
+)
+const htmlLanguageServerPath = path.join(
+    __dirname,
+    "node_modules",
+    "vscode-html-languageserver-bin",
+    "htmlServerMain.js",
+)
 
 const BaseConfiguration: IConfigurationValues = {
     activate: noop,
@@ -49,9 +59,9 @@ const BaseConfiguration: IConfigurationValues = {
 
     "autoClosingPairs.enabled": true,
     "autoClosingPairs.default": [
-        { "open": "{", "close": "}" },
-        { "open": "[", "close": "]" },
-        { "open": "(", "close": ")" },
+        { open: "{", close: "}" },
+        { open: "[", close: "]" },
+        { open: "(", close: ")" },
     ],
 
     "oni.audio.bellUrl": null,
@@ -107,31 +117,40 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.cursorColumn": false,
     "editor.cursorColumnOpacity": 0.1,
 
-    "editor.tokenColors": [{
-        scope: "variable.object",
-        settings: "Identifier",
-    }, {
-        scope: "variable.other.constant",
-        settings: "Constant",
-    }, {
-        scope: "variable.language",
-        settings: "Identifier",
-    }, {
-        scope: "variable.parameter",
-        settings: "Identifier",
-    }, {
-        scope: "variable.other",
-        settings: "Identifier",
-    }, {
-        scope: "support.function",
-        settings: "Function",
-    }, {
-        scope: "entity.name",
-        settings: "Function",
-    }, {
-        scope: "entity.other",
-        settings: "Constant",
-    }],
+    "editor.tokenColors": [
+        {
+            scope: "variable.object",
+            settings: "Identifier",
+        },
+        {
+            scope: "variable.other.constant",
+            settings: "Constant",
+        },
+        {
+            scope: "variable.language",
+            settings: "Identifier",
+        },
+        {
+            scope: "variable.parameter",
+            settings: "Identifier",
+        },
+        {
+            scope: "variable.other",
+            settings: "Identifier",
+        },
+        {
+            scope: "support.function",
+            settings: "Function",
+        },
+        {
+            scope: "entity.name",
+            settings: "Function",
+        },
+        {
+            scope: "entity.other",
+            settings: "Constant",
+        },
+    ],
 
     "environment.additionalPaths": [],
 
@@ -147,24 +166,48 @@ const BaseConfiguration: IConfigurationValues = {
 
     "language.css.languageServer.command": cssLanguageServerPath,
     "language.css.languageServer.arguments": ["--stdio"],
-    "language.css.textMateGrammar": path.join(__dirname, "extensions", "css", "syntaxes", "css.tmLanguage.json"),
+    "language.css.textMateGrammar": path.join(
+        __dirname,
+        "extensions",
+        "css",
+        "syntaxes",
+        "css.tmLanguage.json",
+    ),
     "language.css.tokenRegex": "[$_a-zA-Z0-9-]",
 
     "language.less.languageServer.command": cssLanguageServerPath,
     "language.less.languageServer.arguments": ["--stdio"],
-    "language.less.textMateGrammar": path.join(__dirname, "extensions", "less", "syntaxes", "less.tmLanguage.json"),
+    "language.less.textMateGrammar": path.join(
+        __dirname,
+        "extensions",
+        "less",
+        "syntaxes",
+        "less.tmLanguage.json",
+    ),
     "language.less.tokenRegex": "[$_a-zA-Z0-9-]",
 
     "language.scss.languageServer.command": cssLanguageServerPath,
     "language.scss.languageServer.arguments": ["--stdio"],
-    "language.scss.textMateGrammar": path.join(__dirname, "extensions", "scss", "syntaxes", "scss.json"),
+    "language.scss.textMateGrammar": path.join(
+        __dirname,
+        "extensions",
+        "scss",
+        "syntaxes",
+        "scss.json",
+    ),
     "language.scss.tokenRegex": "[$_a-zA-Z0-9-]",
 
     "language.reason.languageServer.command": ocamlLanguageServerPath,
     "language.reason.languageServer.arguments": ["--stdio"],
     "language.reason.languageServer.rootFiles": [".merlin", "bsconfig.json"],
     "language.reason.languageServer.configuration": ocamlAndReasonConfiguration,
-    "language.reason.textMateGrammar": path.join(__dirname, "extensions", "reason", "syntaxes", "reason.json"),
+    "language.reason.textMateGrammar": path.join(
+        __dirname,
+        "extensions",
+        "reason",
+        "syntaxes",
+        "reason.json",
+    ),
 
     "language.ocaml.languageServer.command": ocamlLanguageServerPath,
     "language.ocaml.languageServer.arguments": ["--stdio"],
@@ -172,13 +215,37 @@ const BaseConfiguration: IConfigurationValues = {
 
     "language.typescript.completionTriggerCharacters": [".", "/", "\\"],
     "language.typescript.textMateGrammar": {
-        ".ts": path.join(__dirname, "extensions", "typescript", "syntaxes", "TypeScript.tmLanguage.json"),
-        ".tsx": path.join(__dirname, "extensions", "typescript", "syntaxes", "TypeScriptReact.tmLanguage.json"),
+        ".ts": path.join(
+            __dirname,
+            "extensions",
+            "typescript",
+            "syntaxes",
+            "TypeScript.tmLanguage.json",
+        ),
+        ".tsx": path.join(
+            __dirname,
+            "extensions",
+            "typescript",
+            "syntaxes",
+            "TypeScriptReact.tmLanguage.json",
+        ),
     },
     "language.javascript.completionTriggerCharacters": [".", "/", "\\"],
     "language.javascript.textMateGrammar": {
-        ".js": path.join(__dirname, "extensions", "javascript", "syntaxes", "JavaScript.tmLanguage.json"),
-        ".jsx": path.join(__dirname, "extensions", "javascript", "syntaxes", "JavaScriptReact.tmLanguage.json"),
+        ".js": path.join(
+            __dirname,
+            "extensions",
+            "javascript",
+            "syntaxes",
+            "JavaScript.tmLanguage.json",
+        ),
+        ".jsx": path.join(
+            __dirname,
+            "extensions",
+            "javascript",
+            "syntaxes",
+            "JavaScriptReact.tmLanguage.json",
+        ),
     },
 
     "menu.caseSensitive": "smart",
@@ -210,7 +277,8 @@ const BaseConfiguration: IConfigurationValues = {
     "ui.animations.enabled": true,
     "ui.colorscheme": "onedark",
     "ui.iconTheme": "theme-icons-seti",
-    "ui.fontFamily": "BlinkMacSystemFont, 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",
+    "ui.fontFamily":
+        "BlinkMacSystemFont, 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",
     "ui.fontSize": "13px",
     "ui.fontSmoothing": "auto",
 
@@ -219,10 +287,7 @@ const BaseConfiguration: IConfigurationValues = {
 
 const MacConfigOverrides: Partial<IConfigurationValues> = {
     "editor.fontFamily": "Menlo",
-    "environment.additionalPaths": [
-        "/usr/bin",
-        "/usr/local/bin",
-    ],
+    "environment.additionalPaths": ["/usr/bin", "/usr/local/bin"],
 }
 
 const WindowsConfigOverrides: Partial<IConfigurationValues> = {
@@ -231,13 +296,12 @@ const WindowsConfigOverrides: Partial<IConfigurationValues> = {
 
 const LinuxConfigOverrides: Partial<IConfigurationValues> = {
     "editor.fontFamily": "DejaVu Sans Mono",
-    "environment.additionalPaths": [
-        "/usr/bin",
-        "/usr/local/bin",
-    ],
+    "environment.additionalPaths": ["/usr/bin", "/usr/local/bin"],
 }
 
-const PlatformConfigOverride = Platform.isWindows() ? WindowsConfigOverrides : Platform.isLinux() ? LinuxConfigOverrides : MacConfigOverrides
+const PlatformConfigOverride = Platform.isWindows()
+    ? WindowsConfigOverrides
+    : Platform.isLinux() ? LinuxConfigOverrides : MacConfigOverrides
 
 export const DefaultConfiguration = {
     ...BaseConfiguration,

--- a/browser/src/Services/Configuration/DeprecatedConfigurationValues.ts
+++ b/browser/src/Services/Configuration/DeprecatedConfigurationValues.ts
@@ -13,19 +13,24 @@ export interface IDeprecatedConfigurationInfo {
     documentationUrl: string
 }
 
-const deprecatedSettings: { [deprecatedConfigurationName: string]: IDeprecatedConfigurationInfo } = {
+const deprecatedSettings: {
+    [deprecatedConfigurationName: string]: IDeprecatedConfigurationInfo
+} = {
     "editor.completions.enabled": {
         replacementConfigurationName: "editor.completions.mode",
         documentationUrl: "https://github.com/onivim/oni/wiki/Configuration#editor",
     },
 }
 
-export const checkDeprecatedSettings = (config: {[key: string]: any}): void => {
-    Object.keys(config).forEach((configurationName) => {
+export const checkDeprecatedSettings = (config: { [key: string]: any }): void => {
+    Object.keys(config).forEach(configurationName => {
         if (deprecatedSettings[configurationName]) {
-
             const deprecationInfo = deprecatedSettings[configurationName]
-            Log.warn(`Configuration setting '${configurationName}' is deprecated and will be replaced with '${deprecationInfo.replacementConfigurationName}'. See more info at: ${deprecationInfo.documentationUrl}`)
+            Log.warn(
+                `Configuration setting '${configurationName}' is deprecated and will be replaced with '${
+                    deprecationInfo.replacementConfigurationName
+                }'. See more info at: ${deprecationInfo.documentationUrl}`,
+            )
         }
     })
 }

--- a/browser/src/Services/Configuration/FileConfigurationProvider.ts
+++ b/browser/src/Services/Configuration/FileConfigurationProvider.ts
@@ -42,7 +42,6 @@ export class FileConfigurationProvider implements IConfigurationProvider {
     }
 
     constructor(filePath: string) {
-
         this._configChangedObservable = new Subject<void>()
         this._configErrorObservable = new Subject<Error>()
 
@@ -69,8 +68,10 @@ export class FileConfigurationProvider implements IConfigurationProvider {
         // Unfortunately, this also means the 'change' event fires twice.
         // I could use watchFile() but that polls every 5 seconds.  Not ideal.
         fs.watch(this._containingFolder, (event, filename) => {
-            if ((event === "change" && filename === "config.js") ||
-                (event === "rename" && filename === "config.js")) {
+            if (
+                (event === "change" && filename === "config.js") ||
+                (event === "rename" && filename === "config.js")
+            ) {
                 // invalidate the Config currently stored in cache
                 delete global["require"].cache[global["require"].resolve(filePath)] // tslint:disable-line no-string-literal
                 this._getLatestConfig()
@@ -91,9 +92,14 @@ export class FileConfigurationProvider implements IConfigurationProvider {
     public activate(api: Oni.Plugin.Api): void {
         if (this._latestConfiguration && this._latestConfiguration.activate) {
             try {
-            this._latestConfiguration.activate(api)
+                this._latestConfiguration.activate(api)
             } catch (e) {
-                alert("[Config Error] Failed to activate " + this._configurationFilePath + ":\n" + (e as Error).message)
+                alert(
+                    "[Config Error] Failed to activate " +
+                        this._configurationFilePath +
+                        ":\n" +
+                        (e as Error).message,
+                )
             }
         }
     }
@@ -121,7 +127,11 @@ export class FileConfigurationProvider implements IConfigurationProvider {
             try {
                 userRuntimeConfig = global["require"](this._configurationFilePath) // tslint:disable-line no-string-literal
             } catch (e) {
-                e.message = "[Config Error] Failed to parse " + this._configurationFilePath + ":\n" + (e as Error).message
+                e.message =
+                    "[Config Error] Failed to parse " +
+                    this._configurationFilePath +
+                    ":\n" +
+                    (e as Error).message
                 error = e
 
                 this._lastError = e
@@ -130,7 +140,6 @@ export class FileConfigurationProvider implements IConfigurationProvider {
         }
 
         if (!error) {
-
             // If the configuration is null, but it had some value at some point,
             // we assume this is due to reading while the file write is still
             // in transition, and ignore it

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -18,14 +18,13 @@ export interface ITokenColorsSetting {
 export type FontSmoothingOptions = "auto" | "antialiased" | "subpixel-antialiased" | "none"
 
 export interface IConfigurationValues {
-
-    "activate": (oni: Oni.Plugin.Api) => void
-    "deactivate": () => void
+    activate: (oni: Oni.Plugin.Api) => void
+    deactivate: () => void
 
     // Debug settings
     "debug.fixedSize": {
-        rows: number,
-        columns: number,
+        rows: number
+        columns: number
     } | null
 
     // Option to override neovim path. Used for testing new versions before bringing them in.
@@ -39,7 +38,7 @@ export interface IConfigurationValues {
     "debug.fakeLag.languageServer": number | null
     "debug.fakeLag.neovimInput": number | null
 
-        // - textMateHighlighting
+    // - textMateHighlighting
     "experimental.editor.textMateHighlighting.enabled": boolean
 
     "experimental.sidebar.enabled": boolean
@@ -47,10 +46,10 @@ export interface IConfigurationValues {
     // The transport to use for Neovim
     // Valid values are "stdio" and "pipe"
     "experimental.neovim.transport": string
-    "experimental.commandline.mode": boolean,
-    "experimental.commandline.icons": boolean,
+    "experimental.commandline.mode": boolean
+    "experimental.commandline.icons": boolean
 
-    "experimental.welcome.enabled": boolean,
+    "experimental.welcome.enabled": boolean
 
     "autoClosingPairs.enabled": boolean
     "autoClosingPairs.default": any
@@ -143,7 +142,7 @@ export interface IConfigurationValues {
 
     // Maximum supported file size (by lines)
     // to include language services/completion/syntax highlight/etc
-    "editor.maxLinesForLanguageServices": 2500,
+    "editor.maxLinesForLanguageServices": 2500
 
     // If true (default), the buffer scroll bar will be visible
     "editor.scrollBar.visible": boolean
@@ -207,12 +206,12 @@ export interface IConfigurationValues {
     "statusbar.fontSize": string
 
     "statusbar.priority": {
-        "oni.status.filetype": number,
-        "oni.status.workingDirectory": number,
-        "oni.status.git": number,
-        "oni.status.gitHubRepo": number,
-        "oni.status.linenumber": number,
-        "oni.status.mode": number,
+        "oni.status.filetype": number
+        "oni.status.workingDirectory": number
+        "oni.status.git": number
+        "oni.status.gitHubRepo": number
+        "oni.status.linenumber": number
+        "oni.status.mode": number
     }
 
     "tabs.mode": string

--- a/browser/src/Services/Configuration/ReasonConfiguration.ts
+++ b/browser/src/Services/Configuration/ReasonConfiguration.ts
@@ -8,7 +8,9 @@ import * as path from "path"
 
 import * as Platform from "./../../Platform"
 
-export const ocamlLanguageServerPath = Platform.isWindows() ? path.join(__dirname, "node_modules", ".bin", "ocaml-language-server.cmd") : path.join(__dirname, "node_modules", ".bin", "ocaml-language-server")
+export const ocamlLanguageServerPath = Platform.isWindows()
+    ? path.join(__dirname, "node_modules", ".bin", "ocaml-language-server.cmd")
+    : path.join(__dirname, "node_modules", ".bin", "ocaml-language-server")
 
 // If Windows, wrap in `bash -ic` to support WSL
 const wrapCommand = Platform.isWindows() ? (str: string) => "bash -ic " + str : (str: string) => str

--- a/browser/src/Services/Configuration/UserConfiguration.ts
+++ b/browser/src/Services/Configuration/UserConfiguration.ts
@@ -19,6 +19,7 @@ export const getUserConfigFilePath = (): string => {
 }
 
 export const getUserConfigFolderPath = (): string => {
-    return Platform.isWindows() ? path.join(Platform.getUserHome(), "oni") :
-                                  path.join(Platform.getUserHome(), ".oni")
+    return Platform.isWindows()
+        ? path.join(Platform.getUserHome(), "oni")
+        : path.join(Platform.getUserHome(), ".oni")
 }

--- a/browser/src/Services/ContextMenu/ContextMenu.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenu.tsx
@@ -25,7 +25,8 @@ import { ContextMenuContainer } from "./ContextMenuComponent"
 
 // TODO: Remove filtering from the context menu responsibility
 const reducer = createReducer<types.CompletionItem, types.CompletionItem>()
-const noopFilter = (opts: types.CompletionItem[], searchText: string): types.CompletionItem[] => opts
+const noopFilter = (opts: types.CompletionItem[], searchText: string): types.CompletionItem[] =>
+    opts
 
 // TODO: This is essentially a duplicate of `MenuManager.ts` - can this be consolidated?
 // Can potentially move to a higher-order class that takes contextMenuActions/store as arguments
@@ -37,17 +38,20 @@ export class ContextMenuManager {
     private _store: Store<ContextMenuState>
     private _actions: typeof ActionCreators
 
-    constructor(
-        private _toolTips: IToolTipsProvider,
-        private _colors: IColors,
-    ) {
+    constructor(private _toolTips: IToolTipsProvider, private _colors: IColors) {
         this._store = createStore("CONTEXT-MENU", reducer, State.createDefaultState(), [thunk])
         this._actions = bindActionCreators(ActionCreators as any, this._store.dispatch)
     }
 
     public create(): ContextMenu {
         this._id++
-        return new ContextMenu(this._id.toString(), this._store, this._actions, this._toolTips, this._colors)
+        return new ContextMenu(
+            this._id.toString(),
+            this._store,
+            this._actions,
+            this._toolTips,
+            this._colors,
+        )
     }
 
     public isMenuOpen(): boolean {
@@ -109,7 +113,7 @@ export class ContextMenu {
         private _actions: typeof ActionCreators,
         private _toolTips: IToolTipsProvider,
         private _colors: IColors,
-    ) { }
+    ) {}
 
     public isOpen(): boolean {
         const contextMenuState = this._store.getState()
@@ -117,7 +121,6 @@ export class ContextMenu {
     }
 
     public setFilter(filter: string): void {
-
         const contextMenuState = this._store.getState()
 
         if (contextMenuState.menu && contextMenuState.menu.filter !== filter) {
@@ -130,7 +133,6 @@ export class ContextMenu {
     }
 
     public setItems(items: Oni.Menu.MenuOption[]): void {
-
         if (items === this._lastItems) {
             return
         }
@@ -141,7 +143,6 @@ export class ContextMenu {
     }
 
     public show(items?: any[], filter?: string): void {
-
         const backgroundColor = this._colors.getColor("contextMenu.background")
         const foregroundColor = this._colors.getColor("contextMenu.foreground")
         const borderColor = this._colors.getColor("contextMenu.border") || foregroundColor
@@ -154,21 +155,30 @@ export class ContextMenu {
             highlightColor,
         }
 
-        this._actions.showPopupMenu(this._id, {
-            ...colors,
-            filterFunction: noopFilter,
-            onSelectedItemChanged: (item: any) => this._onSelectedItemChanged.dispatch(item),
-            onSelectItem: (idx: number) => this._onItemSelectedHandler(idx),
-            onHide: () => this._onHidden(),
-            onFilterTextChanged: (newText: string) => this._onFilterTextChanged.dispatch(newText),
-        } as any, items, filter)
+        this._actions.showPopupMenu(
+            this._id,
+            {
+                ...colors,
+                filterFunction: noopFilter,
+                onSelectedItemChanged: (item: any) => this._onSelectedItemChanged.dispatch(item),
+                onSelectItem: (idx: number) => this._onItemSelectedHandler(idx),
+                onHide: () => this._onHidden(),
+                onFilterTextChanged: (newText: string) =>
+                    this._onFilterTextChanged.dispatch(newText),
+            } as any,
+            items,
+            filter,
+        )
 
-        this._toolTips.showToolTip(this._getContextMenuId(), <ContextMenuContainer store={this._store}/>, {
-            openDirection: 2,
-            position: null,
-            padding: "0px",
-        })
-
+        this._toolTips.showToolTip(
+            this._getContextMenuId(),
+            <ContextMenuContainer store={this._store} />,
+            {
+                openDirection: 2,
+                position: null,
+                padding: "0px",
+            },
+        )
     }
 
     public updateItem(item: any): void {
@@ -180,7 +190,6 @@ export class ContextMenu {
     }
 
     private _onItemSelectedHandler(idx?: number): void {
-
         const selectedOption = this._getSelectedItem(idx)
         this._onItemSelected.dispatch(selectedOption)
 
@@ -194,7 +203,7 @@ export class ContextMenu {
             return null
         }
 
-        const index = (typeof idx === "number") ? idx : contextMenuState.menu.selectedIndex
+        const index = typeof idx === "number" ? idx : contextMenuState.menu.selectedIndex
 
         return contextMenuState.menu.filteredOptions[index]
     }

--- a/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
@@ -40,9 +40,7 @@ export interface IContextMenuProps {
 }
 
 export class ContextMenuView extends React.PureComponent<IContextMenuProps, {}> {
-
     public render(): null | JSX.Element {
-
         if (!this.props.visible) {
             return null
         }
@@ -53,17 +51,27 @@ export class ContextMenuView extends React.PureComponent<IContextMenuProps, {}> 
         const entries = firstTenEntries.map((s, i) => {
             const isSelected = i === this.props.selectedIndex
 
-            return <ContextMenuItem key={`${i}-${s.detail}`} {...s} isSelected={isSelected} base={this.props.base} highlightColor={this.props.highlightColor}/>
+            return (
+                <ContextMenuItem
+                    key={`${i}-${s.detail}`}
+                    {...s}
+                    isSelected={isSelected}
+                    base={this.props.base}
+                    highlightColor={this.props.highlightColor}
+                />
+            )
         })
 
-        const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
-        return <div className="autocompletion enable-mouse">
-                    <div className="entries">
-                        {entries}
-                    </div>
-                    <ContextMenuDocumentation documentation={selectedItemDocumentation} />
-                </div>
-
+        const selectedItemDocumentation = getDocumentationFromItems(
+            firstTenEntries,
+            this.props.selectedIndex,
+        )
+        return (
+            <div className="autocompletion enable-mouse">
+                <div className="entries">{entries}</div>
+                <ContextMenuDocumentation documentation={selectedItemDocumentation} />
+            </div>
+        )
     }
 }
 
@@ -87,7 +95,6 @@ export interface IContextMenuItemProps extends Oni.Menu.MenuOption {
 
 export class ContextMenuItem extends React.PureComponent<IContextMenuItemProps, {}> {
     public render(): JSX.Element {
-
         let className = "entry"
         if (this.props.isSelected) {
             className += " selected"
@@ -101,16 +108,23 @@ export class ContextMenuItem extends React.PureComponent<IContextMenuItemProps, 
 
         const arrowColor = this.props.isSelected ? highlightColor : "transparent"
 
-        return <div className={className} key={this.props.label}>
-            <div className="main">
-                <span className="icon" style={iconContainerStyle}>
-                    <Icon name={this.props.icon} />
-                </span>
-                <Arrow direction={ArrowDirection.Right} size={5}  color={arrowColor}/>
-                <HighlightText className="label" highlightClassName="highlight" highlightText={this.props.base} text={this.props.label} />
-                <span className="detail">{this.props.detail}</span>
+        return (
+            <div className={className} key={this.props.label}>
+                <div className="main">
+                    <span className="icon" style={iconContainerStyle}>
+                        <Icon name={this.props.icon} />
+                    </span>
+                    <Arrow direction={ArrowDirection.Right} size={5} color={arrowColor} />
+                    <HighlightText
+                        className="label"
+                        highlightClassName="highlight"
+                        highlightText={this.props.base}
+                        text={this.props.label}
+                    />
+                    <span className="detail">{this.props.detail}</span>
+                </div>
             </div>
-        </div>
+        )
     }
 }
 
@@ -131,15 +145,15 @@ export const ContextMenuDocumentation = (props: IContextMenuDocumentationProps) 
 const EmptyArray: any[] = []
 
 const EmptyProps = {
-            visible: false,
-            base: "",
-            entries: EmptyArray,
-            selectedIndex: 0,
-            backgroundColor: "",
-            foregroundColor: "",
-            borderColor: "",
-            highlightColor: "",
-        }
+    visible: false,
+    base: "",
+    entries: EmptyArray,
+    selectedIndex: 0,
+    backgroundColor: "",
+    foregroundColor: "",
+    borderColor: "",
+    highlightColor: "",
+}
 
 const mapStateToProps = (state: IMenus<types.CompletionItem, types.CompletionItem>) => {
     const contextMenu = state.menu
@@ -162,8 +176,10 @@ const mapStateToProps = (state: IMenus<types.CompletionItem, types.CompletionIte
 
 export const ConnectedContextMenu = connect(mapStateToProps)(ContextMenuView)
 
-export const ContextMenuContainer = (props: {store: Store<ContextMenuState>}) => {
-    return <Provider store={props.store}>
-             <ConnectedContextMenu />
-           </Provider>
+export const ContextMenuContainer = (props: { store: Store<ContextMenuState> }) => {
+    return (
+        <Provider store={props.store}>
+            <ConnectedContextMenu />
+        </Provider>
+    )
 }

--- a/browser/src/Services/Diagnostics.ts
+++ b/browser/src/Services/Diagnostics.ts
@@ -20,7 +20,9 @@ interface IPublishDiagnosticsParams {
     diagnostics: types.Diagnostic[]
 }
 
-export interface Errors { [file: string]: { [key: string]: types.Diagnostic[] } }
+export interface Errors {
+    [file: string]: { [key: string]: types.Diagnostic[] }
+}
 
 export interface IDiagnosticsDataSource {
     onErrorsChanged: IEvent<void>
@@ -51,7 +53,6 @@ export const getAllErrorsForFile = (fileName: string, errors: Errors): types.Dia
 }
 
 export class DiagnosticsDataSource {
-
     private _errors: Errors = {}
     private _onErrorsChangedEvent = new Event<void>()
 
@@ -78,30 +79,36 @@ export class DiagnosticsDataSource {
         return this._errors
     }
 
-    public getErrorsForPosition(filePath: string, line: number, column: number): types.Diagnostic[] {
+    public getErrorsForPosition(
+        filePath: string,
+        line: number,
+        column: number,
+    ): types.Diagnostic[] {
         const errors = getAllErrorsForFile(Utility.normalizePath(filePath), this._errors)
 
-        return errors.filter((diagnostic) => {
+        return errors.filter(diagnostic => {
             return Utility.isInRange(line, column, diagnostic.range)
         })
     }
 
     public start(languageManager: LanguageManager): void {
-        languageManager.subscribeToLanguageServerNotification("textDocument/publishDiagnostics", (args: ILanguageServerNotificationResponse) => {
-            const test = args.payload as IPublishDiagnosticsParams
+        languageManager.subscribeToLanguageServerNotification(
+            "textDocument/publishDiagnostics",
+            (args: ILanguageServerNotificationResponse) => {
+                const test = args.payload as IPublishDiagnosticsParams
 
-            const file = Helpers.unwrapFileUriPath(test.uri)
-            const key = "language-" + args.language
+                const file = Helpers.unwrapFileUriPath(test.uri)
+                const key = "language-" + args.language
 
-            this.setErrors(file, key, test.diagnostics)
-        })
+                this.setErrors(file, key, test.diagnostics)
+            },
+        )
     }
 }
 
 let _diagnostics: DiagnosticsDataSource = null
 
 export const getInstance = (): IDiagnosticsDataSource => {
-
     if (!_diagnostics) {
         _diagnostics = new DiagnosticsDataSource()
     }

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -77,7 +77,6 @@ class AllEditors implements Oni.Editor {
     }
 
     public get activeBuffer(): Oni.Buffer {
-
         // TODO: Replace with null-object pattern
         if (!this._activeEditor) {
             return null
@@ -138,14 +137,26 @@ class AllEditors implements Oni.Editor {
 
     public setActiveEditor(newEditor: Oni.Editor) {
         this._activeEditor = newEditor
-        this._subscriptions.forEach((d) => d.dispose())
+        this._subscriptions.forEach(d => d.dispose())
         this._subscriptions = []
-        this._subscriptions.push(newEditor.onModeChanged.subscribe((val) => this._onModeChanged.dispatch(val)))
-        this._subscriptions.push(newEditor.onBufferEnter.subscribe((val) => this._onBufferEnter.dispatch(val)))
-        this._subscriptions.push(newEditor.onBufferLeave.subscribe((val) => this._onBufferLeave.dispatch(val)))
-        this._subscriptions.push(newEditor.onBufferChanged.subscribe((val) => this._onBufferChanged.dispatch(val)))
-        this._subscriptions.push(newEditor.onBufferSaved.subscribe((val) => this._onBufferSaved.dispatch(val)))
-        this._subscriptions.push(newEditor.onBufferScrolled.subscribe((val) => this._onBufferScrolled.dispatch(val)))
+        this._subscriptions.push(
+            newEditor.onModeChanged.subscribe(val => this._onModeChanged.dispatch(val)),
+        )
+        this._subscriptions.push(
+            newEditor.onBufferEnter.subscribe(val => this._onBufferEnter.dispatch(val)),
+        )
+        this._subscriptions.push(
+            newEditor.onBufferLeave.subscribe(val => this._onBufferLeave.dispatch(val)),
+        )
+        this._subscriptions.push(
+            newEditor.onBufferChanged.subscribe(val => this._onBufferChanged.dispatch(val)),
+        )
+        this._subscriptions.push(
+            newEditor.onBufferSaved.subscribe(val => this._onBufferSaved.dispatch(val)),
+        )
+        this._subscriptions.push(
+            newEditor.onBufferScrolled.subscribe(val => this._onBufferScrolled.dispatch(val)),
+        )
     }
 
     public getUnderlyingEditor(): Oni.Editor {

--- a/browser/src/Services/Errors.ts
+++ b/browser/src/Services/Errors.ts
@@ -53,20 +53,23 @@ export class Errors implements ITaskProvider {
     }
 
     private _setQuickFixErrors(): void {
-        const arrayOfErrors = keys(this._errors).map((filename) => {
-            return this._errors[filename].map((e) => ({
+        const arrayOfErrors = keys(this._errors).map(filename => {
+            return this._errors[filename].map(e => ({
                 ...e,
                 filename,
             }))
         })
 
         const flattenedErrors = flatten(arrayOfErrors)
-        const errors = flattenedErrors.map((e) => ({
-            filename: e.filename,
-            col: e.range.start.character || 0,
-            lnum: e.range.start.line + 1,
-            text: e.message,
-        }) as any)
+        const errors = flattenedErrors.map(
+            e =>
+                ({
+                    filename: e.filename,
+                    col: e.range.start.character || 0,
+                    lnum: e.range.start.line + 1,
+                    text: e.message,
+                } as any),
+        )
 
         this._neovimInstance.quickFix.setqflist(errors, "Errors", " ")
     }

--- a/browser/src/Services/Explorer/ExplorerFileSystem.ts
+++ b/browser/src/Services/Explorer/ExplorerFileSystem.ts
@@ -17,15 +17,12 @@ export interface IFileSystem {
 }
 
 export class FileSystem implements IFileSystem {
-
-    constructor(
-        private _fs: typeof fs,
-    ) {}
+    constructor(private _fs: typeof fs) {}
 
     public readdir(directoryPath: string): Promise<FolderOrFile[]> {
         const files = this._fs.readdirSync(directoryPath)
 
-        const filesAndFolders = files.map((f) => {
+        const filesAndFolders = files.map(f => {
             const fullPath = path.join(directoryPath, f)
             const stat = this._fs.statSync(fullPath)
             if (stat.isDirectory()) {

--- a/browser/src/Services/Explorer/ExplorerSelectors.ts
+++ b/browser/src/Services/Explorer/ExplorerSelectors.ts
@@ -10,26 +10,29 @@ import * as flatten from "lodash/flatten"
 
 import { ExpandedFolders, FolderOrFile, IExplorerState } from "./ExplorerStore"
 
-export type ExplorerNode = {
-    id: string,
-    type: "container",
-    expanded: boolean,
-    name: string,
-} | {
-    id: string,
-    type: "folder",
-    folderPath: string,
-    expanded: boolean,
-    name: string,
-    indentationLevel: number,
-}  | {
-    id: string,
-    type: "file",
-    filePath: string,
-    modified: boolean,
-    name: string,
-    indentationLevel: number,
-}
+export type ExplorerNode =
+    | {
+          id: string
+          type: "container"
+          expanded: boolean
+          name: string
+      }
+    | {
+          id: string
+          type: "folder"
+          folderPath: string
+          expanded: boolean
+          name: string
+          indentationLevel: number
+      }
+    | {
+          id: string
+          type: "file"
+          filePath: string
+          modified: boolean
+          name: string
+          indentationLevel: number
+      }
 
 export const isPathExpanded = (state: IExplorerState, pathToCheck: string): boolean => {
     return !!state.expandedFolders[pathToCheck]
@@ -38,25 +41,25 @@ export const isPathExpanded = (state: IExplorerState, pathToCheck: string): bool
 export const mapStateToNodeList = (state: IExplorerState): ExplorerNode[] => {
     let ret: ExplorerNode[] = []
 
-//     ret.push({
-//         id: "opened",
-//         type: "container",
-//         expanded: true,
-//         name: "Opened Files",
-//     })
+    //     ret.push({
+    //         id: "opened",
+    //         type: "container",
+    //         expanded: true,
+    //         name: "Opened Files",
+    //     })
 
-//     const openedFiles: ExplorerNode[] = Object.keys(state.openedFiles)
-//         .filter(filePath => !!filePath)
-//         .map(filePath => ({
-//         type: "file",
-//         id: "opened:" + filePath,
-//         filePath,
-//         name: path.basename(filePath),
-//         modified: false, // TODO
-//         indentationLevel: 0,
-//     } as ExplorerNode))
+    //     const openedFiles: ExplorerNode[] = Object.keys(state.openedFiles)
+    //         .filter(filePath => !!filePath)
+    //         .map(filePath => ({
+    //         type: "file",
+    //         id: "opened:" + filePath,
+    //         filePath,
+    //         name: path.basename(filePath),
+    //         modified: false, // TODO
+    //         indentationLevel: 0,
+    //     } as ExplorerNode))
 
-//     ret = [...ret, ...openedFiles]
+    //     ret = [...ret, ...openedFiles]
 
     if (!state.rootFolder || !state.rootFolder.fullPath) {
         return ret
@@ -78,7 +81,12 @@ export const mapStateToNodeList = (state: IExplorerState): ExplorerNode[] => {
     return ret
 }
 
-export const flattenFolderTree = (folderTree: FolderOrFile, currentList: ExplorerNode[], expandedFolders: ExpandedFolders, indentationLevel: number): ExplorerNode[] => {
+export const flattenFolderTree = (
+    folderTree: FolderOrFile,
+    currentList: ExplorerNode[],
+    expandedFolders: ExpandedFolders,
+    indentationLevel: number,
+): ExplorerNode[] => {
     switch (folderTree.type) {
         case "file":
             const file: ExplorerNode = {
@@ -103,7 +111,11 @@ export const flattenFolderTree = (folderTree: FolderOrFile, currentList: Explore
             }
 
             const folderChildren = expandedFolders[folderTree.fullPath] || []
-            const children = flatten(folderChildren.map((c) => flattenFolderTree(c, [], expandedFolders, indentationLevel + 1)))
+            const children = flatten(
+                folderChildren.map(c =>
+                    flattenFolderTree(c, [], expandedFolders, indentationLevel + 1),
+                ),
+            )
 
             return [...currentList, folder, ...children]
         default:

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -24,7 +24,6 @@ import { Explorer } from "./ExplorerView"
 import { rm } from "shelljs"
 
 export class ExplorerSplit {
-
     private _onEnterEvent: Event<void> = new Event<void>()
     private _selectedId: string = null
 
@@ -46,7 +45,7 @@ export class ExplorerSplit {
     ) {
         this._store = createStore()
 
-        this._workspace.onDirectoryChanged.subscribe((newDirectory) => {
+        this._workspace.onDirectoryChanged.subscribe(newDirectory => {
             this._store.dispatch({
                 type: "SET_ROOT_DIRECTORY",
                 rootPath: newDirectory,
@@ -60,7 +59,7 @@ export class ExplorerSplit {
             })
         }
 
-        this._editorManager.allEditors.onBufferEnter.subscribe((args) => {
+        this._editorManager.allEditors.onBufferEnter.subscribe(args => {
             this._store.dispatch({
                 type: "BUFFER_OPENED",
                 filePath: args.filePath,
@@ -69,26 +68,30 @@ export class ExplorerSplit {
     }
 
     public enter(): void {
-
-        this._store.dispatch({type: "ENTER"})
-        this._commandManager.registerCommand(new CallbackCommand("explorer.open", null, null, () => this._onOpenItem()))
-        this._commandManager.registerCommand(new CallbackCommand("explorer.delete", null, null, () => this._onDeleteItem()))
+        this._store.dispatch({ type: "ENTER" })
+        this._commandManager.registerCommand(
+            new CallbackCommand("explorer.open", null, null, () => this._onOpenItem()),
+        )
+        this._commandManager.registerCommand(
+            new CallbackCommand("explorer.delete", null, null, () => this._onDeleteItem()),
+        )
 
         this._onEnterEvent.dispatch()
     }
 
     public leave(): void {
-        this._store.dispatch({type: "LEAVE"})
+        this._store.dispatch({ type: "LEAVE" })
 
         this._commandManager.unregisterCommand("explorer.open")
         this._commandManager.unregisterCommand("explorer.delete")
     }
 
     public render(): JSX.Element {
-
-        return <Provider store={this._store}>
-                <Explorer onSelectionChanged={(id) => this._onSelectionChanged(id)} />
+        return (
+            <Provider store={this._store}>
+                <Explorer onSelectionChanged={id => this._onSelectionChanged(id)} />
             </Provider>
+        )
     }
 
     private _onSelectionChanged(id: string): void {
@@ -109,7 +112,10 @@ export class ExplorerSplit {
                 this._editorManager.activeEditor.openFile(selectedItem.filePath)
                 return
             case "folder":
-                const isDirectoryExpanded = ExplorerSelectors.isPathExpanded(state, selectedItem.folderPath)
+                const isDirectoryExpanded = ExplorerSelectors.isPathExpanded(
+                    state,
+                    selectedItem.folderPath,
+                )
                 this._store.dispatch({
                     type: isDirectoryExpanded ? "COLLAPSE_DIRECTORY" : "EXPAND_DIRECTORY",
                     directoryPath: selectedItem.folderPath,
@@ -125,7 +131,7 @@ export class ExplorerSplit {
 
         const nodes = ExplorerSelectors.mapStateToNodeList(state)
 
-        const items = nodes.filter((item) => item.id === this._selectedId)
+        const items = nodes.filter(item => item.id === this._selectedId)
 
         if (!items || !items.length) {
             return null

--- a/browser/src/Services/Explorer/ExplorerView.tsx
+++ b/browser/src/Services/Explorer/ExplorerView.tsx
@@ -31,13 +31,19 @@ export class FileView extends React.PureComponent<IFileViewProps, {}> {
     public render(): JSX.Element {
         const style = {
             paddingLeft: (INDENT_AMOUNT * this.props.indentationLevel).toString() + "px",
-            borderLeft: this.props.isSelected ? "4px solid rgb(97, 175, 239)" : "4px solid transparent",
+            borderLeft: this.props.isSelected
+                ? "4px solid rgb(97, 175, 239)"
+                : "4px solid transparent",
             backgroundColor: this.props.isSelected ? "rgba(97, 175, 239, 0.1)" : "transparent",
         }
-        return <div className="item" style={style}>
-                <div className="icon"><FileIcon fileName={this.props.fileName} isLarge={true}/></div>
+        return (
+            <div className="item" style={style}>
+                <div className="icon">
+                    <FileIcon fileName={this.props.fileName} isLarge={true} />
+                </div>
                 <div className="name">{this.props.fileName}</div>
             </div>
+        )
     }
 }
 
@@ -52,11 +58,32 @@ export class NodeView extends React.PureComponent<INodeViewProps, {}> {
 
         switch (node.type) {
             case "file":
-                return <FileView fileName={node.name} isSelected={this.props.isSelected} indentationLevel={node.indentationLevel}/>
+                return (
+                    <FileView
+                        fileName={node.name}
+                        isSelected={this.props.isSelected}
+                        indentationLevel={node.indentationLevel}
+                    />
+                )
             case "container":
-                return <ContainerView expanded={node.expanded} name={node.name} isContainer={true} isSelected={this.props.isSelected}/>
+                return (
+                    <ContainerView
+                        expanded={node.expanded}
+                        name={node.name}
+                        isContainer={true}
+                        isSelected={this.props.isSelected}
+                    />
+                )
             case "folder":
-                return <ContainerView expanded={node.expanded} name={node.name} isContainer={false} isSelected={this.props.isSelected} indentationLevel={node.indentationLevel}/>
+                return (
+                    <ContainerView
+                        expanded={node.expanded}
+                        name={node.name}
+                        isContainer={false}
+                        isSelected={this.props.isSelected}
+                        indentationLevel={node.indentationLevel}
+                    />
+                )
             default:
                 return <div>{JSON.stringify(node)}</div>
         }
@@ -73,27 +100,30 @@ export interface IContainerViewProps {
 
 export class ContainerView extends React.PureComponent<IContainerViewProps, {}> {
     public render(): JSX.Element {
-
         const indentLevel = this.props.indentationLevel || 0
 
         const headerStyle = {
             paddingLeft: (indentLevel * INDENT_AMOUNT).toString() + "px",
-            backgroundColor: this.props.isContainer ? "#1e2127" : this.props.isSelected ? "rgba(97, 175, 239, 0.1)" : "transparent",
-            borderLeft: this.props.isSelected ? "4px solid rgb(97, 175, 239)" : "4px solid transparent",
+            backgroundColor: this.props.isContainer
+                ? "#1e2127"
+                : this.props.isSelected ? "rgba(97, 175, 239, 0.1)" : "transparent",
+            borderLeft: this.props.isSelected
+                ? "4px solid rgb(97, 175, 239)"
+                : "4px solid transparent",
         }
 
         const caretStyle = {
             transform: this.props.expanded ? "rotateZ(45deg)" : "rotateZ(0deg)",
         }
 
-        return <div className="item" style={headerStyle}>
-            <div className="icon">
-                <i style={caretStyle} className="fa fa-caret-right" />
+        return (
+            <div className="item" style={headerStyle}>
+                <div className="icon">
+                    <i style={caretStyle} className="fa fa-caret-right" />
+                </div>
+                <div className="name">{this.props.name}</div>
             </div>
-            <div className="name">
-                {this.props.name}
-            </div>
-        </div>
+        )
     }
 }
 
@@ -107,28 +137,34 @@ export interface IExplorerViewProps extends IExplorerViewContainerProps {
 }
 
 export class ExplorerView extends React.PureComponent<IExplorerViewProps, {}> {
-
     public render(): JSX.Element {
+        const ids = this.props.nodes.map(node => node.id)
 
-        const ids = this.props.nodes.map((node) => node.id)
-
-        return <VimNavigator
+        return (
+            <VimNavigator
                 ids={ids}
                 active={this.props.isActive}
                 onSelectionChanged={this.props.onSelectionChanged}
                 render={(selectedId: string) => {
-                const nodes = this.props.nodes.map((node) => <NodeView node={node} isSelected={node.id === selectedId}/>)
+                    const nodes = this.props.nodes.map(node => (
+                        <NodeView node={node} isSelected={node.id === selectedId} />
+                    ))
 
-                return <div className="explorer enable-mouse">
-                        <div className="items">
-                            {nodes}
+                    return (
+                        <div className="explorer enable-mouse">
+                            <div className="items">{nodes}</div>
                         </div>
-                    </div>
-                }} />
+                    )
+                }}
+            />
+        )
     }
 }
 
-const mapStateToProps = (state: IExplorerState, containerProps: IExplorerViewContainerProps): IExplorerViewProps => {
+const mapStateToProps = (
+    state: IExplorerState,
+    containerProps: IExplorerViewContainerProps,
+): IExplorerViewProps => {
     return {
         ...containerProps,
         isActive: state.hasFocus,

--- a/browser/src/Services/FileIcon.tsx
+++ b/browser/src/Services/FileIcon.tsx
@@ -20,14 +20,15 @@ export interface IFileIconProps {
 
 export class FileIcon extends React.PureComponent<IFileIconProps, {}> {
     public render(): JSX.Element {
-
         if (!this.props.fileName) {
             return null
         }
 
         const icons = getInstance()
 
-        const className = icons.getIconClassForFile(this.props.fileName, this.props.language) + (this.props.isLarge ? " fa-lg" : "")
+        const className =
+            icons.getIconClassForFile(this.props.fileName, this.props.language) +
+            (this.props.isLarge ? " fa-lg" : "")
         const additionalClasses = this.props.additionalClassNames || ""
 
         return <i className={className + " " + additionalClasses} aria-hidden={true} />

--- a/browser/src/Services/FileMappings.ts
+++ b/browser/src/Services/FileMappings.ts
@@ -14,8 +14,12 @@ export interface IFileMapping {
     mappedFileName: string
 }
 
-export const getMappedFile = (rootFolder: string, filePath: string, mappings: IFileMapping[]): string | null => {
-    const mappingsThatApply = mappings.filter((m) => doesMappingMatchFile(rootFolder, filePath, m))
+export const getMappedFile = (
+    rootFolder: string,
+    filePath: string,
+    mappings: IFileMapping[],
+): string | null => {
+    const mappingsThatApply = mappings.filter(m => doesMappingMatchFile(rootFolder, filePath, m))
 
     if (mappingsThatApply.length === 0) {
         return null
@@ -26,11 +30,19 @@ export const getMappedFile = (rootFolder: string, filePath: string, mappings: IF
     return getMappedFileFromMapping(rootFolder, filePath, mapping)
 }
 
-export const doesMappingMatchFile = (rootFolder: string, filePath: string, mapping: IFileMapping): boolean => {
+export const doesMappingMatchFile = (
+    rootFolder: string,
+    filePath: string,
+    mapping: IFileMapping,
+): boolean => {
     return filePath.indexOf(path.join(rootFolder, mapping.sourceFolder)) === 0
 }
 
-export const getMappedFileFromMapping = (rootFolder: string, filePath: string, mapping: IFileMapping): string | null => {
+export const getMappedFileFromMapping = (
+    rootFolder: string,
+    filePath: string,
+    mapping: IFileMapping,
+): string | null => {
     const fullSourceRoot = path.join(rootFolder, mapping.sourceFolder)
     const difference = getPathDifference(fullSourceRoot, path.dirname(filePath))
 
@@ -42,8 +54,10 @@ export const getMappedFileFromMapping = (rootFolder: string, filePath: string, m
     return mappedFile
 }
 
-export const replaceVariablesInFileName = (mappingFileNameWithVariables: string, originalFilePath: string): string => {
-
+export const replaceVariablesInFileName = (
+    mappingFileNameWithVariables: string,
+    originalFilePath: string,
+): string => {
     const originalFileNameWithExtension = path.basename(originalFilePath)
     const originalExtension = path.extname(originalFileNameWithExtension)
 
@@ -69,7 +83,6 @@ export const getPathDifference = (path1: string, path2: string): string => {
     let idx = 0
     let isEqual: boolean = true
     while (idx < diffPathParts.length) {
-
         if (idx >= basePathParts.length) {
             deltaPathParts.push(diffPathParts[idx])
         } else {

--- a/browser/src/Services/FocusManager.ts
+++ b/browser/src/Services/FocusManager.ts
@@ -5,18 +5,16 @@
 import * as Log from "./../Log"
 
 class FocusManager {
-
     private _focusElementStack: HTMLElement[] = []
 
     public pushFocus(element: HTMLElement) {
-
         this._focusElementStack = [element, ...this._focusElementStack]
 
         element.focus()
     }
 
     public popFocus(element: HTMLElement) {
-        this._focusElementStack = this._focusElementStack.filter((elem) => elem !== element)
+        this._focusElementStack = this._focusElementStack.filter(elem => elem !== element)
 
         this.enforceFocus()
     }
@@ -31,7 +29,6 @@ class FocusManager {
     }
 
     public enforceFocus(): void {
-
         if (this._focusElementStack.length === 0) {
             return
         }

--- a/browser/src/Services/Git.ts
+++ b/browser/src/Services/Git.ts
@@ -17,12 +17,16 @@ export function getBranch(path?: string): Promise<string> {
             options.cwd = path
         }
 
-        exec("git rev-parse --abbrev-ref HEAD", options, (error: any, stdout: string, stderr: string) => {
-            if (error && error.code) {
-                reject(new Error(stderr))
-            } else {
-                resolve(stdout)
-            }
-        })
+        exec(
+            "git rev-parse --abbrev-ref HEAD",
+            options,
+            (error: any, stdout: string, stderr: string) => {
+                if (error && error.code) {
+                    reject(new Error(stderr))
+                } else {
+                    resolve(stdout)
+                }
+            },
+        )
     })
 }

--- a/browser/src/Services/IconThemes/IconThemeLoader.ts
+++ b/browser/src/Services/IconThemes/IconThemeLoader.ts
@@ -22,25 +22,24 @@ export interface IIconThemeLoader {
 }
 
 export class PluginIconThemeLoader {
-    constructor(private _pluginManager: PluginManager) {
-    }
+    constructor(private _pluginManager: PluginManager) {}
 
     public async loadIconTheme(themeName: string): Promise<IIconThemeLoadResult> {
         const plugins = this._pluginManager.plugins
 
-        const pluginsWithThemes = plugins.filter((p) => {
+        const pluginsWithThemes = plugins.filter(p => {
             return p.metadata && p.metadata.contributes && p.metadata.contributes.iconThemes
         })
 
-        const allIconThemes = pluginsWithThemes.reduce((previous: IIconThemeContribution[], current) => {
-            const iconThemes = current.metadata.contributes.iconThemes
-            return [
-                ...previous,
-                ...iconThemes,
-            ]
-        }, [] as IIconThemeContribution[])
+        const allIconThemes = pluginsWithThemes.reduce(
+            (previous: IIconThemeContribution[], current) => {
+                const iconThemes = current.metadata.contributes.iconThemes
+                return [...previous, ...iconThemes]
+            },
+            [] as IIconThemeContribution[],
+        )
 
-        const matchingIconTheme = allIconThemes.find((t) => t.id === themeName)
+        const matchingIconTheme = allIconThemes.find(t => t.id === themeName)
 
         if (!matchingIconTheme || !matchingIconTheme.path) {
             return null

--- a/browser/src/Services/IconThemes/Icons.ts
+++ b/browser/src/Services/IconThemes/Icons.ts
@@ -41,16 +41,24 @@ export interface IIconInfo extends IIconDefinition {
     size: string
 }
 
-export interface IconDefinitions { [key: string]: IIconDefinition }
+export interface IconDefinitions {
+    [key: string]: IIconDefinition
+}
 
 // File extension -> icon definition key
-export interface FileDefinitions { [extension: string]: string }
+export interface FileDefinitions {
+    [extension: string]: string
+}
 
 // File name -> icon definition key
-export interface FileNames { [fileName: string]: string }
+export interface FileNames {
+    [fileName: string]: string
+}
 
 // Language id -> icon definition key
-export interface Language { [language: string]: string }
+export interface Language {
+    [language: string]: string
+}
 
 export interface IIconTheme {
     fonts: IIconFont[]
@@ -63,7 +71,6 @@ export interface IIconTheme {
 }
 
 export class Icons {
-
     private _activeIconTheme: IIconTheme = null
     private _onIconThemeChangedEvent: Event<void> = new Event<void>()
 
@@ -75,12 +82,9 @@ export class Icons {
         return this._onIconThemeChangedEvent
     }
 
-    constructor(
-        private _pluginManager: PluginManager,
-    ) { }
+    constructor(private _pluginManager: PluginManager) {}
 
     public getIconClassForFile(fileName: string, language?: string): string {
-
         if (!this._activeIconTheme) {
             return null
         }
@@ -103,7 +107,9 @@ export class Icons {
             if (extension && extension.length > 1) {
                 const extensionWithoutPeriod = extension.substring(1, extension.length)
 
-                const matchingExtension = this._activeIconTheme.fileExtensions[extensionWithoutPeriod]
+                const matchingExtension = this._activeIconTheme.fileExtensions[
+                    extensionWithoutPeriod
+                ]
                 if (matchingExtension) {
                     return classBase + matchingExtension
                 }
@@ -127,7 +133,6 @@ export class Icons {
     }
 
     public async applyIconTheme(themeName: string): Promise<void> {
-
         const iconThemeLoader = new PluginIconThemeLoader(this._pluginManager)
 
         const loadResults = await iconThemeLoader.loadIconTheme(themeName)
@@ -143,13 +148,15 @@ export class Icons {
 
         const fonts = this._activeIconTheme.fonts || []
 
-        fonts.forEach((font) => {
+        fonts.forEach(font => {
             if (!font.src || !font.src.length) {
                 return
             }
 
             const fontSrc = font.src[0]
-            const fontPath = Utility.normalizePath(path.join(path.dirname(loadResults.filePath), fontSrc.path))
+            const fontPath = Utility.normalizePath(
+                path.join(path.dirname(loadResults.filePath), fontSrc.path),
+            )
             const fontFormat = fontSrc.format
 
             styleWriter.writeFontFace(font.id, fontPath, fontFormat)
@@ -159,7 +166,11 @@ export class Icons {
         if (iconDefinitions) {
             Object.keys(iconDefinitions).forEach((definitionName: string) => {
                 const definitionContents = iconDefinitions[definitionName]
-                styleWriter.writeIcon(definitionName, definitionContents.fontColor, definitionContents.fontCharacter)
+                styleWriter.writeIcon(
+                    definitionName,
+                    definitionContents.fontColor,
+                    definitionContents.fontCharacter,
+                )
             })
         }
 

--- a/browser/src/Services/IconThemes/StyleWriter.ts
+++ b/browser/src/Services/IconThemes/StyleWriter.ts
@@ -13,9 +13,7 @@ export class StyleWriter {
         return this._style
     }
 
-    constructor(
-        private _primaryClassName: string,
-    ) {}
+    constructor(private _primaryClassName: string) {}
 
     public writeFontFace(fontFamily: string, sourceUrl: string, format: string): void {
         // Inspired by:
@@ -31,7 +29,7 @@ export class StyleWriter {
 
         const primaryClassBlock = [
             ".fa." + this._primaryClassName + " {",
-                "font-family: " + fontFamily + ";",
+            "font-family: " + fontFamily + ";",
             "}",
         ]
 
@@ -43,19 +41,11 @@ export class StyleWriter {
         const selector = ".fa." + this._primaryClassName + "." + iconClass
 
         if (fontColor) {
-            const primaryClassBlock = [
-                selector + " {",
-                    "color: " + fontColor + ";",
-                "}",
-            ]
+            const primaryClassBlock = [selector + " {", "color: " + fontColor + ";", "}"]
             this._append(primaryClassBlock)
         }
 
-        const pseudoElementBlock = [
-            selector + ":before {",
-            `   content: '${fontCharacter}';`,
-            "}",
-        ]
+        const pseudoElementBlock = [selector + ":before {", `   content: '${fontCharacter}';`, "}"]
         this._append(pseudoElementBlock)
     }
 

--- a/browser/src/Services/IconThemes/index.ts
+++ b/browser/src/Services/IconThemes/index.ts
@@ -18,7 +18,10 @@ export const getInstance = (): Icons => {
     return _icons
 }
 
-export const activate = async (configuration: Configuration, pluginManager: PluginManager): Promise<void> => {
+export const activate = async (
+    configuration: Configuration,
+    pluginManager: PluginManager,
+): Promise<void> => {
     _icons = new Icons(pluginManager)
 
     const iconTheme = configuration.getValue("ui.iconTheme")

--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -83,8 +83,8 @@ export class InputManager implements Oni.InputManager {
 
         const boundKey = this._boundKeys[keyChord]
 
+        // tslint:disable-next-line prefer-for-of
         for (let i = 0; i < boundKey.length; i++) {
-            // tslint:disable-line prefer-for-of
             const binding = boundKey[i]
 
             // Does the binding pass filter?

--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -1,4 +1,3 @@
-
 import * as Oni from "oni-api"
 
 import { commandManager } from "./CommandManager"
@@ -19,16 +18,19 @@ export interface KeyBindingMap {
 }
 
 export class InputManager implements Oni.InputManager {
-
     private _boundKeys: KeyBindingMap = {}
 
     /**
      * API Methods
      */
-    public bind(keyChord: string | string[], action: ActionOrCommand, filterFunction?: () => boolean): Oni.DisposeFunction {
+    public bind(
+        keyChord: string | string[],
+        action: ActionOrCommand,
+        filterFunction?: () => boolean,
+    ): Oni.DisposeFunction {
         if (Array.isArray(keyChord)) {
-            const disposalFunctions = keyChord.map((key) => this.bind(key, action, filterFunction))
-            return () => disposalFunctions.forEach((df) => df())
+            const disposalFunctions = keyChord.map(key => this.bind(key, action, filterFunction))
+            return () => disposalFunctions.forEach(df => df())
         }
 
         const normalizedKeyChord = keyChord.toLowerCase()
@@ -41,14 +43,14 @@ export class InputManager implements Oni.InputManager {
             const existingBindings = this._boundKeys[normalizedKeyChord]
 
             if (existingBindings) {
-                this._boundKeys[normalizedKeyChord] = existingBindings.filter((f) => f !== newBinding)
+                this._boundKeys[normalizedKeyChord] = existingBindings.filter(f => f !== newBinding)
             }
         }
     }
 
     public unbind(keyChord: string | string[]) {
         if (Array.isArray(keyChord)) {
-            keyChord.forEach((key) => this.unbind(keyChord))
+            keyChord.forEach(key => this.unbind(keyChord))
             return
         }
 
@@ -81,7 +83,8 @@ export class InputManager implements Oni.InputManager {
 
         const boundKey = this._boundKeys[keyChord]
 
-        for (let i = 0; i < boundKey.length; i++) { // tslint:disable-line prefer-for-of
+        for (let i = 0; i < boundKey.length; i++) {
+            // tslint:disable-line prefer-for-of
             const binding = boundKey[i]
 
             // Does the binding pass filter?

--- a/browser/src/Services/Language/CodeAction.ts
+++ b/browser/src/Services/Language/CodeAction.ts
@@ -48,7 +48,6 @@ import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpe
 // }
 
 export const getCodeActions = async (): Promise<types.Command[]> => {
-
     const buffer = editorManager.activeEditor.activeBuffer
 
     const { language, filePath } = buffer
@@ -62,9 +61,15 @@ export const getCodeActions = async (): Promise<types.Command[]> => {
     if (languageManager.isLanguageServerAvailable(language)) {
         let result: types.Command[] = null
         try {
-            result = await languageManager.sendLanguageServerRequest(language, filePath, "textDocument/codeAction",
-            Helpers.eventContextToCodeActionParams(filePath, range))
-        } catch (ex) { Log.verbose(ex) }
+            result = await languageManager.sendLanguageServerRequest(
+                language,
+                filePath,
+                "textDocument/codeAction",
+                Helpers.eventContextToCodeActionParams(filePath, range),
+            )
+        } catch (ex) {
+            Log.verbose(ex)
+        }
 
         if (!result) {
             return null

--- a/browser/src/Services/Language/DefinitionRequestor.ts
+++ b/browser/src/Services/Language/DefinitionRequestor.ts
@@ -19,17 +19,23 @@ export interface IDefinitionResult {
 }
 
 export interface IDefinitionRequestor {
-    getDefinition(fileLanguage: string, filePath: string, line: number, column: number): Promise<IDefinitionResult>
+    getDefinition(
+        fileLanguage: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<IDefinitionResult>
 }
 
 export class LanguageServiceDefinitionRequestor {
+    constructor(private _languageManager: LanguageManager, private _editor: Oni.Editor) {}
 
-    constructor(
-        private _languageManager: LanguageManager,
-        private _editor: Oni.Editor,
-    ) { }
-
-    public async getDefinition(fileLanguage: string, filePath: string, line: number, column: number): Promise<IDefinitionResult> {
+    public async getDefinition(
+        fileLanguage: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<IDefinitionResult> {
         const args = { ...Helpers.createTextDocumentPositionParams(filePath, line, column) }
 
         const token: Oni.IToken = await this._editor.activeBuffer.getTokenAt(line, column)
@@ -43,7 +49,12 @@ export class LanguageServiceDefinitionRequestor {
 
         let result: types.Location | types.Location[] = null
         try {
-            result = await this._languageManager.sendLanguageServerRequest(fileLanguage, filePath, "textDocument/definition", args)
+            result = await this._languageManager.sendLanguageServerRequest(
+                fileLanguage,
+                filePath,
+                "textDocument/definition",
+                args,
+            )
         } catch (ex) {
             Log.warn(ex)
         }
@@ -55,7 +66,9 @@ export class LanguageServiceDefinitionRequestor {
     }
 }
 
-export const getFirstLocationFromArray = (result: types.Location | types.Location[]): types.Location => {
+export const getFirstLocationFromArray = (
+    result: types.Location | types.Location[],
+): types.Location => {
     if (!result) {
         return null
     }

--- a/browser/src/Services/Language/Edits.ts
+++ b/browser/src/Services/Language/Edits.ts
@@ -8,12 +8,17 @@ import * as orderBy from "lodash/orderBy"
 import * as types from "vscode-languageserver-types"
 
 export const sortTextEdits = (edits: types.TextEdit[]): types.TextEdit[] => {
-    const sortedEdits = orderBy(edits, [(e) => e.range.start.line, (e) => e.range.start.character], ["desc", "desc"])
+    const sortedEdits = orderBy(
+        edits,
+        [e => e.range.start.line, e => e.range.start.character],
+        ["desc", "desc"],
+    )
     return sortedEdits
 }
 
-export const convertTextDocumentEditsToFileMap = (edits: types.TextDocumentEdit[]): { [fileUri: string]: types.TextEdit[] } => {
-
+export const convertTextDocumentEditsToFileMap = (
+    edits: types.TextDocumentEdit[],
+): { [fileUri: string]: types.TextEdit[] } => {
     if (!edits) {
         return {}
     }

--- a/browser/src/Services/Language/FindAllReferences.ts
+++ b/browser/src/Services/Language/FindAllReferences.ts
@@ -16,7 +16,6 @@ import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpe
 // - Factor out event context to something simpler
 // - Remove plugin manager
 export const findAllReferences = async () => {
-
     const activeEditor = editorManager.activeEditor
 
     if (!activeEditor) {
@@ -31,20 +30,30 @@ export const findAllReferences = async () => {
 
     const languageManager = LanguageManager.getInstance()
     if (languageManager.isLanguageServerAvailable(activeBuffer.language)) {
-        const args = { ...Helpers.bufferToTextDocumentPositionParams(activeBuffer),
-                       context: {
+        const args = {
+            ...Helpers.bufferToTextDocumentPositionParams(activeBuffer),
+            context: {
                 includeDeclaration: true,
             },
         }
 
         const { line, column } = activeBuffer.cursor
         const token = await activeBuffer.getTokenAt(line, column)
-        const result: types.Location[] = await languageManager.sendLanguageServerRequest(activeBuffer.language, activeBuffer.filePath, "textDocument/references", args)
+        const result: types.Location[] = await languageManager.sendLanguageServerRequest(
+            activeBuffer.language,
+            activeBuffer.filePath,
+            "textDocument/references",
+            args,
+        )
         showReferencesInQuickFix(token.tokenName, result, activeEditor.neovim as any)
     }
 }
 
-export const showReferencesInQuickFix = async (token: string, locations: types.Location[], neovimInstance: INeovimInstance) => {
+export const showReferencesInQuickFix = async (
+    token: string,
+    locations: types.Location[],
+    neovimInstance: INeovimInstance,
+) => {
     const convertToOneIndexedForQuickFix = (location: types.Location) => ({
         filename: Helpers.unwrapFileUriPath(location.uri),
         lnum: location.range.start.line + 1,
@@ -52,7 +61,7 @@ export const showReferencesInQuickFix = async (token: string, locations: types.L
         text: token,
     })
 
-    const quickFixItems = locations.map((item) => convertToOneIndexedForQuickFix(item))
+    const quickFixItems = locations.map(item => convertToOneIndexedForQuickFix(item))
 
     neovimInstance.quickFix.setqflist(quickFixItems, ` Find All References: ${token}`)
     neovimInstance.command("copen")

--- a/browser/src/Services/Language/Formatting.ts
+++ b/browser/src/Services/Language/Formatting.ts
@@ -12,10 +12,11 @@ import { editorManager } from "./../EditorManager"
 import * as LanguageManager from "./LanguageManager"
 
 export const format = async () => {
-
     const activeBuffer = editorManager.activeEditor.activeBuffer
 
-    const capabilities = await LanguageManager.getInstance().getCapabilitiesForLanguage(activeBuffer.language)
+    const capabilities = await LanguageManager.getInstance().getCapabilitiesForLanguage(
+        activeBuffer.language,
+    )
 
     if (capabilities.documentFormattingProvider) {
         await formatDocument()
@@ -37,7 +38,12 @@ export const formatDocument = async () => {
 
     let result: types.TextEdit[] = null
     try {
-        result = await LanguageManager.getInstance().sendLanguageServerRequest(activeBuffer.language, activeBuffer.filePath, "textDocument/formatting", args)
+        result = await LanguageManager.getInstance().sendLanguageServerRequest(
+            activeBuffer.language,
+            activeBuffer.filePath,
+            "textDocument/formatting",
+            args,
+        )
     } catch (ex) {
         Log.warn(ex)
     }
@@ -45,7 +51,6 @@ export const formatDocument = async () => {
     if (result) {
         await activeBuffer.applyTextEdits(result)
     }
-
 }
 
 export const rangeFormatDocument = async () => {
@@ -60,7 +65,12 @@ export const rangeFormatDocument = async () => {
 
     let result: types.TextEdit[] = null
     try {
-        result = await LanguageManager.getInstance().sendLanguageServerRequest(activeBuffer.language, activeBuffer.filePath, "textDocument/rangeFormatting", args)
+        result = await LanguageManager.getInstance().sendLanguageServerRequest(
+            activeBuffer.language,
+            activeBuffer.filePath,
+            "textDocument/rangeFormatting",
+            args,
+        )
     } catch (ex) {
         Log.warn(ex)
     }

--- a/browser/src/Services/Language/HoverRequestor.ts
+++ b/browser/src/Services/Language/HoverRequestor.ts
@@ -19,23 +19,35 @@ export interface IHoverResult {
 }
 
 export interface IHoverRequestor {
-    getHover(fileLanguage: string, filePath: string, line: number, column: number): Promise<IHoverResult>
+    getHover(
+        fileLanguage: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<IHoverResult>
 }
 
 export class LanguageServiceHoverRequestor {
+    constructor(private _languageManager: LanguageManager) {}
 
-    constructor(
-        private _languageManager: LanguageManager,
-    ) { }
-
-    public async getHover(language: string, filePath: string, line: number, column: number): Promise<IHoverResult> {
+    public async getHover(
+        language: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<IHoverResult> {
         const args = { ...Helpers.createTextDocumentPositionParams(filePath, line, column) }
 
         let result: types.Hover = null
 
         if (this._languageManager.isLanguageServerAvailable(language)) {
             try {
-                result = await this._languageManager.sendLanguageServerRequest(language, filePath, "textDocument/hover", args)
+                result = await this._languageManager.sendLanguageServerRequest(
+                    language,
+                    filePath,
+                    "textDocument/hover",
+                    args,
+                )
             } catch (ex) {
                 Log.warn(ex)
             }

--- a/browser/src/Services/Language/LanguageClientStatusBar.tsx
+++ b/browser/src/Services/Language/LanguageClientStatusBar.tsx
@@ -12,19 +12,21 @@ import * as Oni from "oni-api"
 import { Icon } from "./../../UI/Icon"
 
 export class LanguageClientStatusBar {
-
     private _item: Oni.StatusBarItem
     private _fileType: string
 
-    constructor(
-        private _statusBar: Oni.StatusBar,
-    ) {
+    constructor(private _statusBar: Oni.StatusBar) {
         this._item = this._statusBar.createItem(0, "oni.status.fileType")
     }
 
     public show(fileType: string): void {
         this._fileType = fileType
-        this._item.setContents(<StatusBarRenderer state={LanguageClientState.NotAvailable} language={this._fileType} />)
+        this._item.setContents(
+            <StatusBarRenderer
+                state={LanguageClientState.NotAvailable}
+                language={this._fileType}
+            />,
+        )
         this._item.show()
     }
 
@@ -102,10 +104,16 @@ const StatusBarRenderer = (props: StatusBarRendererProps) => {
 
     const iconName = getIconFromStatus(props.state)
 
-    const icon = iconName ? <span style={iconStyle}><Icon name={iconName} className={getClassNameFromstatus(props.state)} /></span> : null
+    const icon = iconName ? (
+        <span style={iconStyle}>
+            <Icon name={iconName} className={getClassNameFromstatus(props.state)} />
+        </span>
+    ) : null
 
-    return <div style={containerStyle} onClick={onClick}>
-        {icon}
-        <span>{props.language}</span>
-    </div>
+    return (
+        <div style={containerStyle} onClick={onClick}>
+            {icon}
+            <span>{props.language}</span>
+        </div>
+    )
 }

--- a/browser/src/Services/Language/LanguageClientTypes.ts
+++ b/browser/src/Services/Language/LanguageClientTypes.ts
@@ -1,4 +1,3 @@
-
 import * as types from "vscode-languageserver-types"
 
 import { IServerCapabilities } from "./ServerCapabilities"

--- a/browser/src/Services/Language/LanguageConfiguration.ts
+++ b/browser/src/Services/Language/LanguageConfiguration.ts
@@ -7,7 +7,11 @@
 import * as Log from "./../../Log"
 
 import { LanguageClient } from "./LanguageClient"
-import { InitializationOptions, LanguageClientProcess, ServerRunOptions } from "./LanguageClientProcess"
+import {
+    InitializationOptions,
+    LanguageClientProcess,
+    ServerRunOptions,
+} from "./LanguageClientProcess"
 import * as LanguageManager from "./LanguageManager"
 
 import { getRootProjectFileFunc } from "./../../Utility"
@@ -23,34 +27,42 @@ export interface ILightweightLanguageServerConfiguration {
     configuration?: any
 }
 
-export const createLanguageClientsFromConfiguration = (configurationValues: { [key: string]: any }) => {
+export const createLanguageClientsFromConfiguration = (configurationValues: {
+    [key: string]: any
+}) => {
     const languageInfo = expandLanguageConfiguration(configurationValues)
     const languages = Object.keys(languageInfo)
 
-    languages.forEach((lang) => {
+    languages.forEach(lang => {
         createLanguageClientFromConfig(lang, languageInfo[lang])
     })
 }
 
 const expandLanguageConfiguration = (configuration: { [key: string]: any }) => {
-
     // Filter for all `language.` keys, ie `language.go.languageServerCommand`
-    const keys = Object.keys(configuration).filter((k) => k.indexOf("language.") === 0)
+    const keys = Object.keys(configuration).filter(k => k.indexOf("language.") === 0)
 
     if (keys.length === 0) {
         return {}
     }
 
     const expanded = keys.reduce<any>((prev, current) => {
-
-        const newValue = expandConfigurationSetting(prev, current.split("."), configuration[current])
+        const newValue = expandConfigurationSetting(
+            prev,
+            current.split("."),
+            configuration[current],
+        )
         return newValue
     }, {})
 
     return expanded.language
 }
 
-const expandConfigurationSetting = (rootObject: any, configurationPath: string[], value: string): any  => {
+const expandConfigurationSetting = (
+    rootObject: any,
+    configurationPath: string[],
+    value: string,
+): any => {
     if (!configurationPath || !configurationPath.length) {
         return value
     }
@@ -67,7 +79,10 @@ const expandConfigurationSetting = (rootObject: any, configurationPath: string[]
 
 const simplePathResolver = (filePath: string) => Promise.resolve(filePath)
 
-const createLanguageClientFromConfig = (language: string, config: ILightweightLanguageConfiguration): void => {
+const createLanguageClientFromConfig = (
+    language: string,
+    config: ILightweightLanguageConfiguration,
+): void => {
     if (!config || !config.languageServer || !config.languageServer.command) {
         return
     }
@@ -77,9 +92,15 @@ const createLanguageClientFromConfig = (language: string, config: ILightweightLa
     const args = config.languageServer.arguments || []
     const configuration = config.languageServer.configuration || null
 
-    Log.info(`[Language Manager - Config] Registering info for language: ${language} - command: ${config.languageServer.command}`)
+    Log.info(
+        `[Language Manager - Config] Registering info for language: ${language} - command: ${
+            config.languageServer.command
+        }`,
+    )
 
-    const commandOrModule = lightweightCommand.endsWith(".js") ? { module: lightweightCommand } : { command: lightweightCommand }
+    const commandOrModule = lightweightCommand.endsWith(".js")
+        ? { module: lightweightCommand }
+        : { command: lightweightCommand }
 
     let pathResolver = simplePathResolver
 
@@ -96,6 +117,9 @@ const createLanguageClientFromConfig = (language: string, config: ILightweightLa
     const initializationOptions: InitializationOptions = {
         rootPath: pathResolver,
     }
-    const languageClient = new LanguageClient(language, new LanguageClientProcess(serverRunOptions, initializationOptions, configuration))
+    const languageClient = new LanguageClient(
+        language,
+        new LanguageClientProcess(serverRunOptions, initializationOptions, configuration),
+    )
     LanguageManager.getInstance().registerLanguageClient(language, languageClient)
 }

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -34,7 +34,6 @@ export interface ILanguageServerNotificationResponse {
 }
 
 export class LanguageManager {
-
     private _languageServerInfo: { [language: string]: ILanguageClient } = {}
     private _notificationSubscriptions: { [notificationMessage: string]: Event<any> } = {}
     private _requestHandlers: { [request: string]: LanguageClientTypes.RequestHandler } = {}
@@ -47,83 +46,102 @@ export class LanguageManager {
         private _statusBar: Oni.StatusBar,
         private _workspace: IWorkspace,
     ) {
-
         this._languageClientStatusBar = new LanguageClientStatusBar(this._statusBar)
 
         this._editorManager.allEditors.onBufferEnter.subscribe(async () => this._onBufferEnter())
 
-        this._editorManager.allEditors.onBufferLeave.subscribe((bufferInfo: Oni.EditorBufferEventArgs) => {
-            const { language, filePath } = bufferInfo
+        this._editorManager.allEditors.onBufferLeave.subscribe(
+            (bufferInfo: Oni.EditorBufferEventArgs) => {
+                const { language, filePath } = bufferInfo
 
-            if (this._currentTrackedFile !== filePath) {
-                return
-            }
-
-            this.sendLanguageServerNotification(language, filePath, "textDocument/didClose", Helpers.pathToTextDocumentIdentifierParms(filePath))
-        })
-
-        this._editorManager.allEditors.onBufferChanged.subscribe(async (change: Oni.EditorBufferChangedEventArgs) => {
-
-            const { language, filePath } = change.buffer
-
-            if (this._currentTrackedFile !== filePath) {
-                return
-            }
-
-            const sendBufferThunk = async (capabilities: IServerCapabilities) => {
-                const textDocument = {
-                    uri: Helpers.wrapPathInFileUri(filePath),
-                    version: change.buffer.version,
+                if (this._currentTrackedFile !== filePath) {
+                    return
                 }
 
-                // If the service supports incremental capabilities, just pass it directly
-                if (capabilities.textDocumentSync === 2) {
-                    return {
-                        textDocument,
-                        contentChanges: change.contentChanges,
-                    }
-                    // Otherwise, get the whole buffer and send it up
-                } else {
-                    const allBufferLines = await change.buffer.getLines()
+                this.sendLanguageServerNotification(
+                    language,
+                    filePath,
+                    "textDocument/didClose",
+                    Helpers.pathToTextDocumentIdentifierParms(filePath),
+                )
+            },
+        )
 
-                    return {
-                        textDocument,
-                        contentChanges: [{ text: allBufferLines.join(os.EOL) }],
+        this._editorManager.allEditors.onBufferChanged.subscribe(
+            async (change: Oni.EditorBufferChangedEventArgs) => {
+                const { language, filePath } = change.buffer
+
+                if (this._currentTrackedFile !== filePath) {
+                    return
+                }
+
+                const sendBufferThunk = async (capabilities: IServerCapabilities) => {
+                    const textDocument = {
+                        uri: Helpers.wrapPathInFileUri(filePath),
+                        version: change.buffer.version,
+                    }
+
+                    // If the service supports incremental capabilities, just pass it directly
+                    if (capabilities.textDocumentSync === 2) {
+                        return {
+                            textDocument,
+                            contentChanges: change.contentChanges,
+                        }
+                        // Otherwise, get the whole buffer and send it up
+                    } else {
+                        const allBufferLines = await change.buffer.getLines()
+
+                        return {
+                            textDocument,
+                            contentChanges: [{ text: allBufferLines.join(os.EOL) }],
+                        }
                     }
                 }
-            }
 
-            this.sendLanguageServerNotification(language, filePath, "textDocument/didChange", sendBufferThunk)
-        })
+                this.sendLanguageServerNotification(
+                    language,
+                    filePath,
+                    "textDocument/didChange",
+                    sendBufferThunk,
+                )
+            },
+        )
 
-        this._editorManager.allEditors.onBufferSaved.subscribe((bufferInfo: Oni.EditorBufferEventArgs) => {
-            const { language, filePath } = bufferInfo
+        this._editorManager.allEditors.onBufferSaved.subscribe(
+            (bufferInfo: Oni.EditorBufferEventArgs) => {
+                const { language, filePath } = bufferInfo
 
-            if (this._currentTrackedFile !== filePath) {
-                return
-            }
+                if (this._currentTrackedFile !== filePath) {
+                    return
+                }
 
-            this.sendLanguageServerNotification(language, filePath, "textDocument/didSave", Helpers.pathToTextDocumentIdentifierParms(filePath))
-        })
+                this.sendLanguageServerNotification(
+                    language,
+                    filePath,
+                    "textDocument/didSave",
+                    Helpers.pathToTextDocumentIdentifierParms(filePath),
+                )
+            },
+        )
 
-        this.subscribeToLanguageServerNotification("window/showMessage", (args) => {
+        this.subscribeToLanguageServerNotification("window/showMessage", args => {
             Log.warn("window/showMessage not implemented: " + JSON.stringify(args.toString()))
         })
 
-        this.subscribeToLanguageServerNotification("window/logMessage", (args) => {
+        this.subscribeToLanguageServerNotification("window/logMessage", args => {
             logVerbose(args)
         })
 
-        this.subscribeToLanguageServerNotification("telemetry/event", (args) => {
+        this.subscribeToLanguageServerNotification("telemetry/event", args => {
             logDebug(args)
         })
 
-        this.handleLanguageServerRequest("workspace/configuration", async (req) => {
+        this.handleLanguageServerRequest("workspace/configuration", async req => {
             Log.warn("workspace/configuration not implemented: " + JSON.stringify(req.toString()))
             return null
         })
 
-        this.handleLanguageServerRequest("window/showMessageRequest", async (req) => {
+        this.handleLanguageServerRequest("window/showMessageRequest", async req => {
             logVerbose(req)
             return null
         })
@@ -142,7 +160,9 @@ export class LanguageManager {
     }
 
     public getTokenRegex(language: string): RegExp {
-        const languageSpecificTokenRegex = this._configuration.getValue(`language.${language}.tokenRegex`) as RegExp
+        const languageSpecificTokenRegex = this._configuration.getValue(
+            `language.${language}.tokenRegex`,
+        ) as RegExp
 
         if (languageSpecificTokenRegex) {
             return RegExp(languageSpecificTokenRegex, "i")
@@ -156,7 +176,9 @@ export class LanguageManager {
     }
 
     public getCompletionTriggerCharacters(language: string): string[] {
-        const languageSpecificTriggerChars = this._configuration.getValue(`language.${language}.completionTriggerCharacters`) as string[]
+        const languageSpecificTriggerChars = this._configuration.getValue(
+            `language.${language}.completionTriggerCharacters`,
+        ) as string[]
 
         if (languageSpecificTriggerChars) {
             return languageSpecificTriggerChars
@@ -169,7 +191,12 @@ export class LanguageManager {
         return !!this._getLanguageClient(language)
     }
 
-    public async sendLanguageServerNotification(language: string, filePath: string, protocolMessage: string, protocolPayload: LanguageClientTypes.NotificationValueOrThunk): Promise<void> {
+    public async sendLanguageServerNotification(
+        language: string,
+        filePath: string,
+        protocolMessage: string,
+        protocolPayload: LanguageClientTypes.NotificationValueOrThunk,
+    ): Promise<void> {
         const languageClient = this._getLanguageClient(language)
 
         await this._simulateFakeLag()
@@ -181,16 +208,30 @@ export class LanguageManager {
         }
     }
 
-    public async sendLanguageServerRequest(language: string, filePath: string, protocolMessage: string, protocolPayload: LanguageClientTypes.NotificationValueOrThunk): Promise<any> {
+    public async sendLanguageServerRequest(
+        language: string,
+        filePath: string,
+        protocolMessage: string,
+        protocolPayload: LanguageClientTypes.NotificationValueOrThunk,
+    ): Promise<any> {
         const languageClient = this._getLanguageClient(language)
 
-        Log.verbose("[LANGUAGE] Sending request: " + protocolMessage + "|" + JSON.stringify(protocolPayload))
+        Log.verbose(
+            "[LANGUAGE] Sending request: " +
+                protocolMessage +
+                "|" +
+                JSON.stringify(protocolPayload),
+        )
 
         await this._simulateFakeLag()
 
         if (languageClient) {
             try {
-                const result = await languageClient.sendRequest(filePath, protocolMessage, protocolPayload)
+                const result = await languageClient.sendRequest(
+                    filePath,
+                    protocolMessage,
+                    protocolPayload,
+                )
                 this._setStatus(protocolMessage, LanguageClientState.Active)
                 return result
             } catch (ex) {
@@ -204,8 +245,10 @@ export class LanguageManager {
     }
 
     // Register a handler for requests incoming from the language server
-    public handleLanguageServerRequest(protocolMessage: string, callback: (args: ILanguageServerNotificationResponse) => Promise<any>): void {
-
+    public handleLanguageServerRequest(
+        protocolMessage: string,
+        callback: (args: ILanguageServerNotificationResponse) => Promise<any>,
+    ): void {
         const currentHandler = this._requestHandlers[protocolMessage]
 
         if (currentHandler) {
@@ -215,13 +258,15 @@ export class LanguageManager {
         this._requestHandlers[protocolMessage] = callback
 
         const languageClients = Object.values(this._languageServerInfo)
-        languageClients.forEach((ls) => {
+        languageClients.forEach(ls => {
             ls.handleRequest(protocolMessage, callback)
         })
     }
 
-    public subscribeToLanguageServerNotification(protocolMessage: string, callback: (args: ILanguageServerNotificationResponse) => void): IDisposable {
-
+    public subscribeToLanguageServerNotification(
+        protocolMessage: string,
+        callback: (args: ILanguageServerNotificationResponse) => void,
+    ): IDisposable {
         const currentSubscription = this._notificationSubscriptions[protocolMessage]
 
         if (!currentSubscription) {
@@ -229,13 +274,13 @@ export class LanguageManager {
             this._notificationSubscriptions[protocolMessage] = evt
 
             const languageClients = Object.values(this._languageServerInfo)
-            languageClients.forEach((ls) => {
+            languageClients.forEach(ls => {
                 ls.subscribe(protocolMessage, evt)
             })
 
-            return evt.subscribe((args) => callback(args))
+            return evt.subscribe(args => callback(args))
         } else {
-            return currentSubscription.subscribe((args) => callback(args))
+            return currentSubscription.subscribe(args => callback(args))
         }
     }
 
@@ -253,11 +298,11 @@ export class LanguageManager {
             return
         }
 
-        Object.keys(this._notificationSubscriptions).forEach((notification) => {
+        Object.keys(this._notificationSubscriptions).forEach(notification => {
             languageClient.subscribe(notification, this._notificationSubscriptions[notification])
         })
 
-        Object.keys(this._requestHandlers).forEach((request) => {
+        Object.keys(this._requestHandlers).forEach(request => {
             languageClient.handleRequest(request, this._requestHandlers[request])
         })
 
@@ -265,8 +310,10 @@ export class LanguageManager {
 
         // If there is already a buffer open matching this language,
         // we should send a buffer open event
-        if (this._editorManager.activeEditor.activeBuffer
-            && this._editorManager.activeEditor.activeBuffer.language === language) {
+        if (
+            this._editorManager.activeEditor.activeBuffer &&
+            this._editorManager.activeEditor.activeBuffer.language === language
+        ) {
             this._onBufferEnter()
         }
     }
@@ -292,18 +339,25 @@ export class LanguageManager {
 
         if (buffer.lineCount > this._configuration.getValue("editor.maxLinesForLanguageServices")) {
             this._languageClientStatusBar.setStatus(LanguageClientState.NotAvailable)
-            Log.info("[LanguageManager] Not sending 'didOpen' because file line count exceeds limit.")
+            Log.info(
+                "[LanguageManager] Not sending 'didOpen' because file line count exceeds limit.",
+            )
             return
         }
 
-        this.sendLanguageServerNotification(language, filePath, "textDocument/didOpen", async () => {
-            this._currentTrackedFile = filePath
-            const lines = await this._editorManager.activeEditor.activeBuffer.getLines()
-            const text = lines.join(os.EOL)
-            const version = this._editorManager.activeEditor.activeBuffer.version
-            this._languageClientStatusBar.setStatus(LanguageClientState.Active)
-            return Helpers.pathToTextDocumentItemParams(filePath, language, text, version)
-        })
+        this.sendLanguageServerNotification(
+            language,
+            filePath,
+            "textDocument/didOpen",
+            async () => {
+                this._currentTrackedFile = filePath
+                const lines = await this._editorManager.activeEditor.activeBuffer.getLines()
+                const text = lines.join(os.EOL)
+                const version = this._editorManager.activeEditor.activeBuffer.version
+                this._languageClientStatusBar.setStatus(LanguageClientState.Active)
+                return Helpers.pathToTextDocumentItemParams(filePath, language, text, version)
+            },
+        )
     }
 
     private _getLanguageClient(language: string): ILanguageClient {
@@ -323,7 +377,6 @@ export class LanguageManager {
     }
 
     private _setStatus(protocolMessage: string, status: LanguageClientState): void {
-
         switch (protocolMessage) {
             case "textDocument/didOpen":
             case "textDocument/didChange":
@@ -358,7 +411,12 @@ const logDebug = (args: any) => {
 
 let _languageManager: LanguageManager = null
 
-export const activate = (configuration: Oni.Configuration, editorManager: Oni.EditorManager, statusBar: Oni.StatusBar, workspace: IWorkspace): void => {
+export const activate = (
+    configuration: Oni.Configuration,
+    editorManager: Oni.EditorManager,
+    statusBar: Oni.StatusBar,
+    workspace: IWorkspace,
+): void => {
     _languageManager = new LanguageManager(configuration, editorManager, statusBar, workspace)
 }
 

--- a/browser/src/Services/Language/LanguageStore.ts
+++ b/browser/src/Services/Language/LanguageStore.ts
@@ -76,35 +76,39 @@ export const DefaultLanguageState: ILanguageState = {
     definitionResult: DefaultLocationBasedResult,
 }
 
-export type LanguageAction = {
-    type: "MODE_CHANGED",
-    mode: string,
-} | {
-        type: "CURSOR_MOVED",
-        line: number,
-        column: number,
-    } | {
-        type: "BUFFER_ENTER",
-        filePath: string,
-        language: string,
-    } | {
-        type: "HOVER_QUERY",
-        location: ILocation,
-    } | {
-        type: "DEFINITION_QUERY",
-        location: ILocation,
-    } | {
-        type: "HOVER_QUERY_RESULT",
-        result: ILocationBasedResult<IHoverResult>,
-    } | {
-        type: "DEFINITION_QUERY_RESULT",
-        result: ILocationBasedResult<IDefinitionResult>,
-    }
+export type LanguageAction =
+    | {
+          type: "MODE_CHANGED"
+          mode: string
+      }
+    | {
+          type: "CURSOR_MOVED"
+          line: number
+          column: number
+      }
+    | {
+          type: "BUFFER_ENTER"
+          filePath: string
+          language: string
+      }
+    | {
+          type: "HOVER_QUERY"
+          location: ILocation
+      }
+    | {
+          type: "DEFINITION_QUERY"
+          location: ILocation
+      }
+    | {
+          type: "HOVER_QUERY_RESULT"
+          result: ILocationBasedResult<IHoverResult>
+      }
+    | {
+          type: "DEFINITION_QUERY_RESULT"
+          result: ILocationBasedResult<IDefinitionResult>
+      }
 
-export const modeReducer: Reducer<string> = (
-    state: string = null,
-    action: LanguageAction,
-) => {
+export const modeReducer: Reducer<string> = (state: string = null, action: LanguageAction) => {
     switch (action.type) {
         case "MODE_CHANGED":
             return action.mode
@@ -185,24 +189,37 @@ export const languageStateReducer = combineReducers<ILanguageState>({
     hoverResult: hoverResultReducer,
 })
 
-export const createStore = (configuration: Configuration, hoverRequestor: IHoverRequestor, definitionRequestor: IDefinitionRequestor): Store<ILanguageState> => {
+export const createStore = (
+    configuration: Configuration,
+    hoverRequestor: IHoverRequestor,
+    definitionRequestor: IDefinitionRequestor,
+): Store<ILanguageState> => {
+    const epicMiddleware = createEpicMiddleware(
+        combineEpics(
+            queryForDefinitionEpic(configuration),
+            queryForHoverEpic(configuration),
+            queryDefinitionEpic(definitionRequestor),
+            queryHoverEpic(hoverRequestor),
+        ),
+    )
 
-    const epicMiddleware = createEpicMiddleware(combineEpics(
-        queryForDefinitionEpic(configuration),
-        queryForHoverEpic(configuration),
-        queryDefinitionEpic(definitionRequestor),
-        queryHoverEpic(hoverRequestor),
-    ))
-
-    return oniCreateStore<ILanguageState>("LANGUAGE", languageStateReducer, DefaultLanguageState, [epicMiddleware])
+    return oniCreateStore<ILanguageState>("LANGUAGE", languageStateReducer, DefaultLanguageState, [
+        epicMiddleware,
+    ])
 }
-export const queryForHoverEpic = (configuration: Configuration): Epic<LanguageAction, ILanguageState> => (action$, store) =>
-    action$.ofType("CURSOR_MOVED")
-        .filter(() => store.getState().mode === "normal" && configuration.getValue("editor.quickInfo.enabled"))
+export const queryForHoverEpic = (
+    configuration: Configuration,
+): Epic<LanguageAction, ILanguageState> => (action$, store) =>
+    action$
+        .ofType("CURSOR_MOVED")
+        .filter(
+            () =>
+                store.getState().mode === "normal" &&
+                configuration.getValue("editor.quickInfo.enabled"),
+        )
         .debounceTime(configuration.getValue("editor.quickInfo.delay"))
         .filter(() => store.getState().mode === "normal")
         .map((action: LanguageAction) => {
-
             const currentState = store.getState()
             const filePath = currentState.activeBuffer.filePath
             const language = currentState.activeBuffer.language
@@ -222,11 +239,17 @@ export const queryForHoverEpic = (configuration: Configuration): Epic<LanguageAc
             } as LanguageAction
         })
 
-export const queryForDefinitionEpic = (configuration: Configuration): Epic<LanguageAction, ILanguageState> => (action$, store) =>
-    action$.ofType("CURSOR_MOVED")
-        .filter(() => store.getState().mode === "normal" && configuration.getValue("editor.definition.enabled"))
+export const queryForDefinitionEpic = (
+    configuration: Configuration,
+): Epic<LanguageAction, ILanguageState> => (action$, store) =>
+    action$
+        .ofType("CURSOR_MOVED")
+        .filter(
+            () =>
+                store.getState().mode === "normal" &&
+                configuration.getValue("editor.definition.enabled"),
+        )
         .map((action: LanguageAction) => {
-
             const currentState = store.getState()
             const filePath = currentState.activeBuffer.filePath
             const language = currentState.activeBuffer.language
@@ -248,25 +271,36 @@ export const queryForDefinitionEpic = (configuration: Configuration): Epic<Langu
 
 export const NullAction = { type: null } as LanguageAction
 
-export const doesLocationBasedResultMatchCursorPosition = (result: ILocationBasedResult<any>, state: ILanguageState) => {
-    return result.filePath === state.activeBuffer.filePath
-    && result.line === state.cursor.line
-    && result.column === state.cursor.column
-    && state.mode === "normal"
+export const doesLocationBasedResultMatchCursorPosition = (
+    result: ILocationBasedResult<any>,
+    state: ILanguageState,
+) => {
+    return (
+        result.filePath === state.activeBuffer.filePath &&
+        result.line === state.cursor.line &&
+        result.column === state.cursor.column &&
+        state.mode === "normal"
+    )
 }
 
-export const queryDefinitionEpic = (definitionRequestor: IDefinitionRequestor): Epic<LanguageAction, ILanguageState> => (action$, store) =>
-    action$.ofType("DEFINITION_QUERY")
+export const queryDefinitionEpic = (
+    definitionRequestor: IDefinitionRequestor,
+): Epic<LanguageAction, ILanguageState> => (action$, store) =>
+    action$
+        .ofType("DEFINITION_QUERY")
         .switchMap(() => {
-
             const state = store.getState()
 
             const { filePath, language } = state.activeBuffer
             const { line, column } = state.cursor
 
             return Observable.defer(async () => {
-
-                const result = await definitionRequestor.getDefinition(language, filePath, line, column)
+                const result = await definitionRequestor.getDefinition(
+                    language,
+                    filePath,
+                    line,
+                    column,
+                )
                 return {
                     type: "DEFINITION_QUERY_RESULT",
                     result: {
@@ -279,7 +313,7 @@ export const queryDefinitionEpic = (definitionRequestor: IDefinitionRequestor): 
                 } as LanguageAction
             })
         })
-        .filter((action) => {
+        .filter(action => {
             if (action.type !== "DEFINITION_QUERY_RESULT") {
                 return false
             }
@@ -287,8 +321,11 @@ export const queryDefinitionEpic = (definitionRequestor: IDefinitionRequestor): 
             return doesLocationBasedResultMatchCursorPosition(action.result, store.getState())
         })
 
-export const queryHoverEpic = (hoverRequestor: IHoverRequestor): Epic<LanguageAction, ILanguageState> => (action$, store) =>
-    action$.ofType("HOVER_QUERY")
+export const queryHoverEpic = (
+    hoverRequestor: IHoverRequestor,
+): Epic<LanguageAction, ILanguageState> => (action$, store) =>
+    action$
+        .ofType("HOVER_QUERY")
         .switchMap(() => {
             const state = store.getState()
 
@@ -309,7 +346,7 @@ export const queryHoverEpic = (hoverRequestor: IHoverRequestor): Epic<LanguageAc
                 } as LanguageAction
             })
         })
-        .filter((action) => {
+        .filter(action => {
             if (action.type !== "HOVER_QUERY_RESULT") {
                 return false
             }

--- a/browser/src/Services/Language/PromiseQueue.ts
+++ b/browser/src/Services/Language/PromiseQueue.ts
@@ -3,18 +3,21 @@ import * as Log from "./../../Log"
 export class PromiseQueue {
     private _currentPromise: Promise<any> = Promise.resolve(null)
 
-    public enqueuePromise<T>(functionThatReturnsPromiseOrThenable: () => Promise<T> | Thenable<T>, requireConnection: boolean = true): Promise<T> {
-
+    public enqueuePromise<T>(
+        functionThatReturnsPromiseOrThenable: () => Promise<T> | Thenable<T>,
+        requireConnection: boolean = true,
+    ): Promise<T> {
         const promiseExecutor = () => {
             return functionThatReturnsPromiseOrThenable()
         }
 
-        const newPromise = this._currentPromise
-            .then(() => promiseExecutor(),
-            (err) => {
+        const newPromise = this._currentPromise.then(
+            () => promiseExecutor(),
+            err => {
                 Log.error(err)
                 return promiseExecutor()
-            })
+            },
+        )
 
         this._currentPromise = newPromise
         return newPromise

--- a/browser/src/Services/Language/RenameView.tsx
+++ b/browser/src/Services/Language/RenameView.tsx
@@ -14,11 +14,11 @@ export interface IRenameViewProps {
 }
 
 export class RenameView extends React.PureComponent<IRenameViewProps, {}> {
-
     public render(): JSX.Element {
-
-        return <div className="rename">
-                    <TextInput {...this.props} defaultValue={this.props.tokenName} />
-                </div>
+        return (
+            <div className="rename">
+                <TextInput {...this.props} defaultValue={this.props.tokenName} />
+            </div>
+        )
     }
 }

--- a/browser/src/Services/Language/ServerCapabilities.ts
+++ b/browser/src/Services/Language/ServerCapabilities.ts
@@ -9,202 +9,202 @@
  * Defines how the host (editor) should sync document changes to the language server.
  */
 export namespace TextDocumentSyncKind {
-   /**
-    * Documents should not be synced at all.
-    */
-   export const None = 0
+    /**
+     * Documents should not be synced at all.
+     */
+    export const None = 0
 
-   /**
-    * Documents are synced by always sending the full content
-    * of the document.
-    */
-   export const Full = 1
+    /**
+     * Documents are synced by always sending the full content
+     * of the document.
+     */
+    export const Full = 1
 
-   /**
-    * Documents are synced by sending the full content on open.
-    * After that only incremental updates to the document are
-    * send.
-    */
-   export const Incremental = 2
+    /**
+     * Documents are synced by sending the full content on open.
+     * After that only incremental updates to the document are
+     * send.
+     */
+    export const Incremental = 2
 }
 
 /**
  * Completion options.
  */
 export interface CompletionOptions {
-   /**
-    * The server provides support to resolve additional
-    * information for a completion item.
-    */
-   resolveProvider?: boolean
+    /**
+     * The server provides support to resolve additional
+     * information for a completion item.
+     */
+    resolveProvider?: boolean
 
-   /**
-    * The characters that trigger completion automatically.
-    */
-   triggerCharacters?: string[]
+    /**
+     * The characters that trigger completion automatically.
+     */
+    triggerCharacters?: string[]
 }
 /**
  * Signature help options.
  */
 export interface SignatureHelpOptions {
-   /**
-    * The characters that trigger signature help
-    * automatically.
-    */
-   triggerCharacters?: string[]
+    /**
+     * The characters that trigger signature help
+     * automatically.
+     */
+    triggerCharacters?: string[]
 }
 
 /**
  * Code Lens options.
  */
 export interface CodeLensOptions {
-   /**
-    * Code lens has a resolve provider as well.
-    */
-   resolveProvider?: boolean
+    /**
+     * Code lens has a resolve provider as well.
+     */
+    resolveProvider?: boolean
 }
 
 /**
  * Format document on type options
  */
 export interface DocumentOnTypeFormattingOptions {
-   /**
-    * A character on which formatting should be triggered, like `}`.
-    */
-   firstTriggerCharacter: string
+    /**
+     * A character on which formatting should be triggered, like `}`.
+     */
+    firstTriggerCharacter: string
 
-   /**
-    * More trigger characters.
-    */
-   moreTriggerCharacter?: string[]
+    /**
+     * More trigger characters.
+     */
+    moreTriggerCharacter?: string[]
 }
 
 /**
  * Document link options
  */
 export interface DocumentLinkOptions {
-   /**
-    * Document links have a resolve provider as well.
-    */
-   resolveProvider?: boolean
+    /**
+     * Document links have a resolve provider as well.
+     */
+    resolveProvider?: boolean
 }
 
 /**
  * Execute command options.
  */
 export interface ExecuteCommandOptions {
-   /**
-    * The commands to be executed on the server
-    */
-   commands: string[]
+    /**
+     * The commands to be executed on the server
+     */
+    commands: string[]
 }
 
 /**
  * Save options.
  */
 export interface SaveOptions {
-   /**
-    * The client is supposed to include the content on save.
-    */
-   includeText?: boolean
+    /**
+     * The client is supposed to include the content on save.
+     */
+    includeText?: boolean
 }
 
 export interface TextDocumentSyncOptions {
-   /**
-    * Open and close notifications are sent to the server.
-    */
-   openClose?: boolean
-   /**
-    * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
-    * and TextDocumentSyncKindIncremental.
-    */
-   change?: number
-   /**
-    * Will save notifications are sent to the server.
-    */
-   willSave?: boolean
-   /**
-    * Will save wait until requests are sent to the server.
-    */
-   willSaveWaitUntil?: boolean
-   /**
-    * Save notifications are sent to the server.
-    */
-   save?: SaveOptions
+    /**
+     * Open and close notifications are sent to the server.
+     */
+    openClose?: boolean
+    /**
+     * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+     * and TextDocumentSyncKindIncremental.
+     */
+    change?: number
+    /**
+     * Will save notifications are sent to the server.
+     */
+    willSave?: boolean
+    /**
+     * Will save wait until requests are sent to the server.
+     */
+    willSaveWaitUntil?: boolean
+    /**
+     * Save notifications are sent to the server.
+     */
+    save?: SaveOptions
 }
 
 export interface IServerCapabilities {
-   /**
-    * Defines how text documents are synced. Is either a detailed structure defining each notification or
-    * for backwards compatibility the TextDocumentSyncKind number.
-    */
-   textDocumentSync?: TextDocumentSyncOptions | number
-   /**
-    * The server provides hover support.
-    */
-   hoverProvider?: boolean
-   /**
-    * The server provides completion support.
-    */
-   completionProvider?: CompletionOptions
-   /**
-    * The server provides signature help support.
-    */
-   signatureHelpProvider?: SignatureHelpOptions
-   /**
-    * The server provides goto definition support.
-    */
-   definitionProvider?: boolean
-   /**
-    * The server provides find references support.
-    */
-   referencesProvider?: boolean
-   /**
-    * The server provides document highlight support.
-    */
-   documentHighlightProvider?: boolean
-   /**
-    * The server provides document symbol support.
-    */
-   documentSymbolProvider?: boolean
-   /**
-    * The server provides workspace symbol support.
-    */
-   workspaceSymbolProvider?: boolean
-   /**
-    * The server provides code actions.
-    */
-   codeActionProvider?: boolean
-   /**
-    * The server provides code lens.
-    */
-   codeLensProvider?: CodeLensOptions
-   /**
-    * The server provides document formatting.
-    */
-   documentFormattingProvider?: boolean
-   /**
-    * The server provides document range formatting.
-    */
-   documentRangeFormattingProvider?: boolean
-   /**
-    * The server provides document formatting on typing.
-    */
-   documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions
-   /**
-    * The server provides rename support.
-    */
-   renameProvider?: boolean
-   /**
-    * The server provides document link support.
-    */
-   documentLinkProvider?: DocumentLinkOptions
-   /**
-    * The server provides execute command support.
-    */
-   executeCommandProvider?: ExecuteCommandOptions
-   /**
-    * Experimental server capabilities.
-    */
-   experimental?: any
+    /**
+     * Defines how text documents are synced. Is either a detailed structure defining each notification or
+     * for backwards compatibility the TextDocumentSyncKind number.
+     */
+    textDocumentSync?: TextDocumentSyncOptions | number
+    /**
+     * The server provides hover support.
+     */
+    hoverProvider?: boolean
+    /**
+     * The server provides completion support.
+     */
+    completionProvider?: CompletionOptions
+    /**
+     * The server provides signature help support.
+     */
+    signatureHelpProvider?: SignatureHelpOptions
+    /**
+     * The server provides goto definition support.
+     */
+    definitionProvider?: boolean
+    /**
+     * The server provides find references support.
+     */
+    referencesProvider?: boolean
+    /**
+     * The server provides document highlight support.
+     */
+    documentHighlightProvider?: boolean
+    /**
+     * The server provides document symbol support.
+     */
+    documentSymbolProvider?: boolean
+    /**
+     * The server provides workspace symbol support.
+     */
+    workspaceSymbolProvider?: boolean
+    /**
+     * The server provides code actions.
+     */
+    codeActionProvider?: boolean
+    /**
+     * The server provides code lens.
+     */
+    codeLensProvider?: CodeLensOptions
+    /**
+     * The server provides document formatting.
+     */
+    documentFormattingProvider?: boolean
+    /**
+     * The server provides document range formatting.
+     */
+    documentRangeFormattingProvider?: boolean
+    /**
+     * The server provides document formatting on typing.
+     */
+    documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions
+    /**
+     * The server provides rename support.
+     */
+    renameProvider?: boolean
+    /**
+     * The server provides document link support.
+     */
+    documentLinkProvider?: DocumentLinkOptions
+    /**
+     * The server provides execute command support.
+     */
+    executeCommandProvider?: ExecuteCommandOptions
+    /**
+     * Experimental server capabilities.
+     */
+    experimental?: any
 }

--- a/browser/src/Services/Language/SignatureHelp.ts
+++ b/browser/src/Services/Language/SignatureHelp.ts
@@ -18,16 +18,24 @@ import { ILatestCursorAndBufferInfo } from "./addInsertModeLanguageFunctionality
 import * as LanguageManager from "./LanguageManager"
 import * as SignatureHelp from "./SignatureHelpView"
 
-export const initUI = (latestCursorAndBufferInfo$: Observable<ILatestCursorAndBufferInfo>, modeChanged$: Observable<Oni.Vim.Mode>, toolTips: IToolTipsProvider) => {
-
+export const initUI = (
+    latestCursorAndBufferInfo$: Observable<ILatestCursorAndBufferInfo>,
+    modeChanged$: Observable<Oni.Vim.Mode>,
+    toolTips: IToolTipsProvider,
+) => {
     const signatureHelpToolTipName = "signature-help-tool-tip"
 
     // Show signature help as the cursor moves
     latestCursorAndBufferInfo$
-        .flatMap(async (val) => {
-            return await showSignatureHelp(val.language, val.filePath, val.cursorLine, val.cursorColumn)
+        .flatMap(async val => {
+            return await showSignatureHelp(
+                val.language,
+                val.filePath,
+                val.cursorLine,
+                val.cursorColumn,
+            )
         })
-        .subscribe((result) => {
+        .subscribe(result => {
             if (result) {
                 toolTips.showToolTip(signatureHelpToolTipName, SignatureHelp.render(result), {
                     position: null,
@@ -40,18 +48,21 @@ export const initUI = (latestCursorAndBufferInfo$: Observable<ILatestCursorAndBu
         })
 
     // Hide signature help when we leave insert mode
-    modeChanged$
-        .subscribe((newMode) => {
-            if (newMode !== "insert") {
-                toolTips.hideToolTip(signatureHelpToolTipName)
-            }
-        })
+    modeChanged$.subscribe(newMode => {
+        if (newMode !== "insert") {
+            toolTips.hideToolTip(signatureHelpToolTipName)
+        }
+    })
 }
 
-export const showSignatureHelp = async (language: string, filePath: string, line: number, column: number): Promise<types.SignatureHelp> => {
+export const showSignatureHelp = async (
+    language: string,
+    filePath: string,
+    line: number,
+    column: number,
+): Promise<types.SignatureHelp> => {
     const languageManager = LanguageManager.getInstance()
     if (languageManager.isLanguageServerAvailable(language)) {
-
         const buffer = editorManager.activeEditor.activeBuffer
         const currentLine = await buffer.getLines(line, line + 1)
 
@@ -73,8 +84,15 @@ export const showSignatureHelp = async (language: string, filePath: string, line
 
         let result: types.SignatureHelp = null
         try {
-            result = await languageManager.sendLanguageServerRequest(language, filePath, "textDocument/signatureHelp", args)
-        } catch (ex) { Log.debug(ex) }
+            result = await languageManager.sendLanguageServerRequest(
+                language,
+                filePath,
+                "textDocument/signatureHelp",
+                args,
+            )
+        } catch (ex) {
+            Log.debug(ex)
+        }
 
         return result
     } else {
@@ -83,8 +101,11 @@ export const showSignatureHelp = async (language: string, filePath: string, line
 }
 
 // TODO: `getSignatureHelpTriggerColumn` rename to `getNearestTriggerCharacter`
-export const getSignatureHelpTriggerColumn = (line: string, character: number, triggerCharacters: string[]): number => {
-
+export const getSignatureHelpTriggerColumn = (
+    line: string,
+    character: number,
+    triggerCharacters: string[],
+): number => {
     let idx = character
     while (idx >= 0) {
         if (line[idx] === triggerCharacters[0]) {

--- a/browser/src/Services/Language/SignatureHelpView.tsx
+++ b/browser/src/Services/Language/SignatureHelpView.tsx
@@ -7,61 +7,67 @@ import { SelectedText, Text } from "./../../UI/components/Text"
 
 export class SignatureHelpView extends React.PureComponent<types.SignatureHelp, {}> {
     public render(): JSX.Element {
-        return <div className="quickinfo-container">
-            <div className="quickinfo">
-                {getElementsFromType(this.props)}
+        return (
+            <div className="quickinfo-container">
+                <div className="quickinfo">{getElementsFromType(this.props)}</div>
             </div>
-        </div>
+        )
     }
 }
 
 export const getElementsFromType = (signatureHelp: types.SignatureHelp): JSX.Element[] => {
-        const elements = []
+    const elements = []
 
-        const currentItem = signatureHelp.signatures[signatureHelp.activeSignature]
+    const currentItem = signatureHelp.signatures[signatureHelp.activeSignature]
 
-        if (!currentItem || !currentItem.label || !currentItem.parameters) {
-            return null
+    if (!currentItem || !currentItem.label || !currentItem.parameters) {
+        return null
+    }
+
+    const label = currentItem.label
+    const parameters = currentItem.parameters
+
+    let remainingSignatureString = label
+
+    for (let i = 0; i < parameters.length; i++) {
+        const parameterLabel = parameters[i].label
+        const parameterIndex = remainingSignatureString.indexOf(parameterLabel)
+
+        if (parameterIndex === -1) {
+            continue
         }
 
-        const label = currentItem.label
-        const parameters = currentItem.parameters
+        const nonArgumentText = remainingSignatureString.substring(0, parameterIndex)
+        elements.push(<Text text={nonArgumentText} />)
 
-        let remainingSignatureString = label
+        const argumentText = remainingSignatureString.substring(
+            parameterIndex,
+            parameterIndex + parameterLabel.length,
+        )
 
-        for (let i = 0; i < parameters.length; i++) {
-            const parameterLabel = parameters[i].label
-            const parameterIndex = remainingSignatureString.indexOf(parameterLabel)
-
-            if (parameterIndex === -1) {
-                continue
-            }
-
-            const nonArgumentText = remainingSignatureString.substring(0, parameterIndex)
-            elements.push(<Text text={nonArgumentText} />)
-
-            const argumentText = remainingSignatureString.substring(parameterIndex, parameterIndex + parameterLabel.length)
-
-            if (i === signatureHelp.activeParameter) {
-                elements.push(<SelectedText text={argumentText} />)
-            } else {
-                elements.push(<Text text={argumentText} />)
-            }
-
-            remainingSignatureString = remainingSignatureString.substring(parameterIndex + parameterLabel.length, remainingSignatureString.length)
+        if (i === signatureHelp.activeParameter) {
+            elements.push(<SelectedText text={argumentText} />)
+        } else {
+            elements.push(<Text text={argumentText} />)
         }
 
-        elements.push(<Text key={remainingSignatureString} text={remainingSignatureString} />)
+        remainingSignatureString = remainingSignatureString.substring(
+            parameterIndex + parameterLabel.length,
+            remainingSignatureString.length,
+        )
+    }
 
-        const titleContents = [<Title padding="0.5rem">{elements}</Title>]
+    elements.push(<Text key={remainingSignatureString} text={remainingSignatureString} />)
 
-        const selectedIndex = Math.min(currentItem.parameters.length, signatureHelp.activeParameter)
-        const selectedArgument = currentItem.parameters[selectedIndex]
-        if (selectedArgument && selectedArgument.documentation) {
-            titleContents.push(<QuickInfoDocumentation text={selectedArgument.documentation} />)
-        }
+    const titleContents = [<Title padding="0.5rem">{elements}</Title>]
 
-        return titleContents
+    const selectedIndex = Math.min(currentItem.parameters.length, signatureHelp.activeParameter)
+    const selectedArgument = currentItem.parameters[selectedIndex]
+    if (selectedArgument && selectedArgument.documentation) {
+        titleContents.push(<QuickInfoDocumentation text={selectedArgument.documentation} />)
+    }
+
+    return titleContents
 }
 
 export const render = (signatureHelp: types.SignatureHelp) => {

--- a/browser/src/Services/Language/Workspace.ts
+++ b/browser/src/Services/Language/Workspace.ts
@@ -10,12 +10,15 @@ import { IWorkspace } from "./../Workspace"
 
 import { LanguageManager } from "./LanguageManager"
 
-export const listenForWorkspaceEdits = (languageManager: LanguageManager, workspace: IWorkspace) => {
+export const listenForWorkspaceEdits = (
+    languageManager: LanguageManager,
+    workspace: IWorkspace,
+) => {
     languageManager.handleLanguageServerRequest("workspace/applyEdit", async (args: any) => {
-         const payload: types.WorkspaceEdit = args.payload.edit.changes
-         await workspace.applyEdits(payload)
-         return {
-             applied: true,
-         }
+        const payload: types.WorkspaceEdit = args.payload.edit.changes
+        await workspace.applyEdits(payload)
+        return {
+            applied: true,
+        }
     })
 }

--- a/browser/src/Services/Language/addInsertModeLanguageFunctionality.ts
+++ b/browser/src/Services/Language/addInsertModeLanguageFunctionality.ts
@@ -16,31 +16,34 @@ import * as SignatureHelp from "./SignatureHelp"
 import { IToolTipsProvider } from "./../../Editor/NeovimEditor/ToolTipsProvider"
 
 export interface ILatestCursorAndBufferInfo {
-    filePath: string,
-    language: string,
-    cursorLine: number,
-    contents: string,
-    cursorColumn: number,
+    filePath: string
+    language: string
+    cursorLine: number
+    contents: string
+    cursorColumn: number
 }
 
-export const addInsertModeLanguageFunctionality = (cursorMoved$: Observable<Oni.Cursor>, modeChanged$: Observable<Oni.Vim.Mode>, toolTips: IToolTipsProvider) => {
+export const addInsertModeLanguageFunctionality = (
+    cursorMoved$: Observable<Oni.Cursor>,
+    modeChanged$: Observable<Oni.Vim.Mode>,
+    toolTips: IToolTipsProvider,
+) => {
+    const latestCursorAndBufferInfo$: Observable<
+        ILatestCursorAndBufferInfo
+    > = cursorMoved$.auditTime(10).mergeMap(async cursorPos => {
+        const editor = editorManager.activeEditor
+        const buffer = editor.activeBuffer
 
-    const latestCursorAndBufferInfo$: Observable<ILatestCursorAndBufferInfo> = cursorMoved$
-            .auditTime(10)
-            .mergeMap(async (cursorPos) => {
-                const editor = editorManager.activeEditor
-                const buffer = editor.activeBuffer
-
-                const changedLines: string[] = await buffer.getLines(cursorPos.line, cursorPos.line + 1)
-                const changedLine = changedLines[0]
-                return {
-                    filePath: buffer.filePath,
-                    language: buffer.language,
-                    cursorLine: cursorPos.line,
-                    contents: changedLine,
-                    cursorColumn: cursorPos.column,
-                }
-            })
+        const changedLines: string[] = await buffer.getLines(cursorPos.line, cursorPos.line + 1)
+        const changedLine = changedLines[0]
+        return {
+            filePath: buffer.filePath,
+            language: buffer.language,
+            cursorLine: cursorPos.line,
+            contents: changedLine,
+            cursorColumn: cursorPos.column,
+        }
+    })
 
     SignatureHelp.initUI(latestCursorAndBufferInfo$, modeChanged$, toolTips)
 }

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -28,17 +28,22 @@ export type MenuState = State.IMenus<Oni.Menu.MenuOption, IMenuOptionWithHighlig
 
 const reducer = createReducer<Oni.Menu.MenuOption, IMenuOptionWithHighlights>()
 
-export const menuStore = createStore<MenuState>(reducer, State.createDefaultState<Oni.Menu.MenuOption, IMenuOptionWithHighlights>(), applyMiddleware(thunk))
+export const menuStore = createStore<MenuState>(
+    reducer,
+    State.createDefaultState<Oni.Menu.MenuOption, IMenuOptionWithHighlights>(),
+    applyMiddleware(thunk),
+)
 
-export const menuActions: typeof ActionCreators = bindActionCreators(ActionCreators as any, menuStore.dispatch)
+export const menuActions: typeof ActionCreators = bindActionCreators(
+    ActionCreators as any,
+    menuStore.dispatch,
+)
 
 export class MenuManager {
     private _id: number = 0
     private _overlay: Overlay
 
-    constructor(
-        private _overlayManager: OverlayManager,
-    ) {
+    constructor(private _overlayManager: OverlayManager) {
         this._overlay = this._overlayManager.createItem()
         this._overlay.setContents(MenuContainer())
         this._overlay.show()
@@ -101,8 +106,7 @@ export class Menu {
         return this._getSelectedItem()
     }
 
-    constructor(private _id: string) {
-    }
+    constructor(private _id: string) {}
 
     public isOpen(): boolean {
         const menuState = menuStore.getState()
@@ -117,18 +121,22 @@ export class Menu {
         menuActions.setMenuItems(this._id, items)
     }
 
-    public setFilterFunction(filterFunc: (items: Oni.Menu.MenuOption[], searchString: string) => IMenuOptionWithHighlights[]) {
+    public setFilterFunction(
+        filterFunc: (
+            items: Oni.Menu.MenuOption[],
+            searchString: string,
+        ) => IMenuOptionWithHighlights[],
+    ) {
         this._filterFunction = filterFunc
     }
 
     public show(): void {
-
         menuActions.showPopupMenu(this._id, {
             filterFunction: this._filterFunction,
-            onSelectedItemChanged: (item) => this._onSelectedItemChanged.dispatch(item),
+            onSelectedItemChanged: item => this._onSelectedItemChanged.dispatch(item),
             onSelectItem: (idx: number) => this._onItemSelectedHandler(idx),
             onHide: () => this._onHide.dispatch(),
-            onFilterTextChanged: (newText) => this._onFilterTextChanged.dispatch(newText),
+            onFilterTextChanged: newText => this._onFilterTextChanged.dispatch(newText),
         })
     }
 
@@ -137,7 +145,6 @@ export class Menu {
     }
 
     private _onItemSelectedHandler(idx?: number): void {
-
         const selectedOption = this._getSelectedItem(idx)
         this._onItemSelected.dispatch(selectedOption)
 
@@ -151,7 +158,7 @@ export class Menu {
             return null
         }
 
-        const index = (typeof idx === "number") ? idx : menuState.menu.selectedIndex
+        const index = typeof idx === "number" ? idx : menuState.menu.selectedIndex
 
         return menuState.menu.filteredOptions[index]
     }

--- a/browser/src/Services/Menu/MenuActionCreators.ts
+++ b/browser/src/Services/Menu/MenuActionCreators.ts
@@ -24,8 +24,12 @@ const notifySelectedItemChange = (contextMenuState: any) => {
     }
 }
 
-export const showPopupMenu = (id: string, opts?: MenuActions.IMenuOptions, items?: any, filter?: string) => {
-
+export const showPopupMenu = (
+    id: string,
+    opts?: MenuActions.IMenuOptions,
+    items?: any,
+    filter?: string,
+) => {
     const state: any = Shell.store.getState()
     const backgroundColor = state.colors["menu.background"]
     const foregroundColor = state.colors["menu.foreground"]
@@ -103,7 +107,6 @@ export const previousMenuItem = () => (dispatch: any, getState: any) => {
 }
 
 export const filterMenu = (filterString: string) => (dispatch: any, getState: any) => {
-
     const state = getState()
 
     if (!state.menu) {
@@ -126,7 +129,7 @@ export const filterMenu = (filterString: string) => (dispatch: any, getState: an
 
 export const nextMenuItem = () => (dispatch: any, getState: any) => {
     dispatch({
-    type: "NEXT_MENU",
+        type: "NEXT_MENU",
     })
 
     notifySelectedItemChange(getState())

--- a/browser/src/Services/Menu/MenuActions.ts
+++ b/browser/src/Services/Menu/MenuActions.ts
@@ -16,43 +16,43 @@ export interface IMenuOptions {
 }
 
 export interface IShowMenuAction {
-    type: "SHOW_MENU",
+    type: "SHOW_MENU"
     payload: {
-        id: string,
-        options?: IMenuOptions,
-        items?: any[],
-        filter?: string,
+        id: string
+        options?: IMenuOptions
+        items?: any[]
+        filter?: string
     }
 }
 
 export interface ISetDetailedMenuItem<T> {
-    type: "SET_DETAILED_MENU_ITEM",
+    type: "SET_DETAILED_MENU_ITEM"
     payload: {
-        detailedItem: T,
+        detailedItem: T
     }
 }
 
 export interface ISetMenuItems<T> {
-    type: "SET_MENU_ITEMS",
+    type: "SET_MENU_ITEMS"
     payload: {
-        id: string,
-        items: T[],
+        id: string
+        items: T[]
     }
 }
 
 export interface ISetMenuLoading {
-    type: "SET_MENU_LOADING",
+    type: "SET_MENU_LOADING"
     payload: {
-        id: string,
-        isLoading: boolean,
+        id: string
+        isLoading: boolean
     }
 }
 
 export interface IFilterMenuAction {
-    type: "FILTER_MENU",
+    type: "FILTER_MENU"
     payload: {
-        id: string,
-        filter: string,
+        id: string
+        filter: string
     }
 }
 
@@ -69,10 +69,10 @@ export interface IPreviousMenuAction {
 }
 
 export type MenuAction =
-    IShowMenuAction |
-    ISetMenuLoading |
-    ISetMenuItems<any> |
-    IFilterMenuAction |
-    IHideMenuAction |
-    INextMenuAction |
-    IPreviousMenuAction
+    | IShowMenuAction
+    | ISetMenuLoading
+    | ISetMenuItems<any>
+    | IFilterMenuAction
+    | IHideMenuAction
+    | INextMenuAction
+    | IPreviousMenuAction

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -31,13 +31,10 @@ export interface IMenuProps {
 }
 
 export class MenuView extends React.PureComponent<IMenuProps, {}> {
-
     private _inputElement: HTMLInputElement = null
 
     public componentWillUpdate(newProps: Readonly<IMenuProps>): void {
-        if (newProps.visible !== this.props.visible
-            && !newProps.visible
-            && this._inputElement) {
+        if (newProps.visible !== this.props.visible && !newProps.visible && this._inputElement) {
             focusManager.popFocus(this._inputElement)
         }
     }
@@ -52,14 +49,16 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
 
         // const pinnedItems = initialItems.filter(f => f.pinned)
         // const unpinnedItems = initialItems.filter(f => !f.pinned)
-        const items = initialItems.map((menuItem, index) =>
+        const items = initialItems.map((menuItem, index) => (
             // FIXME: undefined
-            <MenuItem {...menuItem as any}
+            <MenuItem
+                {...menuItem as any}
                 key={index}
                 filterText={this.props.filterText}
                 isSelected={index === this.props.selectedIndex}
                 onClick={() => this.props.onSelect(index)}
-            />)
+            />
+        ))
 
         const menuStyle = {
             backgroundColor: this.props.backgroundColor,
@@ -68,23 +67,28 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
 
         const footerClassName = "footer " + (this.props.isLoading ? "loading" : "loaded")
 
-        return <div className="menu-background enable-mouse">
-            <div className="menu" style={menuStyle}>
-                <TextInputView
-                    overrideDefaultStyle={true}
-                    backgroundColor={null}
-                    foregroundColor={this.props.foregroundColor}
-                    onChange={(evt) => this._onChange(evt)} />
-                <div className="items">
-                    {items}
-                </div>
-                <div className={footerClassName} style={menuStyle}>
-                    <div className="loading-spinner">
-                        <Icon name="circle-o-notch" className=" fa-spin" size={IconSize.Large} />
+        return (
+            <div className="menu-background enable-mouse">
+                <div className="menu" style={menuStyle}>
+                    <TextInputView
+                        overrideDefaultStyle={true}
+                        backgroundColor={null}
+                        foregroundColor={this.props.foregroundColor}
+                        onChange={evt => this._onChange(evt)}
+                    />
+                    <div className="items">{items}</div>
+                    <div className={footerClassName} style={menuStyle}>
+                        <div className="loading-spinner">
+                            <Icon
+                                name="circle-o-notch"
+                                className=" fa-spin"
+                                size={IconSize.Large}
+                            />
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        )
     }
 
     private _onChange(evt: React.FormEvent<HTMLInputElement>) {
@@ -94,7 +98,7 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
 }
 
 const EmptyArray: any[] = []
-const noop = () => { } // tslint:disable-line
+const noop = () => {} // tslint:disable-line
 
 const mapStateToProps = (state: State.IMenus<Oni.Menu.MenuOption, IMenuOptionWithHighlights>) => {
     if (!state.menu) {
@@ -136,9 +140,11 @@ const mapDispatchToProps = (dispatch: any) => {
 export const ConnectedMenu = connect(mapStateToProps, mapDispatchToProps)(MenuView)
 
 export const MenuContainer = () => {
-    return <Provider store={menuStore}>
+    return (
+        <Provider store={menuStore}>
             <ConnectedMenu />
         </Provider>
+    )
 }
 
 export interface IMenuItemProps {
@@ -154,7 +160,6 @@ export interface IMenuItemProps {
 }
 
 export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
-
     public render(): JSX.Element {
         let className = "item"
 
@@ -162,15 +167,32 @@ export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
             className += " selected"
         }
 
-        const icon = this.props.icon && typeof this.props.icon === "string" ? <Icon name={this.props.icon} /> : this.props.icon
+        const icon =
+            this.props.icon && typeof this.props.icon === "string" ? (
+                <Icon name={this.props.icon} />
+            ) : (
+                this.props.icon
+            )
 
-        return <div className={className} onClick={() => this.props.onClick()}>
-            {icon}
-            <HighlightTextByIndex className="label" text={this.props.label} highlightIndices={this.props.labelHighlights} highlightClassName={"highlight"} />
-            <HighlightTextByIndex className="detail" text={this.props.detail} highlightIndices={this.props.detailHighlights} highlightClassName={"highlight"} />
-            <Visible visible={this.props.pinned}>
-                <Icon name="clock-o" />
-            </Visible>
-        </div>
+        return (
+            <div className={className} onClick={() => this.props.onClick()}>
+                {icon}
+                <HighlightTextByIndex
+                    className="label"
+                    text={this.props.label}
+                    highlightIndices={this.props.labelHighlights}
+                    highlightClassName={"highlight"}
+                />
+                <HighlightTextByIndex
+                    className="detail"
+                    text={this.props.detail}
+                    highlightIndices={this.props.detailHighlights}
+                    highlightClassName={"highlight"}
+                />
+                <Visible visible={this.props.pinned}>
+                    <Icon name="clock-o" />
+                </Visible>
+            </div>
+        )
     }
 }

--- a/browser/src/Services/Menu/MenuFilter.ts
+++ b/browser/src/Services/Menu/MenuFilter.ts
@@ -14,7 +14,6 @@ import { configuration } from "./../../Services/Configuration"
 import { IMenuOptionWithHighlights } from "./Menu"
 
 export const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
-
     // TODO: Technically, this makes the reducer 'impure',
     // which is not ideal - need to refactor eventually.
     //
@@ -32,17 +31,19 @@ export const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
         // If the string is all lower-case, not case sensitive..
         if (searchString === searchString.toLowerCase()) {
             return false
-        // Otherwise, it is case sensitive..
+            // Otherwise, it is case sensitive..
         } else {
             return true
         }
     }
 }
 
-export const fuseFilter = (options: Oni.Menu.MenuOption[], searchString: string): IMenuOptionWithHighlights[] => {
-
+export const fuseFilter = (
+    options: Oni.Menu.MenuOption[],
+    searchString: string,
+): IMenuOptionWithHighlights[] => {
     if (!searchString) {
-        const opt = options.map((o) => {
+        const opt = options.map(o => {
             return {
                 ...o,
                 label: o.label,
@@ -54,17 +55,20 @@ export const fuseFilter = (options: Oni.Menu.MenuOption[], searchString: string)
             }
         })
 
-        return sortBy(opt, (o) => o.pinned ? 0 : 1)
+        return sortBy(opt, o => (o.pinned ? 0 : 1))
     }
 
     const fuseOptions = {
-        keys: [{
-            name: "label",
-            weight: 0.6,
-        }, {
-            name: "detail",
-            weight: 0.4,
-        }],
+        keys: [
+            {
+                name: "label",
+                weight: 0.6,
+            },
+            {
+                name: "detail",
+                weight: 0.4,
+            },
+        ],
         caseSensitive: shouldFilterbeCaseSensitive(searchString),
         include: ["matches"],
     }
@@ -74,8 +78,7 @@ export const fuseFilter = (options: Oni.Menu.MenuOption[], searchString: string)
 
     // remove any items that don't have all the characters from searchString
     // For this first pass, ignore case
-    const filteredOptions = options.filter((o) => {
-
+    const filteredOptions = options.filter(o => {
         if (!o.label && !o.detail) {
             return false
         }
@@ -127,7 +130,7 @@ export const fuseFilter = (options: Oni.Menu.MenuOption[], searchString: string)
 const convertArrayOfPairsToIndices = (pairs: number[][]): number[] => {
     const ret: number[] = []
 
-    pairs.forEach((p) => {
+    pairs.forEach(p => {
         const [startIndex, endIndex] = p
 
         for (let i = startIndex; i <= endIndex; i++) {

--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -9,80 +9,83 @@ import * as MenuFilter from "./MenuFilter"
 import * as State from "./MenuState"
 
 export function createReducer<T, FilteredT extends T>() {
-
-    const reducer = (s: State.IMenus<T, FilteredT>, a: Actions.MenuAction): State.IMenus<T, FilteredT> => {
+    const reducer = (
+        s: State.IMenus<T, FilteredT>,
+        a: Actions.MenuAction,
+    ): State.IMenus<T, FilteredT> => {
         return {
             ...s,
             menu: popupMenuReducer(s.menu, a),
         }
     }
 
-    function popupMenuReducer(s: State.IMenu<T, FilteredT> | null, a: any): State.IMenu<T, FilteredT> {
-
+    function popupMenuReducer(
+        s: State.IMenu<T, FilteredT> | null,
+        a: any,
+    ): State.IMenu<T, FilteredT> {
         // TODO: sync max display items (10) with value in Menu.render() (Menu.tsx)
         const size = s ? Math.min(10, s.filteredOptions.length) : 0
 
         switch (a.type) {
-
-            case "SHOW_MENU":
-                {
-                    const options3 = a.payload.items || []
-                    const filterText = a.payload.filter || ""
-                    const filterFunc = (a.payload.options && a.payload.options.filterFunction) ? a.payload.options.filterFunction : MenuFilter.fuseFilter
-                    const filteredOptions3 = filterFunc(options3, filterText)
-                    return {
-                        ...a.payload.options,
-                        id: a.payload.id,
-                        filter: filterText,
-                        filterFunction: filterFunc,
-                        filteredOptions: filteredOptions3,
-                        options: options3,
-                        selectedIndex: 0,
-                        isLoading: false,
-                    }
+            case "SHOW_MENU": {
+                const options3 = a.payload.items || []
+                const filterText = a.payload.filter || ""
+                const filterFunc =
+                    a.payload.options && a.payload.options.filterFunction
+                        ? a.payload.options.filterFunction
+                        : MenuFilter.fuseFilter
+                const filteredOptions3 = filterFunc(options3, filterText)
+                return {
+                    ...a.payload.options,
+                    id: a.payload.id,
+                    filter: filterText,
+                    filterFunction: filterFunc,
+                    filteredOptions: filteredOptions3,
+                    options: options3,
+                    selectedIndex: 0,
+                    isLoading: false,
                 }
-            case "SET_DETAILED_MENU_ITEM":
-                {
-                    if (!s || !s.options) {
-                        return s
-                    }
-
-                    if (!a.payload.detailedItem) {
-                        return s
-                    }
-
-                    const options = s.options.map((entry) => {
-                        // TODO: Decide on canonical interface for menu options
-                        if ((entry as any).label === a.payload.detailedItem.label) {
-                            return a.payload.detailedItem
-                        } else {
-                            return entry
-                        }
-                    })
-
-                    const filterFunc = s.filterFunction
-                    const filteredOptions2 = filterFunc(options, s.filter)
-                    return {
-                        ...s,
-                        options,
-                        filteredOptions: filteredOptions2,
-                    }
+            }
+            case "SET_DETAILED_MENU_ITEM": {
+                if (!s || !s.options) {
+                    return s
                 }
-            case "SET_MENU_ITEMS":
-                {
-                    if (!s || s.id !== a.payload.id) {
-                        return s
-                    }
 
-                    const filterFunc = s.filterFunction
-                    const filteredOptions = filterFunc(a.payload.items, s.filter)
-
-                    return {
-                        ...s,
-                        options: a.payload.items,
-                        filteredOptions,
-                    }
+                if (!a.payload.detailedItem) {
+                    return s
                 }
+
+                const options = s.options.map(entry => {
+                    // TODO: Decide on canonical interface for menu options
+                    if ((entry as any).label === a.payload.detailedItem.label) {
+                        return a.payload.detailedItem
+                    } else {
+                        return entry
+                    }
+                })
+
+                const filterFunc = s.filterFunction
+                const filteredOptions2 = filterFunc(options, s.filter)
+                return {
+                    ...s,
+                    options,
+                    filteredOptions: filteredOptions2,
+                }
+            }
+            case "SET_MENU_ITEMS": {
+                if (!s || s.id !== a.payload.id) {
+                    return s
+                }
+
+                const filterFunc = s.filterFunction
+                const filteredOptions = filterFunc(a.payload.items, s.filter)
+
+                return {
+                    ...s,
+                    options: a.payload.items,
+                    filteredOptions,
+                }
+            }
             case "SET_MENU_LOADING":
                 if (!s || s.id !== a.payload.id) {
                     return s
@@ -95,24 +98,29 @@ export function createReducer<T, FilteredT extends T>() {
             case "HIDE_MENU":
                 return null
             case "NEXT_MENU":
-                return {...s,
-                        selectedIndex: (s.selectedIndex + 1) % size}
-            case "PREVIOUS_MENU":
-                return {...s,
-                        selectedIndex: s.selectedIndex > 0 ? s.selectedIndex - 1 : size - 1}
-            case "FILTER_MENU":
-                {
-                    if (!s) {
-                        return s
-                    }
-
-                    const filterFunc = s.filterFunction
-                    const filteredOptionsSorted = filterFunc(s.options, a.payload.filter)
-
-                    return {...s,
-                            filter: a.payload.filter,
-                            filteredOptions: filteredOptionsSorted}
+                return {
+                    ...s,
+                    selectedIndex: (s.selectedIndex + 1) % size,
                 }
+            case "PREVIOUS_MENU":
+                return {
+                    ...s,
+                    selectedIndex: s.selectedIndex > 0 ? s.selectedIndex - 1 : size - 1,
+                }
+            case "FILTER_MENU": {
+                if (!s) {
+                    return s
+                }
+
+                const filterFunc = s.filterFunction
+                const filteredOptionsSorted = filterFunc(s.options, a.payload.filter)
+
+                return {
+                    ...s,
+                    filter: a.payload.filter,
+                    filteredOptions: filteredOptionsSorted,
+                }
+            }
             default:
                 return s
         }

--- a/browser/src/Services/Menu/MenuState.ts
+++ b/browser/src/Services/Menu/MenuState.ts
@@ -10,10 +10,10 @@ export interface IMenus<T, FilteredT> {
 }
 
 export interface IMenu<T, FilteredT> {
-    id: string,
-    filter: string,
-    filteredOptions: FilteredT[],
-    options: T[],
+    id: string
+    filter: string
+    filteredOptions: FilteredT[]
+    options: T[]
     selectedIndex: number
     isLoading: boolean
 

--- a/browser/src/Services/Metadata.ts
+++ b/browser/src/Services/Metadata.ts
@@ -18,7 +18,6 @@ export const getMetadata = async (): Promise<IMetadata> => {
 
     return new Promise<IMetadata>((resolve, reject) => {
         fs.readFile(packageMetadata, "utf8", (err: NodeJS.ErrnoException, data: string) => {
-
             if (err) {
                 reject(err)
                 return
@@ -40,11 +39,11 @@ export const showAboutMessage = async () => {
     const metadata = await getMetadata()
 
     const infoLines = [
-    `${metadata.name} version ${metadata.version}`,
-    "https://www.onivim.io",
-    "",
-    "Copyright 2017 Bryan Phelps",
-    "MIT License",
+        `${metadata.name} version ${metadata.version}`,
+        "https://www.onivim.io",
+        "",
+        "Copyright 2017 Bryan Phelps",
+        "MIT License",
     ]
 
     alert(infoLines.join(os.EOL))

--- a/browser/src/Services/Overlay.ts
+++ b/browser/src/Services/Overlay.ts
@@ -10,9 +10,7 @@ export class Overlay {
     private _contents: JSX.Element
     private _visible: boolean = false
 
-    constructor(
-        private _id: string,
-    ) { }
+    constructor(private _id: string) {}
 
     public show(): void {
         this._visible = true

--- a/browser/src/Services/QuickOpen/FinderProcess.ts
+++ b/browser/src/Services/QuickOpen/FinderProcess.ts
@@ -9,7 +9,6 @@ import { ChildProcess, spawn } from "child_process"
 import { Event, IEvent } from "oni-types"
 
 export class FinderProcess {
-
     private _process: ChildProcess
 
     private _lastData: string = ""
@@ -26,9 +25,7 @@ export class FinderProcess {
         return this._onComplete
     }
 
-    constructor(private _command: string,
-                private _splitCharacter: string) {
-    }
+    constructor(private _command: string, private _splitCharacter: string) {}
 
     public start(): void {
         if (this._process) {
@@ -36,7 +33,7 @@ export class FinderProcess {
         }
 
         this._process = spawn(this._command, [], { shell: true })
-        this._process.stdout.on("data", (data) => {
+        this._process.stdout.on("data", data => {
             if (!data) {
                 return
             }
@@ -57,11 +54,11 @@ export class FinderProcess {
             this._onData.dispatch(splitData)
         })
 
-        this._process.stderr.on("data", (data) => {
+        this._process.stderr.on("data", data => {
             this._onError.dispatch(data.toString())
         })
 
-        this._process.on("exit", (code) => {
+        this._process.on("exit", code => {
             this._onComplete.dispatch()
         })
     }

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -36,7 +36,9 @@ export class QuickOpen {
         this._neovimInstance = neovimInstance
 
         this._menu = menuManager.create()
-        this._menu.onItemSelected.subscribe((selectedItem: any) => { this._onItemSelected(selectedItem) })
+        this._menu.onItemSelected.subscribe((selectedItem: any) => {
+            this._onItemSelected(selectedItem)
+        })
 
         this._menu.onHide.subscribe(() => {
             this._stopFinderProcess()
@@ -44,7 +46,10 @@ export class QuickOpen {
 
         this._menu.onFilterTextChanged.subscribe((newFilter: any) => {
             if (this._isFinderCommandDynamic() && this._menu.isOpen()) {
-                const commandWithFilter = this._getDynamicSearchCommand(this._lastCommand, newFilter)
+                const commandWithFilter = this._getDynamicSearchCommand(
+                    this._lastCommand,
+                    newFilter,
+                )
                 this._updateFinderProcess(commandWithFilter)
             }
         })
@@ -90,7 +95,6 @@ export class QuickOpen {
 
         //  If in exec directory or home, show bookmarks to change cwd to
         if (this._isInstallDirectoryOrHome()) {
-
             this._menu.show()
             this._loadDefaultMenuItems()
 
@@ -108,7 +112,8 @@ export class QuickOpen {
         } else {
             // Default strategy
             const excludeFiles = configuration.getValue("oni.exclude")
-            const command = RipGrep.getCommand() + " " + RipGrep.getArguments(excludeFiles).join(" ")
+            const command =
+                RipGrep.getCommand() + " " + RipGrep.getArguments(excludeFiles).join(" ")
             this.loadMenu(command, "\n")
         }
     }
@@ -220,7 +225,10 @@ export class QuickOpen {
             // If we are a directory, open it.
             if (arg.icon === QuickOpenItem.convertTypeToIcon(QuickOpenType.bookmark)) {
                 // If I use this one more place I'm going to make a function >.>
-                fullPath = fullPath.replace("~", process.env[(process.platform  === "win32") ? "USERPROFILE" : "HOME"])
+                fullPath = fullPath.replace(
+                    "~",
+                    process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"],
+                )
 
                 if (lstatSync(fullPath).isDirectory()) {
                     this._neovimInstance.chdir(fullPath)
@@ -235,13 +243,15 @@ export class QuickOpen {
 
     // If we are in home or install dir offer to open folder/bookmark (Basically user hasn't opened a folder yet)
     private _isInstallDirectoryOrHome() {
-        return path.dirname(process.execPath) === process.cwd() ||
-               process.env[(process.platform  === "win32") ? "USERPROFILE" : "HOME"] === process.cwd()
+        return (
+            path.dirname(process.execPath) === process.cwd() ||
+            process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"] === process.cwd()
+        )
     }
 
     // Show menu based on items given
     private _setItemsFromQuickOpenItems(items: QuickOpenItem[]): void {
-        const options = items.map((qitem) => {
+        const options = items.map(qitem => {
             const f = qitem.item.trim()
             const file = path.basename(f)
             const folder = path.dirname(f)
@@ -259,10 +269,7 @@ export class QuickOpen {
 
     private _loadDefaultMenuItems() {
         // Open folder help at top
-        this._loadedItems.push(new QuickOpenItem(
-            "Open Folder",
-            QuickOpenType.folderHelp,
-        ))
+        this._loadedItems.push(new QuickOpenItem("Open Folder", QuickOpenType.folderHelp))
 
         // Get bookmarks, if we added remove them all so we don't think we have length
         const bookmarks = configuration.getValue("oni.bookmarks")

--- a/browser/src/Services/QuickOpen/RegExFilter.ts
+++ b/browser/src/Services/QuickOpen/RegExFilter.ts
@@ -10,11 +10,17 @@ import * as Oni from "oni-api"
 
 import { IMenuOptionWithHighlights, shouldFilterbeCaseSensitive } from "./../Menu"
 
-import { createLetterCountDictionary, LetterCountDictionary } from "./../../UI/components/HighlightText"
+import {
+    createLetterCountDictionary,
+    LetterCountDictionary,
+} from "./../../UI/components/HighlightText"
 
-export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string): IMenuOptionWithHighlights[] => {
+export const regexFilter = (
+    options: Oni.Menu.MenuOption[],
+    searchString: string,
+): IMenuOptionWithHighlights[] => {
     if (!searchString) {
-        const opt = options.map((o) => {
+        const opt = options.map(o => {
             return {
                 ...o,
                 detailHighlights: [],
@@ -22,7 +28,7 @@ export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string
             }
         })
 
-        return sortBy(opt, (o) => o.pinned ? 0 : 1)
+        return sortBy(opt, o => (o.pinned ? 0 : 1))
     }
 
     const isCaseSensitive = shouldFilterbeCaseSensitive(searchString)
@@ -33,7 +39,7 @@ export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string
 
     const filterRegExp = new RegExp(".*" + searchString.split("").join(".*") + ".*")
 
-    const filteredOptions = options.filter((f) => {
+    const filteredOptions = options.filter(f => {
         let textToFilterOn = f.detail + f.label
 
         if (!isCaseSensitive) {
@@ -43,7 +49,7 @@ export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string
         return textToFilterOn.match(filterRegExp)
     })
 
-    const ret = filteredOptions.map((fo) => {
+    const ret = filteredOptions.map(fo => {
         const letterCountDictionary = createLetterCountDictionary(searchString)
 
         const detailHighlights = getHighlightsFromString(fo.detail, letterCountDictionary)
@@ -59,7 +65,10 @@ export const regexFilter = (options: Oni.Menu.MenuOption[], searchString: string
     return ret
 }
 
-export const getHighlightsFromString = (text: string, letterCountDictionary: LetterCountDictionary): number[] => {
+export const getHighlightsFromString = (
+    text: string,
+    letterCountDictionary: LetterCountDictionary,
+): number[] => {
     if (!text) {
         return []
     }

--- a/browser/src/Services/QuickOpen/RipGrep.ts
+++ b/browser/src/Services/QuickOpen/RipGrep.ts
@@ -13,7 +13,7 @@ export const getCommand = () => {
     const executableName = Platform.isWindows() ? "rg.exe" : "rg"
 
     // Wrap in quotes in case there are spaces in the path
-    return "\"" + path.join(rootPath, executableName) + "\""
+    return '"' + path.join(rootPath, executableName) + '"'
 }
 
 export const getArguments = (excludePaths: string[]) => {

--- a/browser/src/Services/Recorder.ts
+++ b/browser/src/Services/Recorder.ts
@@ -36,27 +36,38 @@ class Recorder {
         document.title = ONI_RECORDER_TITLE
 
         desktopCapturer.getSources({ types: ["window", "screen"] }, (error, sources) => {
-            if (error) { throw error }
-            for (let i = 0; i < sources.length; i++) { // tslint:disable-line prefer-for-of
+            if (error) {
+                throw error
+            }
+            for (let i = 0; i < sources.length; i++) {
+                // tslint:disable-line prefer-for-of
                 const src = sources[i]
                 if (src.name === ONI_RECORDER_TITLE) {
                     document.title = title
 
                     const size = getDimensions()
-                    navigator["webkitGetUserMedia"]({ // tslint:disable-line no-string-literal
-                        audio: false,
-                        video: {
-                            mandatory: {
-                                chromeMediaSource: "desktop",
-                                chromeMediaSourceId: src.id,
-                                minWidth: 320,
-                                maxWidth: size.width,
-                                minHeight: 240,
-                                maxHeight: size.height,
+                    navigator["webkitGetUserMedia"](
+                        {
+                            // tslint:disable-line no-string-literal
+                            audio: false,
+                            video: {
+                                mandatory: {
+                                    chromeMediaSource: "desktop",
+                                    chromeMediaSourceId: src.id,
+                                    minWidth: 320,
+                                    maxWidth: size.width,
+                                    minHeight: 240,
+                                    maxHeight: size.height,
+                                },
                             },
                         },
-                    }, (stream: any) => { this._handleStream(stream) },
-                        (err: Error) => { this._handleUserMediaError(err) })
+                        (stream: any) => {
+                            this._handleStream(stream)
+                        },
+                        (err: Error) => {
+                            this._handleUserMediaError(err)
+                        },
+                    )
                     return
                 }
             }
@@ -70,7 +81,7 @@ class Recorder {
     public async stopRecording(fileName?: string): Promise<void> {
         this._recorder.stop()
 
-        const arrayBuffer = await toArrayBuffer(new Blob(this._blobs, {type: "video/webm"}))
+        const arrayBuffer = await toArrayBuffer(new Blob(this._blobs, { type: "video/webm" }))
 
         const buffer = toBuffer(arrayBuffer)
         fileName = fileName || getFileName("oni-video", "webm")
@@ -90,8 +101,8 @@ class Recorder {
 
     public takeScreenshot(fileName?: string, scale: number = 1): void {
         const webContents = require("electron").remote.getCurrentWebContents()
-        webContents.capturePage((image) => {
-            const pngBuffer = image.toPNG({ scaleFactor: scale})
+        webContents.capturePage(image => {
+            const pngBuffer = image.toPNG({ scaleFactor: scale })
 
             fileName = fileName || getFileName("oni-screenshot", "png")
             const screenshotPath = getOutputPath(fileName)
@@ -106,14 +117,15 @@ class Recorder {
     private _handleStream(stream: any) {
         this._recorder = new MediaRecorder(stream)
         this._blobs = []
-        this._recorder.ondataavailable = (evt: any) => { this._blobs.push(evt.data) }
+        this._recorder.ondataavailable = (evt: any) => {
+            this._blobs.push(evt.data)
+        }
         this._recorder.start(100 /* ms */)
     }
 
     private _handleUserMediaError(err: Error) {
         Log.error(err)
     }
-
 }
 
 // Some of this code was adapted and modified from this stackoverflow post:
@@ -130,7 +142,9 @@ const toArrayBuffer = async (blob: Blob): Promise<ArrayBuffer> => {
 }
 
 const getDimensions = () => {
-    const size = require("electron").remote.getCurrentWindow().getSize()
+    const size = require("electron")
+        .remote.getCurrentWindow()
+        .getSize()
     return {
         width: size[0],
         height: size[1],

--- a/browser/src/Services/Recorder.ts
+++ b/browser/src/Services/Recorder.ts
@@ -39,16 +39,16 @@ class Recorder {
             if (error) {
                 throw error
             }
+            // tslint:disable-next-line prefer-for-of
             for (let i = 0; i < sources.length; i++) {
-                // tslint:disable-line prefer-for-of
                 const src = sources[i]
                 if (src.name === ONI_RECORDER_TITLE) {
                     document.title = title
 
                     const size = getDimensions()
+                    // tslint:disable-next-line no-string-literal
                     navigator["webkitGetUserMedia"](
                         {
-                            // tslint:disable-line no-string-literal
                             audio: false,
                             video: {
                                 mandatory: {

--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -6,12 +6,12 @@ import * as React from "react"
 import { connect, Provider } from "react-redux"
 
 import styled from "styled-components"
-import {enableMouse, withProps} from "./../../UI/components/common"
+import { enableMouse, withProps } from "./../../UI/components/common"
 
 import { ISidebarEntry, ISidebarState, SidebarManager, SidebarPane } from "./SidebarStore"
 
 export const getActiveEntry = (state: ISidebarState): ISidebarEntry => {
-    const filteredEntries = state.entries.filter((entry) => entry.id === state.activeEntryId)
+    const filteredEntries = state.entries.filter(entry => entry.id === state.activeEntryId)
 
     const activeEntry = filteredEntries.length > 0 ? filteredEntries[0] : null
 
@@ -22,23 +22,19 @@ export const getActiveEntry = (state: ISidebarState): ISidebarEntry => {
  * Split that is the container for the active sidebar item
  */
 export class SidebarContentSplit {
-
     public get activePane(): SidebarPane {
         const entry = getActiveEntry(this._sidebarManager.store.getState())
 
         return entry && entry.pane ? entry.pane : null
     }
 
-    constructor(
-        private _sidebarManager: SidebarManager = new SidebarManager(),
-    ) { }
+    constructor(private _sidebarManager: SidebarManager = new SidebarManager()) {}
 
     public enter(): void {
         const pane: any = this.activePane
         if (pane && pane.enter) {
             pane.enter()
         }
-
     }
 
     public leave(): void {
@@ -49,9 +45,11 @@ export class SidebarContentSplit {
     }
 
     public render(): JSX.Element {
-        return <Provider store={this._sidebarManager.store}>
+        return (
+            <Provider store={this._sidebarManager.store}>
                 <SidebarContent />
             </Provider>
+        )
     }
 }
 
@@ -83,16 +81,21 @@ export const SidebarHeaderWrapper = withProps<ISidebarHeaderProps>(styled.div)`
     height: 2.5em;
     line-height: 2.5em;
     text-align: center;
-    border-top: ${props => props.hasFocus ? "2px solid " + props.theme["highlight.mode.normal.background"] : "2px solid transparent"};
+    border-top: ${props =>
+        props.hasFocus
+            ? "2px solid " + props.theme["highlight.mode.normal.background"]
+            : "2px solid transparent"};
 
     flex: 0 0 auto;
 `
 
 export class SidebarHeaderView extends React.PureComponent<ISidebarHeaderProps, {}> {
     public render(): JSX.Element {
-        return <SidebarHeaderWrapper {...this.props}>
+        return (
+            <SidebarHeaderWrapper {...this.props}>
                 <span>{this.props.headerName}</span>
             </SidebarHeaderWrapper>
+        )
     }
 }
 
@@ -103,7 +106,6 @@ export const SidebarInnerPaneWrapper = withProps<{}>(styled.div)`
 
 export class SidebarContentView extends React.PureComponent<ISidebarContentViewProps, {}> {
     public render(): JSX.Element {
-
         if (!this.props.activeEntry) {
             return null
         }
@@ -111,17 +113,16 @@ export class SidebarContentView extends React.PureComponent<ISidebarContentViewP
         const activeEntry = this.props.activeEntry
         const header = activeEntry && activeEntry.pane ? activeEntry.pane.title : null
 
-        return <SidebarContentWrapper key={activeEntry.id}>
-                    <SidebarHeaderView hasFocus={true} headerName={header} />
-                    <SidebarInnerPaneWrapper>
-                        {activeEntry.pane.render()}
-                    </SidebarInnerPaneWrapper>
+        return (
+            <SidebarContentWrapper key={activeEntry.id}>
+                <SidebarHeaderView hasFocus={true} headerName={header} />
+                <SidebarInnerPaneWrapper>{activeEntry.pane.render()}</SidebarInnerPaneWrapper>
             </SidebarContentWrapper>
+        )
     }
 }
 
 export const mapStateToProps = (state: ISidebarState): ISidebarContentViewProps => {
-
     const activeEntry = getActiveEntry(state)
     return {
         activeEntry,

--- a/browser/src/Services/Sidebar/SidebarPane/SidebarPane.tsx
+++ b/browser/src/Services/Sidebar/SidebarPane/SidebarPane.tsx
@@ -15,7 +15,6 @@ import { SidebarPaneContainer } from "./SidebarPaneView"
 import * as flatMap from "lodash/flatMap"
 
 export class SidebarPane {
-
     private _store: Store<SidebarPaneStore.ISidebarPaneState>
     private _menuBinding: IMenuBinding
     private _onEnterEvent: Event<void> = new Event<void>()
@@ -28,19 +27,19 @@ export class SidebarPane {
         return this._title
     }
 
-    constructor(
-        private _id: string,
-        private _title: string,
-    ) {
-        this._store = createStore("SidebarPane." + this._id, SidebarPaneStore.reducer, SidebarPaneStore.DefaultSidebarPaneState)
+    constructor(private _id: string, private _title: string) {
+        this._store = createStore(
+            "SidebarPane." + this._id,
+            SidebarPaneStore.reducer,
+            SidebarPaneStore.DefaultSidebarPaneState,
+        )
     }
 
     public enter(): void {
-
         this._menuBinding = getInstance().bindToMenu()
 
         const widgets = this._store.getState().widgets
-        const ids = flatMap(widgets, (w) => w.ids)
+        const ids = flatMap(widgets, w => w.ids)
 
         this._menuBinding.setItems(ids)
 
@@ -73,29 +72,29 @@ export class SidebarPane {
             type: "SET_WIDGETS",
             widgets,
         })
-
     }
 
     public render(): JSX.Element {
-        return <Provider store={this._store}>
-            <div>
-                <SidebarPaneContainer />
-                <div className="input">
-                    <KeyboardInputView
-                        top={0}
-                        left={0}
-                        height={12}
-                        onActivate={this._onEnterEvent}
-                        onKeyDown={(key) => this._onKeyDown(key)}
-                        foregroundColor={"white"}
-                        fontFamily={"Segoe UI"}
-                        fontSize={"12px"}
-                        fontCharacterWidthInPixels={12}
-
-                    />
+        return (
+            <Provider store={this._store}>
+                <div>
+                    <SidebarPaneContainer />
+                    <div className="input">
+                        <KeyboardInputView
+                            top={0}
+                            left={0}
+                            height={12}
+                            onActivate={this._onEnterEvent}
+                            onKeyDown={key => this._onKeyDown(key)}
+                            foregroundColor={"white"}
+                            fontFamily={"Segoe UI"}
+                            fontSize={"12px"}
+                            fontCharacterWidthInPixels={12}
+                        />
+                    </div>
                 </div>
-            </div>
-        </Provider>
+            </Provider>
+        )
     }
 
     private _onKeyDown(key: string) {

--- a/browser/src/Services/Sidebar/SidebarPane/SidebarPaneStore.ts
+++ b/browser/src/Services/Sidebar/SidebarPane/SidebarPaneStore.ts
@@ -13,13 +13,15 @@ export interface ISidebarPaneState {
     widgets: ISidebarWidget[]
 }
 
-export type SidebarPaneActions = {
-    type: "SET_WIDGETS",
-    widgets: ISidebarWidget[],
-} | {
-    type: "SET_SELECTED_ID",
-    selectedId: string,
-}
+export type SidebarPaneActions =
+    | {
+          type: "SET_WIDGETS"
+          widgets: ISidebarWidget[]
+      }
+    | {
+          type: "SET_SELECTED_ID"
+          selectedId: string
+      }
 
 export const DefaultSidebarPaneState: ISidebarPaneState = {
     widgets: [],

--- a/browser/src/Services/Sidebar/SidebarPane/SidebarPaneView.tsx
+++ b/browser/src/Services/Sidebar/SidebarPane/SidebarPaneView.tsx
@@ -10,17 +10,13 @@ export interface ISidebarPaneViewProps {
 
 export class SidebarPaneView extends React.PureComponent<ISidebarPaneViewProps, {}> {
     public render(): JSX.Element[] {
-
         const context: SidebarPaneStore.IWidgetRenderContext = {
             selectedId: this.props.selectedId,
         }
 
         return this.props.widgets.map((w, i) => {
-            return <div key={i}>
-            {w.render(context)}
-            </div>
-        },
-        )
+            return <div key={i}>{w.render(context)}</div>
+        })
     }
 }
 

--- a/browser/src/Services/Sidebar/SidebarPane/SidebarPaneWidgets.tsx
+++ b/browser/src/Services/Sidebar/SidebarPane/SidebarPaneWidgets.tsx
@@ -21,17 +21,17 @@ export class LabelWidget implements ISidebarWidget {
 export type ItemWidgetRenderFunction = (widgetRenderContext: IWidgetRenderContext) => JSX.Element
 
 export class ItemWidget implements ISidebarWidget {
-
     public get ids(): string[] {
         return [this._id]
     }
     private _renderer: ItemWidgetRenderFunction
 
     constructor(
-        private _id: string,
-        // private _renderer: ItemWidgetRenderFunction = (context) => <div style={{fontWeight: context.selectedId === this._id ? "bold" : null}}>Test2</div>
+        private _id: string, // private _renderer: ItemWidgetRenderFunction = (context) => <div style={{fontWeight: context.selectedId === this._id ? "bold" : null}}>Test2</div>
     ) {
-           this._renderer = (context) => <div style={{fontWeight: context.selectedId === this._id ? "bold" : null}}>Test2</div>
+        this._renderer = context => (
+            <div style={{ fontWeight: context.selectedId === this._id ? "bold" : null }}>Test2</div>
+        )
     }
 
     public render(widgetRenderContext: IWidgetRenderContext): JSX.Element {
@@ -51,7 +51,6 @@ export const ContainerWidgetWrapper = styled.div`
 `
 
 export class ContainerWidget implements ISidebarWidget {
-
     public get ids(): string[] {
         return []
     }
@@ -61,14 +60,13 @@ export class ContainerWidget implements ISidebarWidget {
         const caretStyle = {
             transform: expanded ? "rotateZ(45deg)" : "rotateZ(0deg)",
         }
-        return <ContainerWidgetWrapper>
-            <div className="icon">
-                <i style={caretStyle} className="fa fa-caret-right" />
-            </div>
-            <div className="name">
-                {"test"}
-            </div>
-        </ContainerWidgetWrapper>
+        return (
+            <ContainerWidgetWrapper>
+                <div className="icon">
+                    <i style={caretStyle} className="fa fa-caret-right" />
+                </div>
+                <div className="name">{"test"}</div>
+            </ContainerWidgetWrapper>
+        )
     }
-
 }

--- a/browser/src/Services/Sidebar/SidebarSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarSplit.tsx
@@ -12,10 +12,7 @@ import { SidebarManager } from "./SidebarStore"
 import { Sidebar } from "./SidebarView"
 
 export class SidebarSplit {
-
-    constructor(
-        private _sidebarManager: SidebarManager = new SidebarManager(),
-    ) { }
+    constructor(private _sidebarManager: SidebarManager = new SidebarManager()) {}
 
     public enter(): void {
         this._sidebarManager.setActiveEntry(this._sidebarManager.activeEntryId)
@@ -28,9 +25,11 @@ export class SidebarSplit {
     }
 
     public render(): JSX.Element {
-        return <Provider store={this._sidebarManager.store}>
-                <Sidebar onSelectionChanged={(val) => this._onSelectionChanged(val)}/>
+        return (
+            <Provider store={this._sidebarManager.store}>
+                <Sidebar onSelectionChanged={val => this._onSelectionChanged(val)} />
             </Provider>
+        )
     }
 
     private _onSelectionChanged(newVal: string): void {

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -36,7 +36,6 @@ export interface SidebarPane extends Oni.IWindowSplit {
 }
 
 export class SidebarManager {
-
     private _store: Store<ISidebarState>
 
     public get activeEntryId(): string {
@@ -91,17 +90,21 @@ const DefaultSidebarState: ISidebarState = {
     isActive: false,
 }
 
-export type SidebarActions = {
-    type: "SET_ACTIVE_ID",
-    activeEntryId: string,
-} | {
-    type: "ADD_ENTRY",
-    entry: ISidebarEntry,
-} | {
-    type: "ENTER",
-} | {
-    type: "LEAVE",
-}
+export type SidebarActions =
+    | {
+          type: "SET_ACTIVE_ID"
+          activeEntryId: string
+      }
+    | {
+          type: "ADD_ENTRY"
+          entry: ISidebarEntry
+      }
+    | {
+          type: "ENTER"
+      }
+    | {
+          type: "LEAVE"
+      }
 
 export const sidebarReducer: Reducer<ISidebarState> = (
     state: ISidebarState = DefaultSidebarState,

--- a/browser/src/Services/Sidebar/SidebarView.tsx
+++ b/browser/src/Services/Sidebar/SidebarView.tsx
@@ -30,11 +30,13 @@ const SidebarIconWrapper = withProps<ISidebarIconProps>(styled.div)`
     opacity: 0.5;
     outline: none;
     cursor: pointer;
-    opacity: ${props => props.active ? 0.9 : 0.75};
-    border: 1px solid ${props => props.focused ? props.theme["sidebar.selection.border"] : "transparent"};
-    background-color: ${ props => props.active ? props.theme["editor.background"] : props.theme.background};
+    opacity: ${props => (props.active ? 0.9 : 0.75)};
+    border: 1px solid ${props =>
+        props.focused ? props.theme["sidebar.selection.border"] : "transparent"};
+    background-color: ${props =>
+        props.active ? props.theme["editor.background"] : props.theme.background};
     transition: transform 0.2s ease-in;
-    transform: ${ props => (props.active || props.focused) ? "translateX(2px)" : "translateX(0px)"};
+    transform: ${props => (props.active || props.focused ? "translateX(2px)" : "translateX(0px)")};
 
     &.active {
         opacity: 0.75;
@@ -53,12 +55,13 @@ const SidebarIconInner = styled.div`
 
 export class SidebarIcon extends React.PureComponent<ISidebarIconProps, {}> {
     public render(): JSX.Element {
-
-        return <SidebarIconWrapper {...this.props} tabIndex={0}>
-                    <SidebarIconInner>
-                        <Icon name={this.props.iconName} size={IconSize.Large} />
-                    </SidebarIconInner>
-                </SidebarIconWrapper>
+        return (
+            <SidebarIconWrapper {...this.props} tabIndex={0}>
+                <SidebarIconInner>
+                    <Icon name={this.props.iconName} size={IconSize.Large} />
+                </SidebarIconInner>
+            </SidebarIconWrapper>
+        )
     }
 }
 
@@ -94,36 +97,40 @@ export class SidebarView extends React.PureComponent<ISidebarViewProps, {}> {
             return null
         }
 
-        const ids = this.props.entries.map((e) => e.id)
+        const ids = this.props.entries.map(e => e.id)
 
-        return <SidebarWrapper width={this.props.width}>
+        return (
+            <SidebarWrapper width={this.props.width}>
                 <VimNavigator
                     ids={ids}
                     active={this.props.isActive}
-                    onSelectionChanged={(val) => this.props.onSelectionChanged(val)}
-                    render={
-                        (selectedId: string): JSX.Element => {
-                            const items = this.props.entries.map((e) => {
-                                const isActive = e.id === this.props.activeEntryId
-                                const isFocused = e.id === selectedId && this.props.isActive
-                                return <SidebarIcon
-                                            key={e.id}
-                                            iconName={e.icon}
-                                            active={isActive}
-                                            focused={isFocused}
-                                            onClick={() => this.props.onSelectionChanged(e.id)}
-                                        />
-                            })
-                            return <div className="icons">{items}</div>
-                        }
-                    }
-                    />
+                    onSelectionChanged={val => this.props.onSelectionChanged(val)}
+                    render={(selectedId: string): JSX.Element => {
+                        const items = this.props.entries.map(e => {
+                            const isActive = e.id === this.props.activeEntryId
+                            const isFocused = e.id === selectedId && this.props.isActive
+                            return (
+                                <SidebarIcon
+                                    key={e.id}
+                                    iconName={e.icon}
+                                    active={isActive}
+                                    focused={isFocused}
+                                    onClick={() => this.props.onSelectionChanged(e.id)}
+                                />
+                            )
+                        })
+                        return <div className="icons">{items}</div>
+                    }}
+                />
             </SidebarWrapper>
-
+        )
     }
 }
 
-export const mapStateToProps = (state: ISidebarState, containerProps: ISidebarContainerProps): ISidebarViewProps => {
+export const mapStateToProps = (
+    state: ISidebarState,
+    containerProps: ISidebarContainerProps,
+): ISidebarViewProps => {
     return {
         ...containerProps,
         entries: state.entries,

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -14,7 +14,6 @@ import { SidebarPane } from "./SidebarPane"
 let _sidebarManager: SidebarManager = null
 
 export const activate = (configuration: Configuration, workspace: Workspace) => {
-
     _sidebarManager = new SidebarManager()
 
     if (configuration.getValue("experimental.sidebar.enabled")) {

--- a/browser/src/Services/Snippets/OniSnippet.ts
+++ b/browser/src/Services/Snippets/OniSnippet.ts
@@ -21,11 +21,13 @@ export interface OniSnippetPlaceholder {
     value: string
 }
 
-export const getLineCharacterFromOffset = (offset: number, lines: string[]): { line: number, character: number } => {
+export const getLineCharacterFromOffset = (
+    offset: number,
+    lines: string[],
+): { line: number; character: number } => {
     let idx = 0
     let currentOffset = 0
     while (idx < lines.length) {
-
         if (offset >= currentOffset && offset < currentOffset + lines[idx].length) {
             return { line: idx, character: offset - currentOffset }
         }
@@ -34,18 +36,14 @@ export const getLineCharacterFromOffset = (offset: number, lines: string[]): { l
         idx++
     }
 
-    return { line: -1, character: - 1}
+    return { line: -1, character: -1 }
 }
 
 export class OniSnippet {
     private _parser: Snippets.SnippetParser = new Snippets.SnippetParser()
-    private _placeholderValues: { [index: number]: string } = { }
+    private _placeholderValues: { [index: number]: string } = {}
 
-    constructor(
-        private _snippetString: string,
-    ) {
-
-    }
+    constructor(private _snippetString: string) {}
 
     public setPlaceholder(index: number, newValue: string): void {
         this._placeholderValues[index] = newValue
@@ -57,7 +55,7 @@ export class OniSnippet {
 
         const lines = this.getLines()
 
-        const oniPlaceholders = placeholders.map((p) => {
+        const oniPlaceholders = placeholders.map(p => {
             const offset = snippet.offset(p)
             const position = getLineCharacterFromOffset(offset, lines)
 
@@ -84,9 +82,11 @@ export class OniSnippet {
             const val = this._placeholderValues[key]
             const snip = this._parser.parse(val)
 
-            const placeholderToReplace = snippet.placeholders.filter((p) => p.index.toString() === key)
+            const placeholderToReplace = snippet.placeholders.filter(
+                p => p.index.toString() === key,
+            )
 
-            placeholderToReplace.forEach((rep) => {
+            placeholderToReplace.forEach(rep => {
                 snippet.replace(rep, snip.children)
             })
         })

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -10,18 +10,14 @@ import { OniSnippet } from "./OniSnippet"
 import { SnippetSession } from "./SnippetSession"
 
 export class SnippetManager {
-
     private _activeSession: SnippetSession
 
-    constructor(
-        private _editorManager: EditorManager,
-    ) { }
+    constructor(private _editorManager: EditorManager) {}
 
     /**
      * Inserts snippet in the active editor, at current cursor position
      */
     public async insertSnippet(snippet: string): Promise<void> {
-
         const snip = new OniSnippet(snippet)
 
         const activeEditor = this._editorManager.activeEditor

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -12,14 +12,12 @@ import { IBuffer } from "./../../Editor/BufferManager"
 import { IEditor } from "./../../Editor/Editor"
 
 export const splitLineAtPosition = (line: string, position: number): [string, string] => {
-
     const prefix = line.substring(0, position)
     const post = line.substring(position, line.length)
     return [prefix, post]
 }
 
 export class SnippetSession {
-
     private _buffer: IBuffer
     private _position: types.Position
 
@@ -29,15 +27,15 @@ export class SnippetSession {
 
     private _placeholderIndex: number = 0
 
-    constructor(
-        private _editor: IEditor,
-        private _snippet: OniSnippet,
-    ) { }
+    constructor(private _editor: IEditor, private _snippet: OniSnippet) {}
 
     public async start(): Promise<void> {
         this._buffer = this._editor.activeBuffer as IBuffer
         const cursorPosition = await this._buffer.getCursorPosition()
-        const [currentLine] = await this._buffer.getLines(cursorPosition.line, cursorPosition.line + 1)
+        const [currentLine] = await this._buffer.getLines(
+            cursorPosition.line,
+            cursorPosition.line + 1,
+        )
 
         this._position = cursorPosition
 
@@ -51,7 +49,11 @@ export class SnippetSession {
         snippetLines[0] = this._prefix + snippetLines[0]
         snippetLines[lastIndex] = snippetLines[lastIndex] + this._suffix
 
-        await this._buffer.setLines(cursorPosition.line, cursorPosition.line + snippetLines.length, snippetLines)
+        await this._buffer.setLines(
+            cursorPosition.line,
+            cursorPosition.line + snippetLines.length,
+            snippetLines,
+        )
     }
 
     public async nextPlaceholder(): Promise<void> {
@@ -61,9 +63,19 @@ export class SnippetSession {
         this._placeholderIndex++
 
         const adjustedLine = firstPlaceholder.line + this._position.line
-        const adjustedCharacter = firstPlaceholder.line === 0 ? this._position.character + firstPlaceholder.character : firstPlaceholder.character
+        const adjustedCharacter =
+            firstPlaceholder.line === 0
+                ? this._position.character + firstPlaceholder.character
+                : firstPlaceholder.character
         const placeHolderLength = firstPlaceholder.value.length
 
-        await this._editor.setSelection(types.Range.create(adjustedLine, adjustedCharacter, adjustedLine, adjustedCharacter + placeHolderLength))
+        await this._editor.setSelection(
+            types.Range.create(
+                adjustedLine,
+                adjustedCharacter,
+                adjustedLine,
+                adjustedCharacter + placeHolderLength,
+            ),
+        )
     }
 }

--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -32,7 +32,6 @@ export class StatusBarItem implements Oni.StatusBarItem {
         private _alignment?: StatusBarAlignment | null,
         private _priority?: number | null,
     ) {
-
         this._subscription = this._setContentsSubject
             .debounceTime(25)
             .subscribe((contents: any) => {

--- a/browser/src/Services/SyntaxHighlighting/Definitions.ts
+++ b/browser/src/Services/SyntaxHighlighting/Definitions.ts
@@ -1,4 +1,3 @@
-
 import * as types from "vscode-languageserver-types"
 
 export interface IHighlight {
@@ -11,4 +10,7 @@ export interface IHighlight {
 
 export type HighlightGroupId = string
 
-export interface HighlightInfo { range: types.Range, highlightGroup: HighlightGroupId }
+export interface HighlightInfo {
+    range: types.Range
+    highlightGroup: HighlightGroupId
+}

--- a/browser/src/Services/SyntaxHighlighting/GrammarLoader.ts
+++ b/browser/src/Services/SyntaxHighlighting/GrammarLoader.ts
@@ -8,11 +8,15 @@ export interface IGrammarLoader {
     getGrammarForLanguage(language: string, extension: string): Promise<IGrammar>
 }
 
-export interface ExtensionToGrammarMap { [extension: string]: string }
+export interface ExtensionToGrammarMap {
+    [extension: string]: string
+}
 
 export const getPathForLanguage = (language: string, extension: string): string => {
     const verifiedLanguage = language.includes(".") ? language.split(".")[0] : language
-    const grammar: string | ExtensionToGrammarMap = configuration.getValue("language." + verifiedLanguage + ".textMateGrammar")
+    const grammar: string | ExtensionToGrammarMap = configuration.getValue(
+        "language." + verifiedLanguage + ".textMateGrammar",
+    )
 
     if (!grammar) {
         Log.warn("No grammar found for language: " + language)
@@ -25,15 +29,11 @@ export const getPathForLanguage = (language: string, extension: string): string 
 }
 
 export class GrammarLoader implements IGrammarLoader {
-
     private _grammarCache: { [language: string]: IGrammar } = {}
 
-    constructor(
-        private _registry: Registry = new Registry(),
-    ) {}
+    constructor(private _registry: Registry = new Registry()) {}
 
     public async getGrammarForLanguage(language: string, extension: string): Promise<IGrammar> {
-
         if (!language) {
             return null
         }

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightReconciler.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightReconciler.ts
@@ -9,7 +9,11 @@ import { Configuration } from "./../Configuration"
 import { NeovimEditor } from "./../../Editor/NeovimEditor"
 
 import { HighlightGroupId, HighlightInfo } from "./Definitions"
-import { ISyntaxHighlightLineInfo, ISyntaxHighlightState, ISyntaxHighlightTokenInfo } from "./SyntaxHighlightingStore"
+import {
+    ISyntaxHighlightLineInfo,
+    ISyntaxHighlightState,
+    ISyntaxHighlightTokenInfo,
+} from "./SyntaxHighlightingStore"
 
 import * as Selectors from "./SyntaxHighlightSelectors"
 
@@ -21,13 +25,9 @@ import * as Log from "./../../Log"
 // highlight calls to the active buffer based on the active
 // window and viewport
 export class SyntaxHighlightReconciler {
+    private _previousState: { [line: number]: ISyntaxHighlightLineInfo } = {}
 
-    private _previousState: { [line: number]: ISyntaxHighlightLineInfo} = {}
-
-    constructor(
-        private _configuration: Configuration,
-        private _editor: NeovimEditor,
-    ) { }
+    constructor(private _configuration: Configuration, private _editor: NeovimEditor) {}
 
     public update(state: ISyntaxHighlightState) {
         const activeBuffer: any = this._editor.activeBuffer
@@ -45,12 +45,11 @@ export class SyntaxHighlightReconciler {
 
             const relevantRange = Selectors.getRelevantRange(state, bufferId)
 
-            const filteredLines = lineNumbers.filter((line) => {
+            const filteredLines = lineNumbers.filter(line => {
                 const lineNumber = parseInt(line, 10)
 
                 // Ignore lines that are not in current view
-                if (lineNumber < relevantRange.top
-                    || lineNumber > relevantRange.bottom) {
+                if (lineNumber < relevantRange.top || lineNumber > relevantRange.bottom) {
                     return false
                 }
 
@@ -65,7 +64,7 @@ export class SyntaxHighlightReconciler {
                 return this._previousState[line] !== currentHighlightState.lines[line]
             })
 
-            const tokens = filteredLines.map((li) => {
+            const tokens = filteredLines.map(li => {
                 const line = currentHighlightState.lines[li]
 
                 const highlights = this._mapTokensToHighlights(line.tokens)
@@ -75,19 +74,26 @@ export class SyntaxHighlightReconciler {
                 }
             })
 
-            filteredLines.forEach((li) => {
+            filteredLines.forEach(li => {
                 this._previousState[li] = currentHighlightState.lines[li]
             })
 
             if (tokens.length > 0) {
-                Log.verbose("[SyntaxHighlightReconciler] Applying changes to " + tokens.length + " lines.")
+                Log.verbose(
+                    "[SyntaxHighlightReconciler] Applying changes to " + tokens.length + " lines.",
+                )
                 activeBuffer.updateHighlights((highlightUpdater: any) => {
-                    tokens.forEach((token) => {
+                    tokens.forEach(token => {
                         const line = token.line
                         const highlights = token.highlights
 
                         if (Log.isDebugLoggingEnabled()) {
-                            Log.debug("[SyntaxHighlightingReconciler] Updating tokens for line: " + token.line + " | " + JSON.stringify(highlights))
+                            Log.debug(
+                                "[SyntaxHighlightingReconciler] Updating tokens for line: " +
+                                    token.line +
+                                    " | " +
+                                    JSON.stringify(highlights),
+                            )
                         }
 
                         highlightUpdater.setHighlightsForLine(line, highlights)
@@ -98,18 +104,15 @@ export class SyntaxHighlightReconciler {
     }
 
     private _mapTokensToHighlights(tokens: ISyntaxHighlightTokenInfo[]): HighlightInfo[] {
-
         const mapTokenToHighlight = (token: ISyntaxHighlightTokenInfo) => ({
             highlightGroup: this._getHighlightGroupFromScope(token.scopes),
             range: token.range,
         })
 
-        return tokens.map(mapTokenToHighlight)
-                .filter((t) => !!t.highlightGroup)
+        return tokens.map(mapTokenToHighlight).filter(t => !!t.highlightGroup)
     }
 
     private _getHighlightGroupFromScope(scopes: string[]): HighlightGroupId {
-
         const configurationColors = this._configuration.getValue("editor.tokenColors")
 
         for (const scope of scopes) {

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightSelectors.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightSelectors.ts
@@ -4,12 +4,17 @@
 
 import { ISyntaxHighlightState } from "./SyntaxHighlightingStore"
 
-export interface SyntaxHighlightRange { top: number, bottom: number }
+export interface SyntaxHighlightRange {
+    top: number
+    bottom: number
+}
 
 export const NullRange: SyntaxHighlightRange = { top: -1, bottom: -1 }
 
-export const getRelevantRange = (state: ISyntaxHighlightState, bufferId: number | string): SyntaxHighlightRange => {
-
+export const getRelevantRange = (
+    state: ISyntaxHighlightState,
+    bufferId: number | string,
+): SyntaxHighlightRange => {
     if (!state.bufferToHighlights[bufferId]) {
         return NullRange
     }

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlighting.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlighting.ts
@@ -17,7 +17,11 @@ import { Configuration } from "./../Configuration"
 
 import { NeovimEditor } from "./../../Editor/NeovimEditor"
 
-import { createSyntaxHighlightStore, ISyntaxHighlightState, ISyntaxHighlightTokenInfo } from "./SyntaxHighlightingStore"
+import {
+    createSyntaxHighlightStore,
+    ISyntaxHighlightState,
+    ISyntaxHighlightTokenInfo,
+} from "./SyntaxHighlightingStore"
 
 import { ISyntaxHighlighter } from "./ISyntaxHighlighter"
 import { SyntaxHighlightReconciler } from "./SyntaxHighlightReconciler"
@@ -26,15 +30,11 @@ import * as Log from "./../../Log"
 import * as Utility from "./../../Utility"
 
 export class SyntaxHighlighter implements ISyntaxHighlighter {
-
     private _store: Store<ISyntaxHighlightState>
     private _reconciler: SyntaxHighlightReconciler
     private _unsubscribe: Unsubscribe
 
-    constructor(
-        private _configuration: Configuration,
-        private _editor: NeovimEditor,
-    ) {
+    constructor(private _configuration: Configuration, private _editor: NeovimEditor) {
         this._store = createSyntaxHighlightStore()
 
         this._reconciler = new SyntaxHighlightReconciler(this._configuration, this._editor)
@@ -44,14 +44,28 @@ export class SyntaxHighlighter implements ISyntaxHighlighter {
         })
     }
 
-    public notifyViewportChanged(bufferId: string, topLineInView: number, bottomLineInView: number): void {
-
-        Log.verbose("[SyntaxHighlighting.notifyViewportChanged] - bufferId: " + bufferId + " topLineInView: " + topLineInView + " bottomLineInView: " + bottomLineInView)
+    public notifyViewportChanged(
+        bufferId: string,
+        topLineInView: number,
+        bottomLineInView: number,
+    ): void {
+        Log.verbose(
+            "[SyntaxHighlighting.notifyViewportChanged] - bufferId: " +
+                bufferId +
+                " topLineInView: " +
+                topLineInView +
+                " bottomLineInView: " +
+                bottomLineInView,
+        )
 
         const state = this._store.getState()
         const previousBufferState = state.bufferToHighlights[bufferId]
 
-        if (previousBufferState && topLineInView === previousBufferState.topVisibleLine && bottomLineInView === previousBufferState.bottomVisibleLine) {
+        if (
+            previousBufferState &&
+            topLineInView === previousBufferState.topVisibleLine &&
+            bottomLineInView === previousBufferState.bottomVisibleLine
+        ) {
             return
         }
 
@@ -71,7 +85,6 @@ export class SyntaxHighlighter implements ISyntaxHighlighter {
     }
 
     public async notifyEndInsertMode(buffer: any): Promise<void> {
-
         const lines = await buffer.getLines(0, buffer.lineCount, false)
 
         // const currentState = this._store.getState()
@@ -103,7 +116,6 @@ export class SyntaxHighlighter implements ISyntaxHighlighter {
                 lines,
             })
         } else {
-
             // Incremental update
             this._store.dispatch({
                 type: "SYNTAX_UPDATE_BUFFER_LINE",
@@ -114,8 +126,10 @@ export class SyntaxHighlighter implements ISyntaxHighlighter {
         }
     }
 
-    public getHighlightTokenAt(bufferId: string, position: types.Position): ISyntaxHighlightTokenInfo {
-
+    public getHighlightTokenAt(
+        bufferId: string,
+        position: types.Position,
+    ): ISyntaxHighlightTokenInfo {
         const state = this._store.getState()
         const buffer = state.bufferToHighlights[bufferId]
 
@@ -129,7 +143,7 @@ export class SyntaxHighlighter implements ISyntaxHighlighter {
             return null
         }
 
-        return line.tokens.find((r) => Utility.isInRange(position.line, position.character, r.range))
+        return line.tokens.find(r => Utility.isInRange(position.line, position.character, r.range))
     }
 
     public dispose(): void {
@@ -149,11 +163,18 @@ export class NullSyntaxHighlighter implements ISyntaxHighlighter {
         return Promise.resolve(null)
     }
 
-    public getHighlightTokenAt(bufferId: string, position: types.Position): ISyntaxHighlightTokenInfo {
+    public getHighlightTokenAt(
+        bufferId: string,
+        position: types.Position,
+    ): ISyntaxHighlightTokenInfo {
         return null
     }
 
-    public notifyViewportChanged(bufferId: string, topLineInView: number, bottomLineInView: number): void {
+    public notifyViewportChanged(
+        bufferId: string,
+        topLineInView: number,
+        bottomLineInView: number,
+    ): void {
         // tslint: disable-line
     }
     public notifyStartInsertMode(buffer: Oni.Buffer): void {
@@ -164,5 +185,5 @@ export class NullSyntaxHighlighter implements ISyntaxHighlighter {
         // tslint: disable-line
     }
 
-    public dispose(): void { } // tslint:disable-line
+    public dispose(): void {} // tslint:disable-line
 }

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingPeriodicJob.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingPeriodicJob.ts
@@ -20,34 +20,34 @@ import * as Log from "./../../Log"
 export const SYNTAX_JOB_BUDGET = 10 // Budget in milliseconds - time to allow the job to run for
 
 export class SyntaxHighlightingPeriodicJob implements IPeriodicJob {
-
     constructor(
         private _store: Store<SyntaxHighlighting.ISyntaxHighlightState>,
         private _bufferId: string,
         private _grammar: IGrammar,
         private _topLine: number,
         private _bottomLine: number,
-    ) {
-    }
+    ) {}
 
     public execute(): boolean {
-
         const start = new Date().getTime()
 
         // If the window has changed, we should bail
         const currentWindow = Selectors.getRelevantRange(this._store.getState(), this._bufferId)
 
         if (currentWindow.top !== this._topLine || currentWindow.bottom !== this._bottomLine) {
-            Log.verbose("[SyntaxHighlightingPeriodicJob.execute] Completing without doing work, as window size has changed.")
+            Log.verbose(
+                "[SyntaxHighlightingPeriodicJob.execute] Completing without doing work, as window size has changed.",
+            )
             return true
         }
 
         while (true) {
-
             const current = new Date().getTime()
 
             if (current - start > SYNTAX_JOB_BUDGET) {
-                Log.verbose("[SyntaxHighlightingPeriodicJob.execute] Pending due to exceeding budget.")
+                Log.verbose(
+                    "[SyntaxHighlightingPeriodicJob.execute] Pending due to exceeding budget.",
+                )
                 return false
             }
 
@@ -66,12 +66,12 @@ export class SyntaxHighlightingPeriodicJob implements IPeriodicJob {
         }
     }
 
-    private _tokenizeFirstDirtyLine(state: SyntaxHighlighting.IBufferSyntaxHighlightState): boolean {
-
+    private _tokenizeFirstDirtyLine(
+        state: SyntaxHighlighting.IBufferSyntaxHighlightState,
+    ): boolean {
         let index = this._topLine
 
         while (index <= this._bottomLine) {
-
             const line = state.lines[index]
 
             if (!line) {

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
@@ -2,7 +2,12 @@
 //
 // Reducers for handling state changes from ISyntaxHighlightActions
 
-import { IBufferSyntaxHighlightState, ISyntaxHighlightAction, ISyntaxHighlightState, SyntaxHighlightLines } from "./SyntaxHighlightingStore"
+import {
+    IBufferSyntaxHighlightState,
+    ISyntaxHighlightAction,
+    ISyntaxHighlightState,
+    SyntaxHighlightLines,
+} from "./SyntaxHighlightingStore"
 
 import { Reducer } from "redux"
 
@@ -13,7 +18,6 @@ export const reducer: Reducer<ISyntaxHighlightState> = (
     },
     action: ISyntaxHighlightAction,
 ) => {
-
     let newState = state
 
     switch (action.type) {
@@ -37,7 +41,9 @@ export const reducer: Reducer<ISyntaxHighlightState> = (
     }
 }
 
-export const bufferToHighlightsReducer: Reducer<{ [bufferId: string]: IBufferSyntaxHighlightState }> = (
+export const bufferToHighlightsReducer: Reducer<{
+    [bufferId: string]: IBufferSyntaxHighlightState
+}> = (
     state: { [bufferId: string]: IBufferSyntaxHighlightState } = {},
     action: ISyntaxHighlightAction,
 ) => {
@@ -59,7 +65,6 @@ export const bufferReducer: Reducer<IBufferSyntaxHighlightState> = (
     },
     action: ISyntaxHighlightAction,
 ) => {
-
     switch (action.type) {
         case "START_INSERT_MODE":
             return {
@@ -100,56 +105,55 @@ export const linesReducer: Reducer<SyntaxHighlightLines> = (
     state: SyntaxHighlightLines = {},
     action: ISyntaxHighlightAction,
 ) => {
-
     switch (action.type) {
-        case "SYNTAX_UPDATE_TOKENS_FOR_LINE":
-            {
-                const newState = {
-                    ...state,
-                }
-
-                const originalLine = newState[action.lineNumber]
-
-                // If the ruleStack changed, we need to invalidate the next line
-                const shouldDirtyNextLine = originalLine && originalLine.ruleStack && !originalLine.ruleStack.equals(action.ruleStack)
-
-                newState[action.lineNumber] = {
-                    ...originalLine,
-                    dirty: false,
-                    tokens: action.tokens,
-                    ruleStack: action.ruleStack,
-                }
-
-                const nextLine = newState[action.lineNumber + 1]
-                if (shouldDirtyNextLine && nextLine) {
-                    newState[action.lineNumber + 1] = {
-                        ...nextLine,
-                        dirty: true,
-                    }
-                }
-
-                return newState
+        case "SYNTAX_UPDATE_TOKENS_FOR_LINE": {
+            const newState = {
+                ...state,
             }
-        case "SYNTAX_UPDATE_BUFFER_LINE":
-            {
-                const newState = {
-                    ...state,
-                }
 
-                // Set 'dirty' flag for updated line to true
-                const oldLine = newState[action.lineNumber]
-                newState[action.lineNumber] = {
-                    tokens: [],
-                    ruleStack: null,
-                    ...oldLine,
-                    line: action.line,
+            const originalLine = newState[action.lineNumber]
+
+            // If the ruleStack changed, we need to invalidate the next line
+            const shouldDirtyNextLine =
+                originalLine &&
+                originalLine.ruleStack &&
+                !originalLine.ruleStack.equals(action.ruleStack)
+
+            newState[action.lineNumber] = {
+                ...originalLine,
+                dirty: false,
+                tokens: action.tokens,
+                ruleStack: action.ruleStack,
+            }
+
+            const nextLine = newState[action.lineNumber + 1]
+            if (shouldDirtyNextLine && nextLine) {
+                newState[action.lineNumber + 1] = {
+                    ...nextLine,
                     dirty: true,
                 }
-
-                return newState
             }
-        case "SYNTAX_UPDATE_BUFFER":
 
+            return newState
+        }
+        case "SYNTAX_UPDATE_BUFFER_LINE": {
+            const newState = {
+                ...state,
+            }
+
+            // Set 'dirty' flag for updated line to true
+            const oldLine = newState[action.lineNumber]
+            newState[action.lineNumber] = {
+                tokens: [],
+                ruleStack: null,
+                ...oldLine,
+                line: action.line,
+                dirty: true,
+            }
+
+            return newState
+        }
+        case "SYNTAX_UPDATE_BUFFER":
             const updatedBufferState: SyntaxHighlightLines = {
                 ...state,
             }
@@ -169,7 +173,6 @@ export const linesReducer: Reducer<SyntaxHighlightLines> = (
                     line: newLine,
                     dirty: true,
                 }
-
             }
 
             return updatedBufferState

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
@@ -29,10 +29,12 @@ export interface ISyntaxHighlightLineInfo {
     line: string
     ruleStack: StackElement
     tokens: ISyntaxHighlightTokenInfo[]
-    dirty: boolean,
+    dirty: boolean
 }
 
-export interface SyntaxHighlightLines {[key: number]: ISyntaxHighlightLineInfo}
+export interface SyntaxHighlightLines {
+    [key: number]: ISyntaxHighlightLineInfo
+}
 
 export interface IBufferSyntaxHighlightState {
     bufferId: string
@@ -53,7 +55,7 @@ export interface IBufferSyntaxHighlightState {
 export interface ISyntaxHighlightState {
     isInsertMode: boolean
     bufferToHighlights: {
-        [bufferId: string]: IBufferSyntaxHighlightState,
+        [bufferId: string]: IBufferSyntaxHighlightState
     }
 }
 
@@ -62,79 +64,91 @@ export const DefaultSyntaxHighlightState: ISyntaxHighlightState = {
     bufferToHighlights: {},
 }
 
-export type ISyntaxHighlightAction = {
-    type: "SYNTAX_UPDATE_BUFFER",
-    language: string,
-    extension: string,
-    bufferId: string,
-    lines: string[],
-} | {
-        type: "SYNTAX_UPDATE_BUFFER_LINE",
-        bufferId: string,
-        lineNumber: number,
-        line: string,
-    } | {
-        type: "SYNTAX_UPDATE_TOKENS_FOR_LINE",
-        bufferId: string,
-        lineNumber: number,
-        tokens: ISyntaxHighlightTokenInfo[],
-        ruleStack: StackElement,
-    } | {
-        type: "SYNTAX_UPDATE_BUFFER_VIEWPORT",
-        bufferId: string,
-        topVisibleLine: number,
-        bottomVisibleLine: number,
-    } | {
-        type: "START_INSERT_MODE",
-        bufferId: string,
-    } | {
-        type: "END_INSERT_MODE",
-        bufferId: string,
-    }
+export type ISyntaxHighlightAction =
+    | {
+          type: "SYNTAX_UPDATE_BUFFER"
+          language: string
+          extension: string
+          bufferId: string
+          lines: string[]
+      }
+    | {
+          type: "SYNTAX_UPDATE_BUFFER_LINE"
+          bufferId: string
+          lineNumber: number
+          line: string
+      }
+    | {
+          type: "SYNTAX_UPDATE_TOKENS_FOR_LINE"
+          bufferId: string
+          lineNumber: number
+          tokens: ISyntaxHighlightTokenInfo[]
+          ruleStack: StackElement
+      }
+    | {
+          type: "SYNTAX_UPDATE_BUFFER_VIEWPORT"
+          bufferId: string
+          topVisibleLine: number
+          bottomVisibleLine: number
+      }
+    | {
+          type: "START_INSERT_MODE"
+          bufferId: string
+      }
+    | {
+          type: "END_INSERT_MODE"
+          bufferId: string
+      }
 
 const grammarLoader = new GrammarLoader()
 
 const updateTokenMiddleware = (store: any) => (next: any) => (action: any) => {
     const result: ISyntaxHighlightAction = next(action)
 
-    if (action.type === "SYNTAX_UPDATE_BUFFER"
-        || action.type === "SYNTAX_UPDATE_BUFFER_LINE"
-        || action.type === "SYNTAX_UPDATE_BUFFER_VIEWPORT") {
+    if (
+        action.type === "SYNTAX_UPDATE_BUFFER" ||
+        action.type === "SYNTAX_UPDATE_BUFFER_LINE" ||
+        action.type === "SYNTAX_UPDATE_BUFFER_VIEWPORT"
+    ) {
+        const state = store.getState()
+        const bufferId = action.bufferId
 
-            const state = store.getState()
-            const bufferId = action.bufferId
+        const language = state.bufferToHighlights[bufferId].language
+        const extension = state.bufferToHighlights[bufferId].extension
 
-            const language = state.bufferToHighlights[bufferId].language
-            const extension = state.bufferToHighlights[bufferId].extension
+        if (!language || !extension) {
+            return result
+        }
 
-            if (!language || !extension) {
-                return result
+        grammarLoader.getGrammarForLanguage(language, extension).then(grammar => {
+            if (!grammar) {
+                return
             }
 
-            grammarLoader.getGrammarForLanguage(language, extension)
-            .then((grammar) => {
+            const buffer = state.bufferToHighlights[bufferId]
 
-                if (!grammar) {
-                    return
-                }
+            if (
+                Object.keys(buffer.lines).length >=
+                configuration.getValue("experimental.editor.textMateHighlighting.maxLines")
+            ) {
+                Log.info(
+                    "[SyntaxHighlighting - fullBufferUpdateEpic]: Not applying syntax highlighting as the maxLines limit was exceeded",
+                )
+                return
+            }
 
-                const buffer = state.bufferToHighlights[bufferId]
+            const relevantRange = Selectors.getRelevantRange(state, bufferId)
 
-                if (Object.keys(buffer.lines).length >= configuration.getValue("experimental.editor.textMateHighlighting.maxLines")) {
-                    Log.info("[SyntaxHighlighting - fullBufferUpdateEpic]: Not applying syntax highlighting as the maxLines limit was exceeded")
-                    return
-                }
-
-                const relevantRange = Selectors.getRelevantRange(state, bufferId)
-
-                syntaxHighlightingJobs.startJob(new SyntaxHighlightingPeriodicJob(
+            syntaxHighlightingJobs.startJob(
+                new SyntaxHighlightingPeriodicJob(
                     store as any,
                     action.bufferId,
                     grammar,
                     relevantRange.top,
                     relevantRange.bottom,
-                ))
-            })
+                ),
+            )
+        })
     }
 
     return result

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -35,9 +35,7 @@ export class Tasks {
     private _menu: Menu
     private _providers: ITaskProvider[] = []
 
-    constructor(
-        private _menuManager: MenuManager,
-    ) { }
+    constructor(private _menuManager: MenuManager) {}
 
     // TODO: This should be refactored, as it is simply
     // a timing dependency on when the object is created versus when
@@ -49,14 +47,14 @@ export class Tasks {
     public show(): void {
         this._refreshTasks().then(() => {
             const options: Oni.Menu.MenuOption[] = this._lastTasks
-                        .filter((t) => t.name || t.detail)
-                        .map((f) => {
-                            return {
-                                icon: "tasks",
-                                label: f.name,
-                                detail: f.detail,
-                            }
-                        })
+                .filter(t => t.name || t.detail)
+                .map(f => {
+                    return {
+                        icon: "tasks",
+                        label: f.name,
+                        detail: f.detail,
+                    }
+                })
 
             this._menu = this._menuManager.create()
             this._menu.onItemSelected.subscribe((selection: any) => this._onItemSelected(selection))
@@ -66,16 +64,20 @@ export class Tasks {
     }
 
     private async _onItemSelected(selectedOption: Oni.Menu.MenuOption): Promise<void> {
-        const {label, detail} = selectedOption
+        const { label, detail } = selectedOption
 
-        const selectedTask = find(this._lastTasks, (t) => t.name === label && t.detail === detail)
+        const selectedTask = find(this._lastTasks, t => t.name === label && t.detail === detail)
 
         if (selectedTask) {
             await selectedTask.callback()
 
             // TODO: we should make the callback return a bool so we can display either success/fail messages
             if (selectedTask.messageSuccess != null) {
-              remote.dialog.showMessageBox({type: "info", title: "Success", message: selectedTask.messageSuccess})
+                remote.dialog.showMessageBox({
+                    type: "info",
+                    title: "Success",
+                    message: selectedTask.messageSuccess,
+                })
             }
         }
     }
@@ -85,7 +87,9 @@ export class Tasks {
 
         const initialProviders: ITaskProvider[] = []
         const taskProviders = initialProviders.concat(this._providers)
-        const allTasks = await Promise.all(taskProviders.map(async (t: ITaskProvider) => await t.getTasks() || []))
+        const allTasks = await Promise.all(
+            taskProviders.map(async (t: ITaskProvider) => (await t.getTasks()) || []),
+        )
         this._lastTasks = flatten(allTasks)
     }
 }

--- a/browser/src/Services/Themes/ThemeLoader.ts
+++ b/browser/src/Services/Themes/ThemeLoader.ts
@@ -17,7 +17,6 @@ export interface IThemeLoader {
 }
 
 export class DefaultLoader implements IThemeLoader {
-
     public async getAllThemes(): Promise<IThemeContribution[]> {
         return Promise.resolve([])
     }
@@ -28,25 +27,22 @@ export class DefaultLoader implements IThemeLoader {
 }
 
 export class PluginThemeLoader implements IThemeLoader {
-
-    constructor(
-        private _pluginManager: PluginManager,
-    ) { }
+    constructor(private _pluginManager: PluginManager) {}
 
     public async getAllThemes(): Promise<IThemeContribution[]> {
         const plugins = this._pluginManager.plugins
 
-        const pluginsWithThemes = plugins.filter((p) => {
+        const pluginsWithThemes = plugins.filter(p => {
             return p.metadata && p.metadata.contributes && p.metadata.contributes.themes
         })
 
-        const allThemes = pluginsWithThemes.reduce((previous: IThemeContribution[], current) => {
-            const themes = current.metadata.contributes.themes
-            return [
-                ...previous,
-                ...themes,
-            ]
-        }, [] as IThemeContribution[])
+        const allThemes = pluginsWithThemes.reduce(
+            (previous: IThemeContribution[], current) => {
+                const themes = current.metadata.contributes.themes
+                return [...previous, ...themes]
+            },
+            [] as IThemeContribution[],
+        )
 
         return allThemes
     }
@@ -54,7 +50,7 @@ export class PluginThemeLoader implements IThemeLoader {
     public async getThemeByName(name: string): Promise<IThemeMetadata> {
         const allThemes = await this.getAllThemes()
 
-        const matchingTheme = allThemes.find((t) => t.name === name)
+        const matchingTheme = allThemes.find(t => t.name === name)
 
         if (!matchingTheme || !matchingTheme.path) {
             return null

--- a/browser/src/Services/Themes/ThemeManager.ts
+++ b/browser/src/Services/Themes/ThemeManager.ts
@@ -9,18 +9,14 @@ import { Event, IEvent } from "oni-types"
 import { IThemeContribution } from "./../../Plugins/Api/Capabilities"
 import { PluginManager } from "./../../Plugins/PluginManager"
 
-import {
-    Configuration,
-    configuration,
-    GenericConfigurationValues,
-} from "./../Configuration"
+import { Configuration, configuration, GenericConfigurationValues } from "./../Configuration"
 
 import * as PersistentSettings from "./../Configuration/PersistentSettings"
 import { IThemeLoader, PluginThemeLoader } from "./ThemeLoader"
 
 export interface IThemeColors {
-    "background": string
-    "foreground": string
+    background: string
+    foreground: string
     "editor.background": string
     "editor.foreground": string
 
@@ -98,27 +94,40 @@ export const getBorderColor = (bgColor: string, fgColor: string): string => {
     const backgroundColor = Color(bgColor)
     const foregroundColor = Color(fgColor)
 
-    const borderColor = backgroundColor.luminosity() > 0.5 ? foregroundColor.lighten(0.6) : foregroundColor.darken(0.6)
+    const borderColor =
+        backgroundColor.luminosity() > 0.5
+            ? foregroundColor.lighten(0.6)
+            : foregroundColor.darken(0.6)
     return borderColor.hex().toString()
 }
 
 export const getBackgroundColor = (editorBackground: string): string => {
-    return Color(editorBackground).darken(0.25).hex().toString()
+    return Color(editorBackground)
+        .darken(0.25)
+        .hex()
+        .toString()
 }
 
-const darken = (c: string, deg = 0.15) => Color(c).darken(0.15).hex().toString()
-const alterColor = (c: string) => Color(c).luminosity() > 0.5 ? darken(c) : darken(c, 0.6)
+const darken = (c: string, deg = 0.15) =>
+    Color(c)
+        .darken(0.15)
+        .hex()
+        .toString()
+const alterColor = (c: string) => (Color(c).luminosity() > 0.5 ? darken(c) : darken(c, 0.6))
 
-export const getHoverColors = (userConfig: GenericConfigurationValues, colors: Partial<IThemeColors>) => {
+export const getHoverColors = (
+    userConfig: GenericConfigurationValues,
+    colors: Partial<IThemeColors>,
+) => {
     const alteredBackground = alterColor(colors["toolTip.background"])
     const hoverDefaults = {
-            "editor.hover.title.background": alteredBackground,
-            "editor.hover.title.foreground": colors["toolTip.foreground"],
-            "editor.hover.border": colors["toolTip.border"],
-            "editor.hover.contents.background": alteredBackground,
-            "editor.hover.contents.foreground": colors["toolTip.foreground"],
-            "editor.hover.contents.codeblock.background": darken(alteredBackground, 0.25),
-            "editor.hover.contents.codeblock.foreground": colors["toolTip.foreground"],
+        "editor.hover.title.background": alteredBackground,
+        "editor.hover.title.foreground": colors["toolTip.foreground"],
+        "editor.hover.border": colors["toolTip.border"],
+        "editor.hover.contents.background": alteredBackground,
+        "editor.hover.contents.foreground": colors["toolTip.foreground"],
+        "editor.hover.contents.codeblock.background": darken(alteredBackground, 0.25),
+        "editor.hover.contents.codeblock.foreground": colors["toolTip.foreground"],
     }
 
     const userHoverColors = Object.keys(userConfig)
@@ -144,8 +153,8 @@ export const getColorsFromBackgroundAndForeground = (background: string, foregro
     const borderColor = getBorderColor(background, foreground)
     return {
         ...DefaultThemeColors,
-        "background": shellBackground,
-        "foreground": foreground,
+        background: shellBackground,
+        foreground: foreground,
         "editor.background": background,
         "editor.foreground": foreground,
 
@@ -196,8 +205,8 @@ const StatusBarBackground = "#282828"
 const StatusBarForeground = "#c8c8c8"
 
 export const DefaultThemeColors: IThemeColors = {
-    "background": ColorBlack,
-    "foreground": ColorWhite,
+    background: ColorBlack,
+    foreground: ColorWhite,
 
     "editor.background": ColorBlack,
     "editor.foreground": ColorWhite,
@@ -304,9 +313,7 @@ export class ThemeManager {
         return this._activeTheme
     }
 
-    constructor(
-        private _themeLoader: IThemeLoader,
-    ) { }
+    constructor(private _themeLoader: IThemeLoader) {}
 
     public async getAllThemes(): Promise<IThemeContribution[]> {
         return this._themeLoader.getAllThemes()
@@ -338,11 +345,19 @@ export class ThemeManager {
         }
     }
 
-    public notifyVimThemeChanged(vimName: string, backgroundColor: string, foregroundColor: string): void {
-
+    public notifyVimThemeChanged(
+        vimName: string,
+        backgroundColor: string,
+        foregroundColor: string,
+    ): void {
         // If the vim colorscheme changed, for example, via `:co <sometheme>`,
         // then we should update our theme to match
-        if (this._isAnonymousTheme || (this._activeTheme.baseVimTheme && this._activeTheme.baseVimTheme !== vimName && this._activeTheme.baseVimTheme !== "*")) {
+        if (
+            this._isAnonymousTheme ||
+            (this._activeTheme.baseVimTheme &&
+                this._activeTheme.baseVimTheme !== vimName &&
+                this._activeTheme.baseVimTheme !== "*")
+        ) {
             this._isAnonymousTheme = false
 
             const vimTheme: IThemeMetadata = {

--- a/browser/src/Services/Themes/ThemeManager.ts
+++ b/browser/src/Services/Themes/ThemeManager.ts
@@ -154,7 +154,7 @@ export const getColorsFromBackgroundAndForeground = (background: string, foregro
     return {
         ...DefaultThemeColors,
         background: shellBackground,
-        foreground: foreground,
+        foreground,
         "editor.background": background,
         "editor.foreground": foreground,
 

--- a/browser/src/Services/Themes/ThemePicker.ts
+++ b/browser/src/Services/Themes/ThemePicker.ts
@@ -9,48 +9,56 @@ import { Configuration } from "./../Configuration"
 import { MenuManager } from "./../Menu"
 import { ThemeManager } from "./ThemeManager"
 
-const chooseTheme = async (configuration: Configuration, menuManager: MenuManager, themeManager: ThemeManager) => {
-        const themes = await themeManager.getAllThemes()
+const chooseTheme = async (
+    configuration: Configuration,
+    menuManager: MenuManager,
+    themeManager: ThemeManager,
+) => {
+    const themes = await themeManager.getAllThemes()
 
-        const items = themes.map((t) => ({
-            icon: "paint",
-            label: t.name,
-            detail: t.path,
-        }))
+    const items = themes.map(t => ({
+        icon: "paint",
+        label: t.name,
+        detail: t.path,
+    }))
 
-        const currentTheme = themeManager.activeTheme.name
+    const currentTheme = themeManager.activeTheme.name
 
-        const themeMenu = menuManager.create()
-        themeMenu.show()
-        themeMenu.setItems(items)
+    const themeMenu = menuManager.create()
+    themeMenu.show()
+    themeMenu.setItems(items)
 
-        let wasSelected = false
+    let wasSelected = false
 
-        themeMenu.onItemSelected.subscribe(() => wasSelected = true)
+    themeMenu.onItemSelected.subscribe(() => (wasSelected = true))
 
-        themeMenu.onHide.subscribe(() => {
-            if (!wasSelected) {
-                themeManager.setTheme(currentTheme)
-            }
-        })
+    themeMenu.onHide.subscribe(() => {
+        if (!wasSelected) {
+            themeManager.setTheme(currentTheme)
+        }
+    })
 
-        themeMenu.onSelectedItemChanged.subscribe((newOption) => {
-            if (newOption) {
-                configuration.setValues({"ui.colorscheme": newOption.label})
-                themeManager.setTheme(newOption.label)
-            } else {
-                themeManager.setTheme(currentTheme)
-            }
-        })
+    themeMenu.onSelectedItemChanged.subscribe(newOption => {
+        if (newOption) {
+            configuration.setValues({ "ui.colorscheme": newOption.label })
+            themeManager.setTheme(newOption.label)
+        } else {
+            themeManager.setTheme(currentTheme)
+        }
+    })
 }
 
-export const activate = (configuration: Configuration, menuManager: MenuManager, themeManager: ThemeManager) => {
-
+export const activate = (
+    configuration: Configuration,
+    menuManager: MenuManager,
+    themeManager: ThemeManager,
+) => {
     commandManager.registerCommand(
         new CallbackCommand(
             "oni.themes.choose",
             "Themes: Choose Theme",
             "Choose your theme from the available bundled themes.",
             () => chooseTheme(configuration, menuManager, themeManager),
-        ))
+        ),
+    )
 }

--- a/browser/src/Services/Themes/index.ts
+++ b/browser/src/Services/Themes/index.ts
@@ -5,11 +5,15 @@ import { PluginManager } from "./../../Plugins/PluginManager"
 import { Configuration, IConfigurationValues } from "./../Configuration"
 import { activateThemes, getThemeManagerInstance } from "./ThemeManager"
 
-export const activate = async (configuration: Configuration, pluginManager: PluginManager): Promise<void> => {
-
+export const activate = async (
+    configuration: Configuration,
+    pluginManager: PluginManager,
+): Promise<void> => {
     activateThemes(pluginManager)
 
-    const updateColorScheme = async (configurationValues: Partial<IConfigurationValues>): Promise<void> => {
+    const updateColorScheme = async (
+        configurationValues: Partial<IConfigurationValues>,
+    ): Promise<void> => {
         const colorscheme = configurationValues["ui.colorscheme"]
         if (colorscheme) {
             const themeManager = getThemeManagerInstance()

--- a/browser/src/Services/TypingPredictionManager.ts
+++ b/browser/src/Services/TypingPredictionManager.ts
@@ -21,7 +21,6 @@ export interface ITypingPrediction {
 }
 
 export class TypingPredictionManager {
-
     private _predictionsChanged: Event<ITypingPrediction> = new Event<ITypingPrediction>()
     private _predictions: IPredictedCharacter[] = []
     private _backgroundColor: string
@@ -52,7 +51,7 @@ export class TypingPredictionManager {
         const line = screen.cursorRow
         const column = screen.cursorColumn
 
-        const {foregroundColor, backgroundColor}  = getLastTextColorFromScreen(screen)
+        const { foregroundColor, backgroundColor } = getLastTextColorFromScreen(screen)
 
         this._foregroundColor = foregroundColor
         this._backgroundColor = backgroundColor
@@ -77,7 +76,7 @@ export class TypingPredictionManager {
         if (shouldClearAll) {
             this.clearAllPredictions()
         } else {
-            this._predictions = this._predictions.filter((pd) => {
+            this._predictions = this._predictions.filter(pd => {
                 return pd.id > this._column
             })
 
@@ -86,7 +85,6 @@ export class TypingPredictionManager {
     }
 
     public addPrediction(character: string): void {
-
         if (!this._enabled || !this._latestScreenState) {
             return null
         }
@@ -99,10 +97,7 @@ export class TypingPredictionManager {
             return
         }
 
-        this._predictions = [
-            ...this._predictions,
-            { id, character },
-        ]
+        this._predictions = [...this._predictions, { id, character }]
 
         this._notifyPredictionsChanged()
     }
@@ -123,7 +118,9 @@ export class TypingPredictionManager {
     }
 }
 
-export const getLastTextColorFromScreen = (screen: IScreen): { foregroundColor: string, backgroundColor: string } => {
+export const getLastTextColorFromScreen = (
+    screen: IScreen,
+): { foregroundColor: string; backgroundColor: string } => {
     const previousCharacterColumn = screen.cursorColumn - 2
 
     if (previousCharacterColumn <= 0) {

--- a/browser/src/Services/VimConfigurationSynchronizer.ts
+++ b/browser/src/Services/VimConfigurationSynchronizer.ts
@@ -20,12 +20,15 @@ const vimSettingPrefix = "vim.setting."
 // - `onConfigChanged` with updated values
 // - Handle initial load case
 // - Update documentation / default config
-export const synchronizeConfiguration = (neovimInstance: INeovimInstance, configuration: IConfigurationValues) => {
+export const synchronizeConfiguration = (
+    neovimInstance: INeovimInstance,
+    configuration: IConfigurationValues,
+) => {
+    const vimSettingKeys: string[] = Object.keys(configuration).filter(
+        key => key.indexOf(vimSettingPrefix) === 0,
+    )
 
-    const vimSettingKeys: string[] = Object.keys(configuration).filter((key) => key.indexOf(vimSettingPrefix) === 0)
-
-    vimSettingKeys.forEach((key) => {
-
+    vimSettingKeys.forEach(key => {
         const vimSettingValue: any = configuration[key]
 
         const baseSettingName = key.substring(vimSettingPrefix.length, key.length)
@@ -38,9 +41,11 @@ export const synchronizeConfiguration = (neovimInstance: INeovimInstance, config
         }
     })
 
-    const vimGlobalKeys: string[] = Object.keys(configuration).filter((key) => key.indexOf(vimGlobalPrefix) === 0)
+    const vimGlobalKeys: string[] = Object.keys(configuration).filter(
+        key => key.indexOf(vimGlobalPrefix) === 0,
+    )
 
-    vimGlobalKeys.forEach((key) => {
+    vimGlobalKeys.forEach(key => {
         const vimGlobalValue: any = configuration[key]
 
         const globalSettingName = key.substring(vimGlobalPrefix.length, key.length)

--- a/browser/src/Services/WindowManager.ts
+++ b/browser/src/Services/WindowManager.ts
@@ -21,7 +21,15 @@ export enum Direction {
 
 // TODO: Add optional `enter` and `leave` methods to `oni-api`
 
-import { applySplit, closeSplit, createSplitLeaf, createSplitRoot, getFurthestSplitInDirection, ISplitInfo, SplitDirection } from "./WindowSplit"
+import {
+    applySplit,
+    closeSplit,
+    createSplitLeaf,
+    createSplitRoot,
+    getFurthestSplitInDirection,
+    ISplitInfo,
+    SplitDirection,
+} from "./WindowSplit"
 
 export interface INavigatable {
     contains(split: Oni.IWindowSplit): boolean
@@ -39,7 +47,6 @@ export interface IWindowDock extends INavigatable {
 }
 
 export class WindowDock implements IWindowDock {
-
     private _splits: Oni.IWindowSplit[] = []
     private _onSplitsChangedEvent: Event<void> = new Event<void>()
 
@@ -84,7 +91,7 @@ export class WindowDock implements IWindowDock {
     }
 
     public removeSplit(split: Oni.IWindowSplit): void {
-        this._splits = this._splits.filter((s) => s !== split)
+        this._splits = this._splits.filter(s => s !== split)
         this._onSplitsChangedEvent.dispatch()
     }
 }
@@ -158,7 +165,10 @@ export class WindowManager implements Oni.IWindowManager {
             if (newSplit) {
                 this._focusNewSplit(newSplit)
             } else {
-                const innerSplit = getFurthestSplitInDirection(this._splitRoot, 0 /* TODO - Reuse direction? */)
+                const innerSplit = getFurthestSplitInDirection(
+                    this._splitRoot,
+                    0 /* TODO - Reuse direction? */,
+                )
 
                 if (innerSplit) {
                     this._focusNewSplit(innerSplit.contents)

--- a/browser/src/Services/WindowSplit.ts
+++ b/browser/src/Services/WindowSplit.ts
@@ -32,7 +32,10 @@ export interface ISplitLeaf<T> {
     contents: T
 }
 
-export const getFurthestSplitInDirection = <T>(root: SplitOrLeaf<T>, direction: Split): ISplitLeaf<T> => {
+export const getFurthestSplitInDirection = <T>(
+    root: SplitOrLeaf<T>,
+    direction: Split,
+): ISplitLeaf<T> => {
     if (!root) {
         return null
     }
@@ -45,7 +48,10 @@ export const getFurthestSplitInDirection = <T>(root: SplitOrLeaf<T>, direction: 
     }
 }
 
-export function createSplitRoot<T>(direction: SplitDirection, parent?: ISplitInfo<T>): ISplitInfo<T> {
+export function createSplitRoot<T>(
+    direction: SplitDirection,
+    parent?: ISplitInfo<T>,
+): ISplitInfo<T> {
     return {
         type: "Split",
         splits: [],
@@ -61,7 +67,11 @@ export function createSplitLeaf<T>(contents: T): ISplitLeaf<T> {
     }
 }
 
-export function applySplit<T>(originalSplit: ISplitInfo<T>, direction: SplitDirection, leaf: ISplitLeaf<T>): ISplitInfo<T> {
+export function applySplit<T>(
+    originalSplit: ISplitInfo<T>,
+    direction: SplitDirection,
+    leaf: ISplitLeaf<T>,
+): ISplitInfo<T> {
     // TODO: Implement split direction & nested splits
     return {
         ...originalSplit,
@@ -72,7 +82,7 @@ export function applySplit<T>(originalSplit: ISplitInfo<T>, direction: SplitDire
 export function closeSplit<T>(originalSplit: ISplitInfo<T>, contents: T): ISplitInfo<T> {
     // TODO: Implement this in the recursive case, for nesetd splits
 
-    const filteredSplits = originalSplit.splits.filter((s) => {
+    const filteredSplits = originalSplit.splits.filter(s => {
         switch (s.type) {
             case "Split":
                 return true

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -45,9 +45,7 @@ export class Workspace implements IWorkspace {
         return this._activeWorkspace
     }
 
-    constructor(
-        private _editorManager: EditorManager,
-    ) {
+    constructor(private _editorManager: EditorManager) {
         this._mainWindow.on("focus", () => {
             this._onFocusGainedEvent.dispatch(this._lastActiveBuffer)
         })
@@ -72,7 +70,6 @@ export class Workspace implements IWorkspace {
     }
 
     public async applyEdits(edits: types.WorkspaceEdit): Promise<void> {
-
         let editsToUse = edits
         if (edits.documentChanges) {
             editsToUse = convertTextDocumentEditsToFileMap(edits.documentChanges)
@@ -90,15 +87,17 @@ export class Workspace implements IWorkspace {
                 // TODO: Sort changes?
                 Log.verbose("[Workspace] Opening file: " + fileName)
                 const buf = await this._editorManager.activeEditor.openFile(fileName)
-                Log.verbose("[Workspace] Got buffer for file: " + buf.filePath + " and id: " + buf.id)
+                Log.verbose(
+                    "[Workspace] Got buffer for file: " + buf.filePath + " and id: " + buf.id,
+                )
                 await buf.applyTextEdits(changes)
                 Log.verbose("[Workspace] Applied " + changes.length + " edits to buffer")
             })
         })
 
         await Observable.from(deferredEdits)
-                .concatMap(de => de)
-                .toPromise()
+            .concatMap(de => de)
+            .toPromise()
 
         Log.verbose("[Workspace] Completed applying edits")
 
@@ -128,8 +127,8 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
         _workspace.changeDirectory(defaultWorkspace)
     }
 
-    _workspace.onDirectoryChanged.subscribe((newDirectory) => {
-        configuration.setValues({ "workspace.defaultWorkspace": newDirectory}, true)
+    _workspace.onDirectoryChanged.subscribe(newDirectory => {
+        configuration.setValues({ "workspace.defaultWorkspace": newDirectory }, true)
     })
 
     WorkspaceCommands.activateCommands(configuration, editorManager, _workspace)

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -16,29 +16,35 @@ import * as FileMappings from "./../FileMappings"
 
 import { Workspace } from "./Workspace"
 
-export const activateCommands = (configuration: Configuration, editorManager: EditorManager, workspace: Workspace) => {
+export const activateCommands = (
+    configuration: Configuration,
+    editorManager: EditorManager,
+    workspace: Workspace,
+) => {
     const openFolder = () => {
-
         const dialogOptions: any = {
             title: "Open Folder",
             properties: ["openDirectory"],
         }
 
-        remote.dialog.showOpenDialog(remote.getCurrentWindow(), dialogOptions, (folder: string[]) => {
-            if (!folder || !folder[0]) {
-                return
-            }
+        remote.dialog.showOpenDialog(
+            remote.getCurrentWindow(),
+            dialogOptions,
+            (folder: string[]) => {
+                if (!folder || !folder[0]) {
+                    return
+                }
 
-            const folderToOpen = folder[0]
-            workspace.changeDirectory(folderToOpen)
-        })
+                const folderToOpen = folder[0]
+                workspace.changeDirectory(folderToOpen)
+            },
+        )
     }
 
     const openTestFileInSplit = () => {
         const mappedFile = getTestFileMappedToCurrentFile()
 
         if (mappedFile) {
-
             if (!fs.existsSync(mappedFile)) {
                 // Ensure the folder exists for the mapped file
                 const containingFolder = path.dirname(mappedFile)
@@ -62,7 +68,9 @@ export const activateCommands = (configuration: Configuration, editorManager: Ed
     }
 
     const getTestFileMappedToCurrentFile = (): string => {
-        const mappings: FileMappings.IFileMapping[] = configuration.getValue("workspace.testFileMappings")
+        const mappings: FileMappings.IFileMapping[] = configuration.getValue(
+            "workspace.testFileMappings",
+        )
 
         if (!mappings) {
             return null
@@ -75,17 +83,44 @@ export const activateCommands = (configuration: Configuration, editorManager: Ed
             return null
         }
 
-        const mappedFile = FileMappings.getMappedFile(workspace.activeWorkspace, currentBufferPath, mappings)
+        const mappedFile = FileMappings.getMappedFile(
+            workspace.activeWorkspace,
+            currentBufferPath,
+            mappings,
+        )
         return mappedFile
     }
 
     const commands = [
-        new CallbackCommand("workspace.openFolder", "Workspace: Open Folder", "Set a folder as the working directory for Oni", () => openFolder(), () => !!!workspace.activeWorkspace),
-        new CallbackCommand("workspace.openTestFile", "Workspace: Open Test File", "Open the test file corresponding to this source file.", () => openTestFileInSplit(), () => hasExistingTestFile()),
-        new CallbackCommand("workspace.createTestFile", "Workspace: Create Test File", "Create a test file for this source file.", () => openTestFileInSplit(), () => canCreateTestFile()),
-        new CallbackCommand("workspace.closeFolder", "Workspace: Close Folder", "Close the current folder", () => workspace.changeDirectory(null), () => !!workspace.activeWorkspace),
+        new CallbackCommand(
+            "workspace.openFolder",
+            "Workspace: Open Folder",
+            "Set a folder as the working directory for Oni",
+            () => openFolder(),
+            () => !!!workspace.activeWorkspace,
+        ),
+        new CallbackCommand(
+            "workspace.openTestFile",
+            "Workspace: Open Test File",
+            "Open the test file corresponding to this source file.",
+            () => openTestFileInSplit(),
+            () => hasExistingTestFile(),
+        ),
+        new CallbackCommand(
+            "workspace.createTestFile",
+            "Workspace: Create Test File",
+            "Create a test file for this source file.",
+            () => openTestFileInSplit(),
+            () => canCreateTestFile(),
+        ),
+        new CallbackCommand(
+            "workspace.closeFolder",
+            "Workspace: Close Folder",
+            "Close the current folder",
+            () => workspace.changeDirectory(null),
+            () => !!workspace.activeWorkspace,
+        ),
     ]
 
-    commands.forEach((c) => commandManager.registerCommand(c))
-
+    commands.forEach(c => commandManager.registerCommand(c))
 }

--- a/browser/src/Services/Workspace/WorkspaceConfiguration.ts
+++ b/browser/src/Services/Workspace/WorkspaceConfiguration.ts
@@ -17,7 +17,6 @@ export const getWorkspaceConfigurationPath = (workspacePath: string): string => 
 }
 
 export class WorkspaceConfiguration {
-
     private _activeWorkspaceConfiguration: string = null
 
     public get activeWorkspaceConfiguration(): string {
@@ -37,7 +36,6 @@ export class WorkspaceConfiguration {
     }
 
     private _checkWorkspaceConfiguration(): void {
-
         const activeWorkspace = this._workspace.activeWorkspace
 
         if (!activeWorkspace) {
@@ -46,7 +44,10 @@ export class WorkspaceConfiguration {
 
         const configurationPath = getWorkspaceConfigurationPath(activeWorkspace)
 
-        if (this._fs.existsSync(configurationPath) && this._fs.statSync(configurationPath).isFile()) {
+        if (
+            this._fs.existsSync(configurationPath) &&
+            this._fs.statSync(configurationPath).isFile()
+        ) {
             Log.info("[WorkspaceConfiguration] Found configuration file at: " + configurationPath)
             this._loadWorkspaceConfiguration(configurationPath)
         }
@@ -60,7 +61,9 @@ export class WorkspaceConfiguration {
     }
 
     private _loadWorkspaceConfiguration(configurationPath: string): void {
-        Log.info("[WorkspaceConfiguration] Loading workspace configuration from: " + configurationPath)
+        Log.info(
+            "[WorkspaceConfiguration] Loading workspace configuration from: " + configurationPath,
+        )
         this._removePreviousWorkspaceConfiguration()
 
         this._activeWorkspaceConfiguration = configurationPath

--- a/browser/src/UI/Icon.tsx
+++ b/browser/src/UI/Icon.tsx
@@ -24,10 +24,10 @@ export interface IconProps {
 
 export class Icon extends React.PureComponent<IconProps, {}> {
     public render(): JSX.Element {
-
-        const className = "fa fa-" + this.props.name + " " + this._getClassForIconSize(this.props.size as any) // FIXME: undefined
+        const className =
+            "fa fa-" + this.props.name + " " + this._getClassForIconSize(this.props.size as any) // FIXME: undefined
         const additionalClass = this.props.className || ""
-        return <i className={className + additionalClass} aria-hidden="true"></i>
+        return <i className={className + additionalClass} aria-hidden="true" />
     }
 
     private _getClassForIconSize(size: IconSize): string {

--- a/browser/src/UI/Shell/OverlayView.tsx
+++ b/browser/src/UI/Shell/OverlayView.tsx
@@ -15,16 +15,20 @@ export interface IOverlaysViewProps {
 
 export class OverlaysView extends React.PureComponent<IOverlaysViewProps, {}> {
     public render(): JSX.Element[] {
-        const overlays = this.props.overlays.map((overlay) => {
-            return <div className="stack layer" key={overlay.id}>{overlay.contents}</div>
+        const overlays = this.props.overlays.map(overlay => {
+            return (
+                <div className="stack layer" key={overlay.id}>
+                    {overlay.contents}
+                </div>
+            )
         })
 
-        return (overlays)
+        return overlays
     }
 }
 
 export const mapStateToProps = (state: State.IState): IOverlaysViewProps => ({
-    overlays: Object.keys(state.overlays).map((k) => state.overlays[k]),
+    overlays: Object.keys(state.overlays).map(k => state.overlays[k]),
 })
 
 export const Overlays = connect(mapStateToProps)(OverlaysView)

--- a/browser/src/UI/Shell/Shell.tsx
+++ b/browser/src/UI/Shell/Shell.tsx
@@ -30,15 +30,18 @@ const defaultState = State.createDefaultState()
 
 export const store = createStore("Shell", reducer, defaultState, [thunk])
 
-export const Actions: typeof ActionCreators = bindActionCreators(ActionCreators as any, store.dispatch)
+export const Actions: typeof ActionCreators = bindActionCreators(
+    ActionCreators as any,
+    store.dispatch,
+)
 
 const browserWindow = remote.getCurrentWindow()
 browserWindow.on("enter-full-screen", () => {
-    store.dispatch({type: "ENTER_FULL_SCREEN"})
+    store.dispatch({ type: "ENTER_FULL_SCREEN" })
 })
 
 browserWindow.on("leave-full-screen", () => {
-    store.dispatch({type: "LEAVE_FULL_SCREEN"})
+    store.dispatch({ type: "LEAVE_FULL_SCREEN" })
 })
 
 export const activate = (): void => {
@@ -64,11 +67,14 @@ export const render = (state: State.IState): void => {
 
     ReactDOM.render(
         <Provider store={store}>
-            <ShellContainer windowManager={windowManager}/>
-        </Provider>, hostElement)
+            <ShellContainer windowManager={windowManager} />
+        </Provider>,
+        hostElement,
+    )
 }
 
 // Don't execute code that depends on DOM in unit-tests
-if (global["window"]) { // tslint:disable-line
+if (global["window"]) {
+    // tslint:disable-line
     document.body.addEventListener("click", () => focusManager.enforceFocus())
 }

--- a/browser/src/UI/Shell/Shell.tsx
+++ b/browser/src/UI/Shell/Shell.tsx
@@ -74,7 +74,7 @@ export const render = (state: State.IState): void => {
 }
 
 // Don't execute code that depends on DOM in unit-tests
+// tslint:disable-next-line
 if (global["window"]) {
-    // tslint:disable-line
     document.body.addEventListener("click", () => focusManager.enforceFocus())
 }

--- a/browser/src/UI/Shell/ShellActionCreators.ts
+++ b/browser/src/UI/Shell/ShellActionCreators.ts
@@ -34,7 +34,6 @@ export const setLoadingComplete = () => {
 }
 
 export const setWindowTitle = (title: string) => {
-
     document.title = title
 
     return {
@@ -60,8 +59,12 @@ export const setViewport = (width: number, height: number) => ({
     },
 })
 
-export const showStatusBarItem = (id: string, contents: JSX.Element, alignment?: State.StatusBarAlignment, priority?: number) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
-
+export const showStatusBarItem = (
+    id: string,
+    contents: JSX.Element,
+    alignment?: State.StatusBarAlignment,
+    priority?: number,
+) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
     const currentStatusBarItem = getState().statusBar[id]
 
     if (currentStatusBarItem) {
@@ -102,7 +105,10 @@ export const hideOverlay = (id: string): Actions.IOverlayHideAction => ({
     },
 })
 
-export function setConfigValue<K extends keyof IConfigurationValues>(k: K, v: IConfigurationValues[K]): Actions.ISetConfigurationValue<K> {
+export function setConfigValue<K extends keyof IConfigurationValues>(
+    k: K,
+    v: IConfigurationValues[K],
+): Actions.ISetConfigurationValue<K> {
     return {
         type: "SET_CONFIGURATION_VALUE",
         payload: {

--- a/browser/src/UI/Shell/ShellActions.ts
+++ b/browser/src/UI/Shell/ShellActions.ts
@@ -13,92 +13,90 @@ import { IThemeColors } from "./../../Services/Themes"
 import { StatusBarAlignment } from "./ShellState"
 
 export interface ISetHasFocusAction {
-    type: "SET_HAS_FOCUS",
+    type: "SET_HAS_FOCUS"
     payload: {
-        hasFocus: boolean,
+        hasFocus: boolean
     }
 }
 
 export interface IEnterFullScreenAction {
-    type: "ENTER_FULL_SCREEN",
+    type: "ENTER_FULL_SCREEN"
 }
 
 export interface ILeaveFullScreenAction {
-    type: "LEAVE_FULL_SCREEN",
+    type: "LEAVE_FULL_SCREEN"
 }
 
 export interface ISetLoadingCompleteAction {
-    type: "SET_LOADING_COMPLETE",
+    type: "SET_LOADING_COMPLETE"
 }
 
 export interface ISetWindowTitleAction {
-    type: "SET_WINDOW_TITLE",
+    type: "SET_WINDOW_TITLE"
     payload: {
-        title: string,
+        title: string
     }
 }
 
 export interface ISetColorsAction {
-    type: "SET_COLORS",
+    type: "SET_COLORS"
     payload: {
-        colors: IThemeColors,
+        colors: IThemeColors
     }
 }
 
 export interface IStatusBarShowAction {
-    type: "STATUSBAR_SHOW",
+    type: "STATUSBAR_SHOW"
     payload: {
-        id: string,
-        contents: JSX.Element,
-        alignment: StatusBarAlignment,
-        priority: number,
+        id: string
+        contents: JSX.Element
+        alignment: StatusBarAlignment
+        priority: number
     }
 }
 
 export interface IStatusBarHideAction {
-    type: "STATUSBAR_HIDE",
+    type: "STATUSBAR_HIDE"
     payload: {
-        id: string,
+        id: string
     }
 }
 
 export interface IOverlayShowAction {
-    type: "OVERLAY_SHOW",
+    type: "OVERLAY_SHOW"
     payload: {
-        id: string,
-        contents: JSX.Element,
+        id: string
+        contents: JSX.Element
     }
 }
 
 export interface IOverlayHideAction {
-    type: "OVERLAY_HIDE",
+    type: "OVERLAY_HIDE"
     payload: {
-        id: string,
+        id: string
     }
 }
 
 export interface ISetConfigurationValue<K extends keyof IConfigurationValues> {
     type: "SET_CONFIGURATION_VALUE"
     payload: {
-        key: K,
-        value: IConfigurationValues[K],
+        key: K
+        value: IConfigurationValues[K]
     }
 }
 
-export type Action<K extends keyof IConfigurationValues> =
-    SimpleAction | ActionWithGeneric<K>
+export type Action<K extends keyof IConfigurationValues> = SimpleAction | ActionWithGeneric<K>
 
 export type SimpleAction =
-    IEnterFullScreenAction |
-    ILeaveFullScreenAction |
-    ISetColorsAction |
-    IOverlayShowAction |
-    IOverlayHideAction |
-    IStatusBarHideAction |
-    IStatusBarShowAction |
-    ISetHasFocusAction |
-    ISetLoadingCompleteAction |
-    ISetWindowTitleAction
+    | IEnterFullScreenAction
+    | ILeaveFullScreenAction
+    | ISetColorsAction
+    | IOverlayShowAction
+    | IOverlayHideAction
+    | IStatusBarHideAction
+    | IStatusBarShowAction
+    | ISetHasFocusAction
+    | ISetLoadingCompleteAction
+    | ISetWindowTitleAction
 
-export type ActionWithGeneric<K extends keyof IConfigurationValues> =
-    ISetConfigurationValue<K>
+export type ActionWithGeneric<K extends keyof IConfigurationValues> = ISetConfigurationValue<K>

--- a/browser/src/UI/Shell/ShellReducer.ts
+++ b/browser/src/UI/Shell/ShellReducer.ts
@@ -9,8 +9,10 @@ import { IConfigurationValues } from "./../../Services/Configuration"
 import * as Actions from "./ShellActions"
 import * as State from "./ShellState"
 
-export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a: Actions.Action<K>) {
-
+export function reducer<K extends keyof IConfigurationValues>(
+    s: State.IState,
+    a: Actions.Action<K>,
+) {
     if (!s) {
         return s
     }
@@ -45,18 +47,21 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
             return {
                 ...s,
                 colors: a.payload.colors,
-                    }
+            }
         case "SET_CONFIGURATION_VALUE":
             const obj: Partial<IConfigurationValues> = {}
             obj[a.payload.key] = a.payload.value
-            const newConfig = {...s.configuration, ...obj}
-            return {...s,
-                    configuration: newConfig}
+            const newConfig = { ...s.configuration, ...obj }
+            return {
+                ...s,
+                configuration: newConfig,
+            }
         default:
-            return {...s,
-                    overlays: overlaysReducer(s.overlays, a),
-                    statusBar: statusBarReducer(s.statusBar, a),
-                    }
+            return {
+                ...s,
+                overlays: overlaysReducer(s.overlays, a),
+                statusBar: statusBarReducer(s.statusBar, a),
+            }
     }
 }
 

--- a/browser/src/UI/Shell/ShellState.ts
+++ b/browser/src/UI/Shell/ShellState.ts
@@ -11,7 +11,9 @@ import * as Oni from "oni-api"
 import { IConfigurationValues } from "./../../Services/Configuration"
 import { DefaultThemeColors, IThemeColors } from "./../../Services/Themes"
 
-export interface Errors { [file: string]: { [key: string]: types.Diagnostic[] } }
+export interface Errors {
+    [file: string]: { [key: string]: types.Diagnostic[] }
+}
 
 /**
  * Viewport encompasses the actual 'app' height
@@ -22,13 +24,17 @@ export interface IViewport {
 }
 
 export interface IToolTip {
-    id: string,
-    options: Oni.ToolTip.ToolTipOptions,
+    id: string
+    options: Oni.ToolTip.ToolTipOptions
     element: JSX.Element
 }
 
-export interface StatusBar { [key: string]: IStatusBarItem }
-export interface Overlays { [key: string]: IOverlay }
+export interface StatusBar {
+    [key: string]: IStatusBarItem
+}
+export interface Overlays {
+    [key: string]: IOverlay
+}
 
 export interface IState {
     // Editor
@@ -64,8 +70,10 @@ export interface IStatusBarItem {
     visible: boolean
 }
 
-export function readConf<K extends keyof IConfigurationValues>(conf: IConfigurationValues, k: K): IConfigurationValues[K] {
-
+export function readConf<K extends keyof IConfigurationValues>(
+    conf: IConfigurationValues,
+    k: K,
+): IConfigurationValues[K] {
     if (!conf) {
         return null
     } else {

--- a/browser/src/UI/Shell/ShellView.tsx
+++ b/browser/src/UI/Shell/ShellView.tsx
@@ -30,32 +30,36 @@ interface IShellViewComponentProps {
 const titleBarVisible = Platform.isMac()
 
 export class ShellView extends React.PureComponent<IShellViewComponentProps, {}> {
-
     public render() {
-        return <ThemeProvider theme={this.props.theme}>
-          <div className="stack disable-mouse" onKeyDownCapture={(evt) => this._onRootKeyDown(evt)}>
-                <div className="stack">
-                    <Background />
-                </div>
-                <div className="stack">
-                    <div className="container vertical full">
-                        <div className="container fixed">
-                            <WindowTitle visible={titleBarVisible} />
-                        </div>
-                        <div className="container full">
-                            <div className="stack">
-                                <WindowSplits windowManager={this.props.windowManager} />
+        return (
+            <ThemeProvider theme={this.props.theme}>
+                <div
+                    className="stack disable-mouse"
+                    onKeyDownCapture={evt => this._onRootKeyDown(evt)}
+                >
+                    <div className="stack">
+                        <Background />
+                    </div>
+                    <div className="stack">
+                        <div className="container vertical full">
+                            <div className="container fixed">
+                                <WindowTitle visible={titleBarVisible} />
                             </div>
-                            <Overlays />
-                        </div>
-                        <div className="container fixed layer">
-                            <StatusBar />
+                            <div className="container full">
+                                <div className="stack">
+                                    <WindowSplits windowManager={this.props.windowManager} />
+                                </div>
+                                <Overlays />
+                            </div>
+                            <div className="container fixed layer">
+                                <StatusBar />
+                            </div>
                         </div>
                     </div>
+                    <Loading />
                 </div>
-                <Loading/>
-            </div>
-        </ThemeProvider>
+            </ThemeProvider>
+        )
     }
 
     private _onRootKeyDown(evt: React.KeyboardEvent<HTMLElement>): void {

--- a/browser/src/UI/components/Arrow.tsx
+++ b/browser/src/UI/components/Arrow.tsx
@@ -24,44 +24,44 @@ const transparentBorder = (props: IArrowProps) => `${props.size * 0.8}px solid t
 const solidBorder = (props: IArrowProps) => `${props.size}px solid ${props.color}`
 
 function arrowCSS(props: IArrowProps): string {
-  switch (props.direction) {
-  case ArrowDirection.Up:
-      return `
+    switch (props.direction) {
+        case ArrowDirection.Up:
+            return `
         width: 0px;
         height: 0px;
         border-left: ${transparentBorder(props)};
         border-right: ${transparentBorder(props)};
         border-bottom: ${solidBorder(props)};
         `
-  case ArrowDirection.Down:
-      return `
+        case ArrowDirection.Down:
+            return `
         width: 0px;
         height: 0px;
         border-left: ${transparentBorder(props)};
         border-right: ${transparentBorder(props)};
         border-top: ${solidBorder(props)};
         `
-  case ArrowDirection.Left:
-      return `
+        case ArrowDirection.Left:
+            return `
         width: 0px;
         height: 0px;
         border-top: ${transparentBorder(props)};
         border-right: ${solidBorder(props)};
         border-bottom: ${transparentBorder(props)};
         `
-  case ArrowDirection.Right:
-      return `
+        case ArrowDirection.Right:
+            return `
         width: 0px;
         height: 0px;
         border-top: ${transparentBorder(props)};
         border-left: ${solidBorder(props)};
         border-bottom: ${transparentBorder(props)};
         `
-  default:
-      return ``
-  }
+        default:
+            return ``
+    }
 }
 
 export const Arrow = withProps<IArrowProps>(styled.div)`
-    ${ props => arrowCSS(props) }
+    ${props => arrowCSS(props)}
     `

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react"
 
 import { connect } from "react-redux"

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -34,35 +34,36 @@ const ScrollBarWindow = styled.div`
     position: absolute;
     width: ${bufferScrollBarSize};
     background-color: rgba(200, 200, 200, 0.2);
-    border-top:1px solid rgba(255, 255, 255, 0.1);
-    border-bottom:1px solid rgba(255, 255, 255, 0.1);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 `
 
 export class BufferScrollBar extends React.PureComponent<IBufferScrollBarProps, {}> {
-
     constructor(props: any) {
         super(props)
     }
 
     public render(): JSX.Element {
-
         if (!this.props.visible) {
             return null
         }
 
-        const windowHeight = ((this.props.windowBottomLine - this.props.windowTopLine + 1) / this.props.bufferSize) * this.props.height
-        const windowTop = ((this.props.windowTopLine - 1) / this.props.bufferSize) * this.props.height
+        const windowHeight =
+            (this.props.windowBottomLine - this.props.windowTopLine + 1) /
+            this.props.bufferSize *
+            this.props.height
+        const windowTop = (this.props.windowTopLine - 1) / this.props.bufferSize * this.props.height
 
-        const windowStyle: React.CSSProperties  = {
+        const windowStyle: React.CSSProperties = {
             top: windowTop + "px",
             height: windowHeight + "px",
         }
 
         const markers = this.props.markers || []
 
-        const markerElements = markers.map((m) => {
+        const markerElements = markers.map(m => {
             const line = m.line
-            const pos = (line / this.props.bufferSize) * this.props.height
+            const pos = line / this.props.bufferSize * this.props.height
             const size = "2px"
 
             const markerStyle: React.CSSProperties = {
@@ -73,12 +74,14 @@ export class BufferScrollBar extends React.PureComponent<IBufferScrollBarProps, 
                 width: "100%",
             }
 
-            return <div style={markerStyle} key={m.line.toString() + m.color}/>
+            return <div style={markerStyle} key={m.line.toString() + m.color} />
         })
 
-        return <ScrollBarContainer key={this.props.windowId}>
-                    <ScrollBarWindow style={windowStyle}></ScrollBarWindow>
-                    {markerElements}
-                </ScrollBarContainer>
+        return (
+            <ScrollBarContainer key={this.props.windowId}>
+                <ScrollBarWindow style={windowStyle} />
+                {markerElements}
+            </ScrollBarContainer>
+        )
     }
 }

--- a/browser/src/UI/components/CodeActions.tsx
+++ b/browser/src/UI/components/CodeActions.tsx
@@ -15,7 +15,6 @@ import { Icon, IconSize } from "./../Icon"
  * Helper component to render errors in the QuickInfo bubble
  */
 export class CodeActionHover extends React.PureComponent<{}, {}> {
-
     public render(): null | JSX.Element {
         const style: React.CSSProperties = {
             padding: "1em",
@@ -24,15 +23,21 @@ export class CodeActionHover extends React.PureComponent<{}, {}> {
             cursor: "pointer",
         }
 
-        return <div className="container horizontal quickinfo-container">
-        <div className="container horizontal fixed" style={style} onClick={() => commandManager.executeCommand("language.codeAction.expand")}>
-            <Icon name="lightbulb-o" size={IconSize.Large}/>
-        </div>
-        <div className="container full quickinfo">
-            <div className="title">Refactorings available</div>
-            <QuickInfoDocumentation text="Press alt-enter to expand" />
-        </div>
-        </div>
+        return (
+            <div className="container horizontal quickinfo-container">
+                <div
+                    className="container horizontal fixed"
+                    style={style}
+                    onClick={() => commandManager.executeCommand("language.codeAction.expand")}
+                >
+                    <Icon name="lightbulb-o" size={IconSize.Large} />
+                </div>
+                <div className="container full quickinfo">
+                    <div className="title">Refactorings available</div>
+                    <QuickInfoDocumentation text="Press alt-enter to expand" />
+                </div>
+            </div>
+        )
     }
 }
 

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -30,15 +30,13 @@ export interface ICursorRendererProps {
     typingPrediction: TypingPredictionManager
 }
 
-const StyledCursor = styled.div`
-`
+const StyledCursor = styled.div``
 
 export interface ICursorRendererState {
     predictedCursorColumn: number
 }
 
 class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRendererState> {
-
     constructor(props: ICursorRendererProps) {
         super(props)
 
@@ -48,7 +46,7 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
     }
 
     public componentDidMount(): void {
-        this.props.typingPrediction.onPredictionsChanged.subscribe((predictions) => {
+        this.props.typingPrediction.onPredictionsChanged.subscribe(predictions => {
             this.setState({
                 predictedCursorColumn: predictions.predictedCursorColumn,
             })
@@ -56,7 +54,6 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
     }
 
     public render(): JSX.Element {
-
         const fontFamily = this.props.fontFamily
         const fontSize = this.props.fontSize
 
@@ -65,9 +62,10 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
         const width = isInsertCursor ? 0 : this.props.width
         const characterToShow = isInsertCursor ? "" : this.props.character
 
-        const position = this.props.mode === "insert" && this.state.predictedCursorColumn >= 0 ?
-                            this.state.predictedCursorColumn * this.props.fontPixelWidth :
-                            this.props.x
+        const position =
+            this.props.mode === "insert" && this.state.predictedCursorColumn >= 0
+                ? this.state.predictedCursorColumn * this.props.fontPixelWidth
+                : this.props.x
 
         const containerStyle: React.CSSProperties = {
             visibility: this.props.visible ? "visible" : "hidden",
@@ -103,25 +101,47 @@ class CursorRenderer extends React.PureComponent<ICursorRendererProps, ICursorRe
         }
 
         if (!this.props.animated) {
-            return this._renderCursor(containerStyle, cursorBlockStyle, cursorCharacterStyle, characterToShow)
+            return this._renderCursor(
+                containerStyle,
+                cursorBlockStyle,
+                cursorCharacterStyle,
+                characterToShow,
+            )
         } else {
-            return <Motion defaultStyle={{scale: 0}} style={{scale: spring(this.props.scale, { stiffness: 120, damping: 8})}}>
-            {(val) => {
-                const cursorStyle = {
-                    ...cursorBlockStyle,
-                    transform: "scale(" + val.scale + ")",
-                }
-                return this._renderCursor(containerStyle, cursorStyle, cursorCharacterStyle, characterToShow)
-            }}
-            </Motion>
+            return (
+                <Motion
+                    defaultStyle={{ scale: 0 }}
+                    style={{ scale: spring(this.props.scale, { stiffness: 120, damping: 8 }) }}
+                >
+                    {val => {
+                        const cursorStyle = {
+                            ...cursorBlockStyle,
+                            transform: "scale(" + val.scale + ")",
+                        }
+                        return this._renderCursor(
+                            containerStyle,
+                            cursorStyle,
+                            cursorCharacterStyle,
+                            characterToShow,
+                        )
+                    }}
+                </Motion>
+            )
         }
     }
 
-    private _renderCursor(containerStyle: React.CSSProperties, cursorBlockStyle: React.CSSProperties, cursorCharacterStyle: React.CSSProperties, characterToShow: string): JSX.Element {
-            return <StyledCursor style={containerStyle}>
+    private _renderCursor(
+        containerStyle: React.CSSProperties,
+        cursorBlockStyle: React.CSSProperties,
+        cursorCharacterStyle: React.CSSProperties,
+        characterToShow: string,
+    ): JSX.Element {
+        return (
+            <StyledCursor style={containerStyle}>
                 <div style={cursorBlockStyle} />
                 <div style={cursorCharacterStyle}>{characterToShow}</div>
             </StyledCursor>
+        )
     }
 }
 

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -19,8 +19,7 @@ export interface ICursorLineProps {
 }
 
 class CursorLineRenderer extends React.PureComponent<ICursorLineRendererProps, {}> {
-
-    public render(): null |  JSX.Element {
+    public render(): null | JSX.Element {
         if (!this.props.visible) {
             return null
         }
@@ -38,7 +37,7 @@ class CursorLineRenderer extends React.PureComponent<ICursorLineRendererProps, {
             opacity: this.props.opacity,
         }
 
-        return <div style={cursorStyle} className="cursorLine"></div>
+        return <div style={cursorStyle} className="cursorLine" />
     }
 }
 
@@ -53,13 +52,15 @@ const emptyProps: ICursorLineRendererProps = {
 }
 
 const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
-    const opacitySetting = props.lineType === "line" ? "editor.cursorLineOpacity" : "editor.cursorColumnOpacity"
+    const opacitySetting =
+        props.lineType === "line" ? "editor.cursorLineOpacity" : "editor.cursorColumnOpacity"
     const opacity = state.configuration[opacitySetting]
 
     const enabledSetting = props.lineType === "line" ? "editor.cursorLine" : "editor.cursorColumn"
     const enabled = state.configuration[enabledSetting]
 
-    const isNormalInsertOrVisualMode = state.mode === "normal" || state.mode === "insert" || state.mode === "visual"
+    const isNormalInsertOrVisualMode =
+        state.mode === "normal" || state.mode === "insert" || state.mode === "visual"
     const visible = enabled && isNormalInsertOrVisualMode
 
     if (!visible) {

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -86,9 +86,8 @@ export class CursorPositionerView extends React.PureComponent<
         if (this._element) {
             this._measureElement(this._element)
 
+            // tslint:disable-next-line
             this._resizeObserver = new window["ResizeObserver"]((entries: any) => {
-                // tslint:disable-line
-
                 if (!entries || !entries.length) {
                     return
                 }

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -20,7 +20,7 @@ export enum OpenDirection {
 }
 
 export interface ICursorPositionerProps {
-    position?: Oni.Coordinates.PixelSpacePoint,
+    position?: Oni.Coordinates.PixelSpacePoint
     beakColor?: string
     openDirection?: OpenDirection
     hideArrow?: boolean
@@ -43,13 +43,13 @@ export interface ICursorPositionerViewProps extends ICursorPositionerProps {
 export interface ICursorPositionerViewState {
     isMeasured: boolean
 
-    isFullWidth: boolean,
-    shouldOpenDownward: boolean,
+    isFullWidth: boolean
+    shouldOpenDownward: boolean
     adjustedX: number
-    lastMeasuredX: number,
-    lastMeasuredY: number,
-    lastMeasuredHeight: number,
-    lastMeasuredWidth: number,
+    lastMeasuredX: number
+    lastMeasuredY: number
+    lastMeasuredHeight: number
+    lastMeasuredWidth: number
 }
 
 const InitialState = {
@@ -68,8 +68,10 @@ const InitialState = {
 /**
  * Helper component to position an element relative to the current cursor position
  */
-export class CursorPositionerView extends React.PureComponent<ICursorPositionerViewProps, ICursorPositionerViewState> {
-
+export class CursorPositionerView extends React.PureComponent<
+    ICursorPositionerViewProps,
+    ICursorPositionerViewState
+> {
     private _element: HTMLElement
     private _resizeObserver: any
     private _timeout: any
@@ -84,7 +86,8 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
         if (this._element) {
             this._measureElement(this._element)
 
-            this._resizeObserver = new window["ResizeObserver"]((entries: any) => { // tslint:disable-line
+            this._resizeObserver = new window["ResizeObserver"]((entries: any) => {
+                // tslint:disable-line
 
                 if (!entries || !entries.length) {
                     return
@@ -92,7 +95,10 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
 
                 const rect: ClientRect = entries[0].contentRect
 
-                if (rect.width <= this.state.lastMeasuredWidth && rect.height <= this.state.lastMeasuredHeight) {
+                if (
+                    rect.width <= this.state.lastMeasuredWidth &&
+                    rect.height <= this.state.lastMeasuredHeight
+                ) {
                     return
                 }
 
@@ -119,7 +125,9 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
 
     public render(): JSX.Element {
         const adjustedX = this.state.adjustedX
-        const adjustedY = this.state.shouldOpenDownward ? this.props.y + this.props.lineHeight * 2.5 : this.props.y
+        const adjustedY = this.state.shouldOpenDownward
+            ? this.props.y + this.props.lineHeight * 2.5
+            : this.props.y
 
         const containerStyle: React.CSSProperties = {
             position: "absolute",
@@ -151,49 +159,55 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
             visibility: this.props.hideArrow ? "hidden" : "visible",
         }
 
-        const childStyleWithAdjustments: React.CSSProperties = this.state.isMeasured ? {
-            ...childStyle,
-            left: this.state.isFullWidth ? "8px" : Math.abs(adjustedX).toString() + "px",
-            right: this.state.isFullWidth ? "8px" : null,
-        } : childStyle
+        const childStyleWithAdjustments: React.CSSProperties = this.state.isMeasured
+            ? {
+                  ...childStyle,
+                  left: this.state.isFullWidth ? "8px" : Math.abs(adjustedX).toString() + "px",
+                  right: this.state.isFullWidth ? "8px" : null,
+              }
+            : childStyle
 
-        return <div style={containerStyle} key={this.props.key}>
-            <div style={childStyleWithAdjustments}>
-                <div ref={(elem) => this._element = elem}>
-                    {this.props.children}
+        return (
+            <div style={containerStyle} key={this.props.key}>
+                <div style={childStyleWithAdjustments}>
+                    <div ref={elem => (this._element = elem)}>{this.props.children}</div>
+                </div>
+                <div style={arrowStyleWithAdjustments}>
+                    <Arrow
+                        direction={
+                            this.state.shouldOpenDownward ? ArrowDirection.Up : ArrowDirection.Down
+                        }
+                        size={10}
+                        color={this.props.beakColor}
+                    />
                 </div>
             </div>
-            <div style={arrowStyleWithAdjustments}>
-                <Arrow
-                    direction={this.state.shouldOpenDownward
-                        ? ArrowDirection.Up
-                        : ArrowDirection.Down}
-                    size={10}
-                    color={this.props.beakColor}
-                />
-            </div>
-        </div>
+        )
     }
 
     private _measureElement(element: HTMLElement): void {
         if (element) {
             const rect = element.getBoundingClientRect()
 
-            if (rect.left === this.state.lastMeasuredX
-                && rect.top === this.state.lastMeasuredY
-                && rect.height <= this.state.lastMeasuredHeight
-               && rect.width <= this.state.lastMeasuredWidth) {
+            if (
+                rect.left === this.state.lastMeasuredX &&
+                rect.top === this.state.lastMeasuredY &&
+                rect.height <= this.state.lastMeasuredHeight &&
+                rect.width <= this.state.lastMeasuredWidth
+            ) {
                 return
             }
 
             const margin = this.props.lineHeight * 2
             const canOpenUpward = this.props.y - rect.height > margin
             const bottomScreenPadding = 50
-            const canOpenDownard = this.props.y + rect.height + this.props.lineHeight * 3 < this.props.containerHeight - margin - bottomScreenPadding
+            const canOpenDownard =
+                this.props.y + rect.height + this.props.lineHeight * 3 <
+                this.props.containerHeight - margin - bottomScreenPadding
 
             const shouldOpenDownward =
-                (this.props.openDirection !== OpenDirection.Down && !canOpenUpward)
-                || (this.props.openDirection === OpenDirection.Down && canOpenDownard)
+                (this.props.openDirection !== OpenDirection.Down && !canOpenUpward) ||
+                (this.props.openDirection === OpenDirection.Down && canOpenDownard)
 
             const rightBounds = this.props.x + rect.width
 
@@ -202,25 +216,28 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
             let adjustedX = this.props.x
 
             if (!isFullWidth && rightBounds > this.props.containerWidth) {
-                    const offset = rightBounds - this.props.containerWidth + 8
-                    adjustedX = this.props.x - offset
+                const offset = rightBounds - this.props.containerWidth + 8
+                adjustedX = this.props.x - offset
             }
 
             this.setState({
-                    isFullWidth,
-                    shouldOpenDownward,
-                    adjustedX,
-                    isMeasured: true,
-                    lastMeasuredX: rect.left,
-                    lastMeasuredY: rect.top,
-                    lastMeasuredWidth: rect.width,
-                    lastMeasuredHeight: rect.height,
-                })
+                isFullWidth,
+                shouldOpenDownward,
+                adjustedX,
+                isMeasured: true,
+                lastMeasuredX: rect.left,
+                lastMeasuredY: rect.top,
+                lastMeasuredWidth: rect.width,
+                lastMeasuredHeight: rect.height,
+            })
         }
     }
 }
 
-const mapStateToProps = (state: IState, props?: ICursorPositionerProps): ICursorPositionerViewProps => {
+const mapStateToProps = (
+    state: IState,
+    props?: ICursorPositionerProps,
+): ICursorPositionerViewProps => {
     const x = props.position ? props.position.pixelX : state.cursorPixelX
     const y = props.position ? props.position.pixelY : state.cursorPixelY
 
@@ -228,13 +245,13 @@ const mapStateToProps = (state: IState, props?: ICursorPositionerProps): ICursor
 
     const backgroundColor = state.colors["editor.background"]
 
-    const beakColor = (props && props.beakColor) ? props.beakColor : backgroundColor
+    const beakColor = props && props.beakColor ? props.beakColor : backgroundColor
 
     return {
         beakColor,
         fontPixelWidth: state.fontPixelWidth,
-        x: x - (state.fontPixelWidth / 2),
-        y: y - (state.fontPixelHeight),
+        x: x - state.fontPixelWidth / 2,
+        y: y - state.fontPixelHeight,
         containerWidth: state.viewport.width,
         containerHeight: state.viewport.height,
         lineHeight,

--- a/browser/src/UI/components/Definition.tsx
+++ b/browser/src/UI/components/Definition.tsx
@@ -62,7 +62,11 @@ export class Definition extends React.PureComponent<IDefinitionProps, {}> {
             top: startPixelPosition.pixelY + "px",
             left: startPixelPosition.pixelX + "px",
             height: this.props.fontHeightInPixels + "px",
-            width: (endPixelPosition.pixelX - startPixelPosition.pixelX + this.props.fontWidthInPixels) + "px",
+            width:
+                endPixelPosition.pixelX -
+                startPixelPosition.pixelX +
+                this.props.fontWidthInPixels +
+                "px",
             borderBottom: "1px solid " + this.props.color,
         }
 

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -32,9 +32,10 @@ export class Errors extends React.PureComponent<IErrorsProps, {}> {
             return null
         }
 
-        const markers = errors.map((e) => {
-
-            const screenSpaceStart = this.props.bufferToScreen(types.Position.create(e.range.start.line, e.range.start.character))
+        const markers = errors.map(e => {
+            const screenSpaceStart = this.props.bufferToScreen(
+                types.Position.create(e.range.start.line, e.range.start.character),
+            )
             if (!screenSpaceStart) {
                 return null
             }
@@ -42,48 +43,60 @@ export class Errors extends React.PureComponent<IErrorsProps, {}> {
             const screenLine = screenSpaceStart.screenY
 
             const screenY = screenLine
-            const pixelPosition = this.props.screenToPixel({screenX: 0, screenY })
-            const pixelY = pixelPosition.pixelY - (padding / 2)
+            const pixelPosition = this.props.screenToPixel({ screenX: 0, screenY })
+            const pixelY = pixelPosition.pixelY - padding / 2
 
-            return <ErrorMarker
-                y={pixelY}
-                text={e.message}
-                color={getColorFromSeverity(e.severity)} />
+            return (
+                <ErrorMarker y={pixelY} text={e.message} color={getColorFromSeverity(e.severity)} />
+            )
         })
 
         const squiggles = errors
-            .filter((e) => e && e.range && e.range.start && e.range.end)
-            .map((e) => {
-            const lineNumber = e.range.start.line
-            const column = e.range.start.character
-            const endColumn = e.range.end.character
+            .filter(e => e && e.range && e.range.start && e.range.end)
+            .map(e => {
+                const lineNumber = e.range.start.line
+                const column = e.range.start.character
+                const endColumn = e.range.end.character
 
-            const startPosition = this.props.bufferToScreen(types.Position.create(lineNumber, column))
+                const startPosition = this.props.bufferToScreen(
+                    types.Position.create(lineNumber, column),
+                )
 
-            if (!startPosition) {
-                return null
-            }
+                if (!startPosition) {
+                    return null
+                }
 
-            const endPosition = this.props.bufferToScreen(types.Position.create(lineNumber, endColumn))
+                const endPosition = this.props.bufferToScreen(
+                    types.Position.create(lineNumber, endColumn),
+                )
 
-            if (!endPosition) {
-                return null
-            }
+                if (!endPosition) {
+                    return null
+                }
 
-            const pixelStart = this.props.screenToPixel(startPosition)
-            const pixelEnd = this.props.screenToPixel(endPosition)
-            const pixelWidth = pixelEnd.pixelX - pixelStart.pixelX
-            const normalizedPixelWidth = pixelWidth === 0 ? this.props.fontWidthInPixels : pixelWidth
+                const pixelStart = this.props.screenToPixel(startPosition)
+                const pixelEnd = this.props.screenToPixel(endPosition)
+                const pixelWidth = pixelEnd.pixelX - pixelStart.pixelX
+                const normalizedPixelWidth =
+                    pixelWidth === 0 ? this.props.fontWidthInPixels : pixelWidth
 
-            return <ErrorSquiggle
-                y={pixelStart.pixelY}
-                height={this.props.fontHeightInPixels}
-                x={pixelStart.pixelX}
-                width={normalizedPixelWidth}
-                color={getColorFromSeverity(e.severity)} />
-        })
+                return (
+                    <ErrorSquiggle
+                        y={pixelStart.pixelY}
+                        height={this.props.fontHeightInPixels}
+                        x={pixelStart.pixelX}
+                        width={normalizedPixelWidth}
+                        color={getColorFromSeverity(e.severity)}
+                    />
+                )
+            })
 
-        return <div>{markers}{squiggles}</div>
+        return (
+            <div>
+                {markers}
+                {squiggles}
+            </div>
+        )
     }
 }
 
@@ -94,20 +107,18 @@ export interface IErrorMarkerProps {
 }
 
 export class ErrorMarker extends React.PureComponent<IErrorMarkerProps, {}> {
-
     public render(): JSX.Element {
-
         const iconPositionStyles = {
             top: this.props.y.toString() + "px",
         }
 
-        const errorIcon = <div style={iconPositionStyles} className="error-marker">
-            <ErrorIcon color={this.props.color} />
-        </div>
+        const errorIcon = (
+            <div style={iconPositionStyles} className="error-marker">
+                <ErrorIcon color={this.props.color} />
+            </div>
+        )
 
-        return <div>
-            {errorIcon}
-        </div>
+        return <div>{errorIcon}</div>
     }
 }
 
@@ -116,22 +127,23 @@ export interface IErrorIconProps {
 }
 
 export const ErrorIcon = (props: IErrorIconProps) => {
-    return <div className="icon-container" style={{ color: props.color }}>
-        <Icon name="exclamation-circle" />
-    </div>
+    return (
+        <div className="icon-container" style={{ color: props.color }}>
+            <Icon name="exclamation-circle" />
+        </div>
+    )
 }
 
 export interface IErrorSquiggleProps {
-    x: number,
-    y: number,
-    height: number,
-    width: number,
-    color: string,
+    x: number
+    y: number
+    height: number
+    width: number
+    color: string
 }
 
 export class ErrorSquiggle extends React.PureComponent<IErrorSquiggleProps, {}> {
     public render(): JSX.Element {
-
         const { x, y, width, height, color } = this.props
 
         const style = {
@@ -142,6 +154,6 @@ export class ErrorSquiggle extends React.PureComponent<IErrorSquiggleProps, {}> 
             borderBottom: `1px dashed ${color}`,
         }
 
-        return <div className="error-squiggle" style={style}></div>
+        return <div className="error-squiggle" style={style} />
     }
 }

--- a/browser/src/UI/components/ErrorInfo.tsx
+++ b/browser/src/UI/components/ErrorInfo.tsx
@@ -14,21 +14,24 @@ export interface IErrorInfoProps {
  * Helper component to render errors in the QuickInfo bubble
  */
 export class ErrorInfo extends React.PureComponent<IErrorInfoProps, {}> {
-
     public render(): null | JSX.Element {
         if (!this.props.errors) {
             return null
         }
 
-        const errs = this.props.errors.map((e) => <div className="diagnostic">
-                                           <ErrorIcon color={getColorFromSeverity(e.severity)} />
-                                           <span>{e.message}</span>
-                                           </div>)
+        const errs = this.props.errors.map(e => (
+            <div className="diagnostic">
+                <ErrorIcon color={getColorFromSeverity(e.severity)} />
+                <span>{e.message}</span>
+            </div>
+        ))
 
         const style = this.props.style || {}
 
-        return <div className="diagnostic-container" style={style}>
-            {errs}
-        </div>
+        return (
+            <div className="diagnostic-container" style={style}>
+                {errs}
+            </div>
+        )
     }
 }

--- a/browser/src/UI/components/ExternalMenus.tsx
+++ b/browser/src/UI/components/ExternalMenus.tsx
@@ -26,13 +26,14 @@ interface Props {
 }
 
 class ExternalMenus extends React.Component<Props> {
-
     public render() {
         const { wildmenu, commandLine } = this.props
         const visible = commandLine.visible || wildmenu.visible
-        return visible ? <MenuContainer loaded={commandLine.visible && wildmenu.visible}>
-                    {this.props.children}
-                </MenuContainer> : null
+        return visible ? (
+            <MenuContainer loaded={commandLine.visible && wildmenu.visible}>
+                {this.props.children}
+            </MenuContainer>
+        ) : null
     }
 }
 

--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -8,24 +8,21 @@ export interface IHighlightTextProps {
 }
 
 export class HighlightText extends React.PureComponent<IHighlightTextProps, {}> {
-
     public render(): JSX.Element {
-
         const childNodes: JSX.Element[] = []
 
         const letterCountDictionary = createLetterCountDictionary(this.props.highlightText)
 
         this.props.text.split("").forEach((c: string, idx: number) => {
-
             const currentVal = letterCountDictionary[c]
             letterCountDictionary[c] = currentVal - 1
 
             if (currentVal > 0) {
                 childNodes.push(
-                    <span
-                        key={`${idx}-${c}`}
-                        className={this.props.highlightClassName}>
-                    {c}</span>)
+                    <span key={`${idx}-${c}`} className={this.props.highlightClassName}>
+                        {c}
+                    </span>,
+                )
             } else {
                 childNodes.push(<span key={`${idx}-${c}`}>{c}</span>)
             }
@@ -44,20 +41,20 @@ export interface IHighlightTextByIndexProps {
 
 export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIndexProps, {}> {
     public render(): JSX.Element {
-
         const childNodes: JSX.Element[] = []
         const highlightIndices = this.props.highlightIndices || []
         const text = this.props.text || ""
 
         text.split("").forEach((c: string, idx: number) => {
-
             if (shouldHighlightIndex(idx, highlightIndices)) {
                 childNodes.push(
                     <span
                         key={`${idx}-${highlightIndices}-${c}`}
-                        className={this.props.highlightClassName}>
+                        className={this.props.highlightClassName}
+                    >
                         {c}
-                    </span>)
+                    </span>,
+                )
             } else {
                 childNodes.push(<span key={`${idx}-${highlightIndices}-${c}`}>{c}</span>)
             }
@@ -65,14 +62,15 @@ export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIn
 
         return <span className={this.props.className}>{childNodes}</span>
     }
-
 }
 
 function shouldHighlightIndex(index: number, highlights: number[]): boolean {
     return highlights.indexOf(index) >= 0
 }
 
-export interface LetterCountDictionary { [letter: string]: number }
+export interface LetterCountDictionary {
+    [letter: string]: number
+}
 
 export function createLetterCountDictionary(text: string): LetterCountDictionary {
     const array: string[] = text.split("")

--- a/browser/src/UI/components/InstallHelp.tsx
+++ b/browser/src/UI/components/InstallHelp.tsx
@@ -13,7 +13,6 @@ export interface InstallHelpViewProps {
 }
 
 export class InstallHelpView extends React.PureComponent<InstallHelpViewProps, {}> {
-
     public render(): JSX.Element {
         if (!this.props.visible) {
             return null
@@ -29,26 +28,36 @@ export class InstallHelpView extends React.PureComponent<InstallHelpViewProps, {
             evt.preventDefault()
         }
 
-        return <div className="install-help enable-mouse">
-            <div className="title">
-                <Icon name="warning" size={IconSize.FiveX} />
-                <h1>Uh oh! Unable to launch Neovim...</h1>
-                <p>Neovim v0.2.1 is required to run Oni.</p>
+        return (
+            <div className="install-help enable-mouse">
+                <div className="title">
+                    <Icon name="warning" size={IconSize.FiveX} />
+                    <h1>Uh oh! Unable to launch Neovim...</h1>
+                    <p>Neovim v0.2.1 is required to run Oni.</p>
+                </div>
+                <div className="instructions">
+                    <ul>
+                        <li>
+                            <span>Install neovim from here: </span>
+                            <a href="#" onClick={evt => _onClick(evt)}>
+                                Installing Neovim
+                            </a>
+                        </li>
+                        <li>
+                            Run `nvim --version` from your command prompt to verify you're good to
+                            go!
+                        </li>
+                        <li>Close and re-open Oni</li>
+                    </ul>
+                </div>
+                <div>
+                    If this issue persists, help us by logging an{" "}
+                    <a href="#" onClick={evt => _onClickIssue}>
+                        issue!
+                    </a>
+                </div>
             </div>
-            <div className="instructions">
-                <ul>
-                    <li>
-                        <span>Install neovim from here: </span>
-                        <a href="#" onClick={(evt) => _onClick(evt)}>Installing Neovim</a>
-                    </li>
-                    <li>Run `nvim --version` from your command prompt to verify you're good to go!</li>
-                    <li>Close and re-open Oni</li>
-                </ul>
-            </div>
-            <div>
-                If this issue persists, help us by logging an <a href="#" onClick={(evt) => _onClickIssue}>issue!</a>
-            </div>
-        </div>
+        )
     }
 }
 

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -15,7 +15,6 @@ export interface ITextInputViewProps {
     foregroundColor: string
 
     overrideDefaultStyle?: boolean
-
 }
 
 // TODO: Is there a better value for this?
@@ -27,7 +26,6 @@ const EmptyStyle: React.CSSProperties = {}
  * common functionality (like focus management, key handling)
  */
 export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> {
-
     private _element: HTMLInputElement
 
     public componentDidMount(): void {
@@ -37,11 +35,12 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
     }
 
     public render(): JSX.Element {
-
-        const containerStyle: React.CSSProperties = this.props.overrideDefaultStyle ? EmptyStyle : {
-            padding: "4px",
-            border: "1px solid " + this.props.foregroundColor,
-        }
+        const containerStyle: React.CSSProperties = this.props.overrideDefaultStyle
+            ? EmptyStyle
+            : {
+                  padding: "4px",
+                  border: "1px solid " + this.props.foregroundColor,
+              }
 
         const inputStyle: React.CSSProperties = {
             outline: "none",
@@ -53,18 +52,23 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
 
         const defaultValue = this.props.defaultValue || ""
 
-        return <div style={containerStyle}><input type="text"
-            style={inputStyle}
-            placeholder={defaultValue}
-            onKeyDown={(evt) => this._onKeyDown(evt)}
-            onChange={(evt) => this._onChange(evt)}
-            onFocus={(evt) => evt.currentTarget.select()}
-            ref={(elem) => this._element = elem} /></div>
+        return (
+            <div style={containerStyle}>
+                <input
+                    type="text"
+                    style={inputStyle}
+                    placeholder={defaultValue}
+                    onKeyDown={evt => this._onKeyDown(evt)}
+                    onChange={evt => this._onChange(evt)}
+                    onFocus={evt => evt.currentTarget.select()}
+                    ref={elem => (this._element = elem)}
+                />
+            </div>
+        )
     }
 
     public componentWillUnmount(): void {
         if (this._element) {
-
             if (this.props.onComplete) {
                 this.props.onComplete(this._element.value)
             }
@@ -81,24 +85,20 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
     }
 
     private _onKeyDown(keyboardEvent: React.KeyboardEvent<HTMLInputElement>): void {
-
         if (this._element && keyboardEvent.ctrlKey) {
-
             switch (keyboardEvent.key) {
-                case "u":
-                    {
-                        this._element.value = ""
-                        break
-                    }
-                case "h":
-                    {
-                        const previousValue = this._element.value
+                case "u": {
+                    this._element.value = ""
+                    break
+                }
+                case "h": {
+                    const previousValue = this._element.value
 
-                        if (previousValue.length > 0) {
-                            this._element.value = previousValue.substring(0, previousValue.length - 1)
-                        }
-                        break
+                    if (previousValue.length > 0) {
+                        this._element.value = previousValue.substring(0, previousValue.length - 1)
                     }
+                    break
+                }
                 case "w":
                     {
                         const previousValue = this._element.value
@@ -117,7 +117,6 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
                     break
                 default:
                     return
-
             }
         }
     }

--- a/browser/src/UI/components/Loading.tsx
+++ b/browser/src/UI/components/Loading.tsx
@@ -28,7 +28,7 @@ export class LoadingView extends React.PureComponent<ILoadingViewProps, {}> {
             transition: "opacity 0.5s ease",
         }
 
-        return <div style={style}></div>
+        return <div style={style} />
     }
 }
 

--- a/browser/src/UI/components/LoadingSpinner.tsx
+++ b/browser/src/UI/components/LoadingSpinner.tsx
@@ -25,8 +25,10 @@ const LoadingIconWrapper = styled.div`
 
 export class LoadingSpinner extends React.PureComponent<{}, {}> {
     public render(): JSX.Element {
-        return <LoadingIconWrapper>
-            <Icon name="circle-o-notch" size={IconSize.FourX} />
-        </LoadingIconWrapper>
+        return (
+            <LoadingIconWrapper>
+                <Icon name="circle-o-notch" size={IconSize.FourX} />
+            </LoadingIconWrapper>
+        )
     }
 }

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -26,7 +26,7 @@ const childStyles = css`
     > * {
         margin: 0.2rem;
 
-       a {
+        a {
             color: ${p => p.theme["highlight.mode.normal.background"]};
         }
 
@@ -34,7 +34,7 @@ const childStyles = css`
             ${codeBlockStyle};
         }
 
-    /* All code blocks are set to black but
+        /* All code blocks are set to black but
     this overriden for code block INSIDE a Pre element */
 
         code {
@@ -53,7 +53,7 @@ export const Documentation = styled.div`
     padding: 0.5rem;
     line-height: 1.5;
     ${smallScrollbar};
-    background-color:${p => p.theme["editor.hover.contents.background"]};
+    background-color: ${p => p.theme["editor.hover.contents.background"]};
     color: ${p => p.theme["editor.hover.contents.foreground"]};
 
     &:hover {
@@ -63,8 +63,7 @@ export const Documentation = styled.div`
     ${childStyles};
 
     pre {
-        ${smallScrollbar}
-        ${codeBlockStyle};
+        ${smallScrollbar} ${codeBlockStyle};
     }
 `
 // NOTE: Currently with a max-width in CursorPositioner the text
@@ -98,15 +97,15 @@ export const QuickInfoContainer = withProps<{ hasDocs: boolean }>(styled.div)`
   max-height: fit-content;
   overflow: hidden;
   width: 100%;
-  padding-bottom: ${p => p.hasDocs ? "0.5rem" : "0"};
+  padding-bottom: ${p => (p.hasDocs ? "0.5rem" : "0")};
   background-color: ${p => p.theme["editor.hover.contents.background"]};
 `
 
 export interface ITextProps {
-    padding?: string,
-    text?: string,
+    padding?: string
+    text?: string
     html?: {
-        __html: string,
+        __html: string
     }
 }
 
@@ -117,7 +116,11 @@ export class QuickInfoTitle extends React.PureComponent<ITextProps> {
             return null
         }
 
-        return <Title padding={padding} dangerouslySetInnerHTML={html}>{text}</Title>
+        return (
+            <Title padding={padding} dangerouslySetInnerHTML={html}>
+                {text}
+            </Title>
+        )
     }
 }
 
@@ -131,7 +134,6 @@ export class QuickInfoDocumentation extends React.PureComponent<ITextProps> {
 
                 return <Documentation>{divs}</Documentation>
             case Boolean(html && html.__html.length):
-
                 return <Documentation dangerouslySetInnerHTML={this.props.html} />
             default:
                 return null

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -70,8 +70,8 @@ const StatusBarComponent = withProps<IStatusComponent>(styled.div)`
 
 const StatusBarContainer = withProps<StatusBarStyleProps>(styled.div)`
     font-family: ${({ fontFamily }) => fontFamily};
-    font-size: ${({ fontSize }) => fontSize };
-    background-color: ${({ theme }) => theme.background };
+    font-size: ${({ fontSize }) => fontSize};
+    background-color: ${({ theme }) => theme.background};
     color: ${({ theme }) => theme.foreground};
     box-shadow: 0 -8px 20px 0 rgba(0, 0, 0, 0.2);
     pointer-events: auto;

--- a/browser/src/UI/components/StatusResize.tsx
+++ b/browser/src/UI/components/StatusResize.tsx
@@ -63,7 +63,7 @@ class StatusBarResizer extends React.Component<Props, State> {
         this.setState({
             containerWidth: this.elem.getBoundingClientRect().width,
         })
-        //tslint:disable-next-line
+        // tslint:disable-next-line
         this.observer = new window["ResizeObserver"](([entry]: any) => {
             this.setState({ containerWidth: entry.contentRect.width }, this.resize)
         })

--- a/browser/src/UI/components/StatusResize.tsx
+++ b/browser/src/UI/components/StatusResize.tsx
@@ -24,13 +24,13 @@ interface State {
     containerWidth: number
     children: {
         [id: string]: {
-            id: string;
-            width: number;
-            alignment: number;
-            hide?: boolean;
-            priority: number;
-            passWidth: PassWidth;
-        };
+            id: string
+            width: number
+            alignment: number
+            hide?: boolean
+            priority: number
+            passWidth: PassWidth
+        }
     }
 }
 
@@ -41,7 +41,7 @@ interface Section {
 
 const StatusbarSection = withProps<Section>(styled.div)`
     flex: 1 1 auto;
-    display: ${({ count }) => count ? `none` : `flex`};
+    display: ${({ count }) => (count ? `none` : `flex`)};
     flex-direction: row;
     height: 100%;
     max-width: 48%;
@@ -63,7 +63,8 @@ class StatusBarResizer extends React.Component<Props, State> {
         this.setState({
             containerWidth: this.elem.getBoundingClientRect().width,
         })
-        this.observer = new window["ResizeObserver"](([entry]: any) => { //tslint:disable-line
+        this.observer = new window["ResizeObserver"](([entry]: any) => {
+            //tslint:disable-line
             this.setState({ containerWidth: entry.contentRect.width }, this.resize)
         })
         this.observer.observe(this.elem)
@@ -85,7 +86,7 @@ class StatusBarResizer extends React.Component<Props, State> {
                 innerRef={(elem: Element) => (this.elem = elem)}
             >
                 {containerWidth !== undefined &&
-                React.Children.map(children, (child: React.ReactElement<any>) => {
+                    React.Children.map(children, (child: React.ReactElement<any>) => {
                         const current = this.state.children[child.props.id]
                         return React.cloneElement(child, {
                             ...child.props,
@@ -100,13 +101,16 @@ class StatusBarResizer extends React.Component<Props, State> {
 
     private passWidth = (childDimensions: IChildDimensions) => {
         const { width, id, priority, hide } = childDimensions
-        this.setState(state => ({
-            ...state,
-            children: {
-                ...state.children,
-                [id]: { id, width, priority, hide },
-            },
-        }), this.resize)
+        this.setState(
+            state => ({
+                ...state,
+                children: {
+                    ...state.children,
+                    [id]: { id, width, priority, hide },
+                },
+            }),
+            this.resize,
+        )
     }
 
     private resize = () => {

--- a/browser/src/UI/components/StatusResize.tsx
+++ b/browser/src/UI/components/StatusResize.tsx
@@ -63,8 +63,8 @@ class StatusBarResizer extends React.Component<Props, State> {
         this.setState({
             containerWidth: this.elem.getBoundingClientRect().width,
         })
+        //tslint:disable-next-line
         this.observer = new window["ResizeObserver"](([entry]: any) => {
-            //tslint:disable-line
             this.setState({ containerWidth: entry.contentRect.width }, this.resize)
         })
         this.observer.observe(this.elem)

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -68,27 +68,31 @@ export class Tabs extends React.PureComponent<ITabsProps, {}> {
 
         const tabBorderStyle: React.CSSProperties = {
             ...overflowStyle,
-            "borderBottom": `4px solid ${this.props.backgroundColor}`,
+            borderBottom: `4px solid ${this.props.backgroundColor}`,
             fontFamily: this.props.fontFamily,
             fontSize: this.props.fontSize,
         }
 
-        const tabs = this.props.tabs.map((t) => {
-            return <Tab
-                key={t.id}
-                {...t}
-                onClickName={() => this._onSelect(t.id)}
-                onClickClose={() => this._onClickClose(t.id)}
-                backgroundColor={this.props.backgroundColor}
-                foregroundColor={this.props.foregroundColor}
-                height={this.props.height}
-                maxWidth={this.props.maxWidth}
-            />
+        const tabs = this.props.tabs.map(t => {
+            return (
+                <Tab
+                    key={t.id}
+                    {...t}
+                    onClickName={() => this._onSelect(t.id)}
+                    onClickClose={() => this._onClickClose(t.id)}
+                    backgroundColor={this.props.backgroundColor}
+                    foregroundColor={this.props.foregroundColor}
+                    height={this.props.height}
+                    maxWidth={this.props.maxWidth}
+                />
+            )
         })
 
-        return <div className="tabs horizontal enable-mouse layer" style={tabBorderStyle}>
-            {tabs}
-        </div>
+        return (
+            <div className="tabs horizontal enable-mouse layer" style={tabBorderStyle}>
+                {tabs}
+            </div>
+        )
     }
 
     private _onSelect(id: number): void {
@@ -113,7 +117,7 @@ export interface ITabPropsWithClick extends ITabProps {
 
 export const Tab = (props: ITabPropsWithClick) => {
     const cssClasses = classNames("tab", {
-        "selected": props.isSelected,
+        selected: props.isSelected,
         "not-selected": !props.isSelected,
         "is-dirty": props.isDirty,
         "not-dirty": !props.isDirty,
@@ -127,24 +131,28 @@ export const Tab = (props: ITabPropsWithClick) => {
         borderTop: "2px solid " + props.highlightColor,
     }
 
-    return <div className={cssClasses} title={props.description} style={style}>
-        <div className="corner" onClick={props.onClickName}>
-            <FileIcon fileName={props.iconFileName} isLarge={true} additionalClassNames={"file-icon-appear-animation"}/>
-        </div>
-        <div className="name" onClick={props.onClickName}>
-            <span className="name-inner">
-                {props.name}
-            </span>
-        </div>
-        <div className="corner enable-hover" onClick={props.onClickClose}>
-            <div className="icon-container x-icon-container">
-                <Icon name="times" />
+    return (
+        <div className={cssClasses} title={props.description} style={style}>
+            <div className="corner" onClick={props.onClickName}>
+                <FileIcon
+                    fileName={props.iconFileName}
+                    isLarge={true}
+                    additionalClassNames={"file-icon-appear-animation"}
+                />
             </div>
-            <div className="icon-container circle-icon-container">
-                <div className="circle" />
+            <div className="name" onClick={props.onClickName}>
+                <span className="name-inner">{props.name}</span>
+            </div>
+            <div className="corner enable-hover" onClick={props.onClickClose}>
+                <div className="icon-container x-icon-container">
+                    <Icon name="times" />
+                </div>
+                <div className="icon-container circle-icon-container">
+                    <div className="circle" />
+                </div>
             </div>
         </div>
-    </div>
+    )
 }
 
 const getTabName = (name: string): string => {
@@ -191,11 +199,24 @@ export const shouldShowFileIcon = (state: State.IState): boolean => {
 }
 
 const getTabsFromBuffers = createSelector(
-    [BufferSelectors.getBufferMetadata, BufferSelectors.getActiveBufferId, getHighlightColor, showTabId, shouldShowFileIcon],
-    (allBuffers: any, activeBufferId: any, color: string, shouldShowId: boolean, showFileIcon: boolean) => {
+    [
+        BufferSelectors.getBufferMetadata,
+        BufferSelectors.getActiveBufferId,
+        getHighlightColor,
+        showTabId,
+        shouldShowFileIcon,
+    ],
+    (
+        allBuffers: any,
+        activeBufferId: any,
+        color: string,
+        shouldShowId: boolean,
+        showFileIcon: boolean,
+    ) => {
         const bufferCount = allBuffers.length
         const tabs = allBuffers.map((buf: any): ITabProps => {
-            const isActive = (activeBufferId !== null && buf.id === activeBufferId) || bufferCount === 1
+            const isActive =
+                (activeBufferId !== null && buf.id === activeBufferId) || bufferCount === 1
             return {
                 id: buf.id,
                 name: getIdPrefix(buf.id, shouldShowId) + getTabName(buf.file),
@@ -207,7 +228,8 @@ const getTabsFromBuffers = createSelector(
             }
         })
         return tabs.sort(({ id: prevId }: ITabProps, { id: nextId }: ITabProps) => prevId - nextId)
-    })
+    },
+)
 
 const getTabsFromVimTabs = createSelector(
     [getTabState, getHighlightColor, showTabId, shouldShowFileIcon],
@@ -221,10 +243,10 @@ const getTabsFromVimTabs = createSelector(
             isDirty: false,
             description: t.name,
         }))
-    })
+    },
+)
 
 const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITabsProps => {
-
     const oniTabMode = state.configuration["tabs.mode"]
     const shouldUseVimTabs = oniTabMode === "tabs"
 

--- a/browser/src/UI/components/Text.tsx
+++ b/browser/src/UI/components/Text.tsx
@@ -4,9 +4,7 @@ export interface ITextProps {
     text: string
 }
 
-export class TextComponent extends React.PureComponent<ITextProps, {}> {
-
-}
+export class TextComponent extends React.PureComponent<ITextProps, {}> {}
 
 export class Text extends TextComponent {
     public render(): JSX.Element {

--- a/browser/src/UI/components/ToolTip.tsx
+++ b/browser/src/UI/components/ToolTip.tsx
@@ -43,9 +43,7 @@ export interface IToolTipsViewProps {
 export class ToolTipsView extends React.PureComponent<IToolTipsViewProps, {}> {
     public render(): JSX.Element {
         const toolTipElements = this.props.toolTips.map(toolTip => {
-            return (
-                <ToolTipView fontFamily={this.props.fontFamily} {...toolTip} key={toolTip.id} />
-            )
+            return <ToolTipView fontFamily={this.props.fontFamily} {...toolTip} key={toolTip.id} />
         })
 
         const style: React.CSSProperties = {
@@ -88,7 +86,7 @@ export class ToolTipView extends React.PureComponent<IToolTipViewProps, {}> {
     }
 
     public render(): JSX.Element {
-        const { options, fontFamily } =  this.props
+        const { options, fontFamily } = this.props
         const { position = null, openDirection = 1, padding = "8px" } = options
 
         return (
@@ -97,7 +95,7 @@ export class ToolTipView extends React.PureComponent<IToolTipViewProps, {}> {
                     padding={padding}
                     fontFamily={fontFamily}
                     innerRef={(elem: any) => this._setContainer(elem)}
-                    >
+                >
                     {this.props.element}
                 </ToolTipContainer>
             </CursorPositioner>

--- a/browser/src/UI/components/TypingPredictions.tsx
+++ b/browser/src/UI/components/TypingPredictions.tsx
@@ -12,7 +12,10 @@ import { connect } from "react-redux"
 
 import * as State from "./../../Editor/NeovimEditor/NeovimEditorStore"
 
-import { ITypingPrediction, TypingPredictionManager } from "./../../Services/TypingPredictionManager"
+import {
+    ITypingPrediction,
+    TypingPredictionManager,
+} from "./../../Services/TypingPredictionManager"
 
 import { addDefaultUnitIfNeeded } from "./../../Font"
 
@@ -34,67 +37,69 @@ export interface ITypingPredictionViewProps {
     highlightPredictions: boolean
 }
 
-const noop = (val?: any): void => { } // tslint:disable-line
+const noop = (val?: any): void => {} // tslint:disable-line
 
 class TypingPredictionView extends React.PureComponent<ITypingPredictionViewProps, {}> {
-
     private _containerElement: HTMLElement
     private _subscription: IDisposable
 
     private _predictedElements: { [id: number]: HTMLElement } = {}
 
     public componentDidMount(): void {
-        this._subscription = this.props.typingPrediction.onPredictionsChanged.subscribe((prediction: ITypingPrediction) => {
-
-            if (!this._containerElement) {
-                return
-            }
-
-            this._containerElement.innerHTML = ""
-
-            const updatedPredictions = prediction.predictedCharacters
-            const startX = (prediction.predictedCursorColumn - prediction.predictedCharacters.length) * this.props.width
-
-            this._containerElement.style.top = this.props.y.toString() + "px"
-            this._containerElement.style.height = this.props.height.toString() + "px"
-            this._containerElement.style.left = startX.toString() + "px"
-            this._containerElement.style.width = (prediction.predictedCharacters.length * this.props.width).toString() + "px"
-
-            if (this.props.highlightPredictions) {
-                this._containerElement.style.color = "white"
-                this._containerElement.style.backgroundColor = "rgba(255, 0, 0, 0.5)"
-            } else {
-                this._containerElement.style.color = prediction.foregroundColor
-                this._containerElement.style.backgroundColor = prediction.backgroundColor
-            }
-
-            // Add new predictions
-            updatedPredictions.forEach((up, idx) => {
-                const elem = document.createElement("div")
-                elem.className = "predicted-text"
-                elem.style.position = "absolute"
-                elem.style.top = "0px"
-                elem.style.left = (idx * this.props.width).toString() + "px"
-                elem.style.width = (this.props.width.toString()) + "px"
-                elem.style.height = (this.props.height.toString()) + "px"
-                elem.style.lineHeight = this.props.height.toString() + "px"
-
-                if (this.props.highlightPredictions) {
-                    elem.style.color = "white"
-                    elem.style.backgroundColor = "rgba(255, 0, 0, 0.5)"
+        this._subscription = this.props.typingPrediction.onPredictionsChanged.subscribe(
+            (prediction: ITypingPrediction) => {
+                if (!this._containerElement) {
+                    return
                 }
 
-                elem.textContent = up.character
+                this._containerElement.innerHTML = ""
 
-                this._containerElement.appendChild(elem)
+                const updatedPredictions = prediction.predictedCharacters
+                const startX =
+                    (prediction.predictedCursorColumn - prediction.predictedCharacters.length) *
+                    this.props.width
 
-                this._predictedElements[up.id] = this._containerElement
+                this._containerElement.style.top = this.props.y.toString() + "px"
+                this._containerElement.style.height = this.props.height.toString() + "px"
+                this._containerElement.style.left = startX.toString() + "px"
+                this._containerElement.style.width =
+                    (prediction.predictedCharacters.length * this.props.width).toString() + "px"
 
-            })
+                if (this.props.highlightPredictions) {
+                    this._containerElement.style.color = "white"
+                    this._containerElement.style.backgroundColor = "rgba(255, 0, 0, 0.5)"
+                } else {
+                    this._containerElement.style.color = prediction.foregroundColor
+                    this._containerElement.style.backgroundColor = prediction.backgroundColor
+                }
 
-            // Force re-layout
-            noop(this._containerElement.offsetWidth)
-        })
+                // Add new predictions
+                updatedPredictions.forEach((up, idx) => {
+                    const elem = document.createElement("div")
+                    elem.className = "predicted-text"
+                    elem.style.position = "absolute"
+                    elem.style.top = "0px"
+                    elem.style.left = (idx * this.props.width).toString() + "px"
+                    elem.style.width = this.props.width.toString() + "px"
+                    elem.style.height = this.props.height.toString() + "px"
+                    elem.style.lineHeight = this.props.height.toString() + "px"
+
+                    if (this.props.highlightPredictions) {
+                        elem.style.color = "white"
+                        elem.style.backgroundColor = "rgba(255, 0, 0, 0.5)"
+                    }
+
+                    elem.textContent = up.character
+
+                    this._containerElement.appendChild(elem)
+
+                    this._predictedElements[up.id] = this._containerElement
+                })
+
+                // Force re-layout
+                noop(this._containerElement.offsetWidth)
+            },
+        )
     }
 
     public componentWillUnmount(): void {
@@ -115,11 +120,21 @@ class TypingPredictionView extends React.PureComponent<ITypingPredictionViewProp
             position: "absolute",
         }
 
-        return <div className="typing-predictions" key={"typing-predictions"} style={containerStyle} ref={(elem) => this._containerElement = elem}></div>
+        return (
+            <div
+                className="typing-predictions"
+                key={"typing-predictions"}
+                style={containerStyle}
+                ref={elem => (this._containerElement = elem)}
+            />
+        )
     }
 }
 
-const mapStateToProps = (state: State.IState, props: ITypingPredictionProps): ITypingPredictionViewProps => {
+const mapStateToProps = (
+    state: State.IState,
+    props: ITypingPredictionProps,
+): ITypingPredictionViewProps => {
     return {
         ...props,
         highlightPredictions: state.configuration["debug.showTypingPrediction"],

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -62,27 +62,28 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
     }
 
     public render() {
-
-        const inputElement = <div className="input">
-                    <KeyboardInputView
-                        top={0}
-                        left={0}
-                        height={12}
-                        onActivate={this._activateEvent}
-                        onKeyDown={(key) => this._onKeyDown(key)}
-                        foregroundColor={"white"}
-                        fontFamily={"Segoe UI"}
-                        fontSize={"12px"}
-                        fontCharacterWidthInPixels={12}
-                        />
-                </div>
-
-        return <div>
-                <div className="items">
-                    {this.props.render(this.state.selectedId)}
-                </div>
-                { this.props.active ? inputElement : null}
+        const inputElement = (
+            <div className="input">
+                <KeyboardInputView
+                    top={0}
+                    left={0}
+                    height={12}
+                    onActivate={this._activateEvent}
+                    onKeyDown={key => this._onKeyDown(key)}
+                    foregroundColor={"white"}
+                    fontFamily={"Segoe UI"}
+                    fontSize={"12px"}
+                    fontCharacterWidthInPixels={12}
+                />
             </div>
+        )
+
+        return (
+            <div>
+                <div className="items">{this.props.render(this.state.selectedId)}</div>
+                {this.props.active ? inputElement : null}
+            </div>
+        )
     }
 
     private _onKeyDown(key: string): void {
@@ -99,13 +100,12 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
     }
 
     private _updateBasedOnProps(props: IVimNavigatorProps) {
-
         if (props.active && !this._activeBinding) {
             Log.info("[VimNavigator::activating]")
             this._releaseBinding()
             this._activeBinding = getInstance().bindToMenu()
 
-            this._activeBinding.onCursorMoved.subscribe((newValue) => {
+            this._activeBinding.onCursorMoved.subscribe(newValue => {
                 Log.info("[VimNavigator::onCursorMoved] - " + newValue)
 
                 if (newValue !== this.state.selectedId) {
@@ -127,5 +127,4 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
             this._releaseBinding()
         }
     }
-
 }

--- a/browser/src/UI/components/Visible.tsx
+++ b/browser/src/UI/components/Visible.tsx
@@ -5,7 +5,6 @@ export interface IVisibleProps {
 }
 
 export class Visible extends React.PureComponent<IVisibleProps, {}> {
-
     public render(): null | JSX.Element {
         if (this.props.visible) {
             return React.Children.only(this.props.children)

--- a/browser/src/UI/components/WindowSplitHost.tsx
+++ b/browser/src/UI/components/WindowSplitHost.tsx
@@ -18,15 +18,14 @@ export interface IWindowSplitHostProps {
  * Component responsible for rendering an individual window split
  */
 export class WindowSplitHost extends React.PureComponent<IWindowSplitHostProps, {}> {
-
     public render(): JSX.Element {
+        const className =
+            this.props.containerClassName + (this.props.isFocused ? " focus" : " not-focused")
 
-        const className = this.props.containerClassName + (this.props.isFocused ? " focus" : " not-focused")
-
-        return <div className="container vertical full">
-                <div className={className}>
-                    {this.props.split.render()}
-                </div>
-        </div>
+        return (
+            <div className="container vertical full">
+                <div className={className}>{this.props.split.render()}</div>
+            </div>
+        )
     }
 }

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -31,26 +31,24 @@ export interface IDockProps {
 export class Dock extends React.PureComponent<IDockProps, {}> {
     public render(): JSX.Element {
         const docks = this.props.splits.map((s, i) => {
-            return (<div style={{display: "flex", flexDirection: "row"}}>
-            <WindowSplitHost
-                key={i}
-                containerClassName="split"
-                split={s}
-                isFocused={this.props.activeSplit === s}
-            />
-            <div className="split-spacer vertical" />
+            return (
+                <div style={{ display: "flex", flexDirection: "row" }}>
+                    <WindowSplitHost
+                        key={i}
+                        containerClassName="split"
+                        split={s}
+                        isFocused={this.props.activeSplit === s}
+                    />
+                    <div className="split-spacer vertical" />
                 </div>
             )
         })
 
-        return <div className = "dock container fixed horizontal">
-            {docks}
-            </div>
+        return <div className="dock container fixed horizontal">{docks}</div>
     }
 }
 
 export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindowSplitsState> {
-
     constructor(props: IWindowSplitsProps) {
         super(props)
 
@@ -62,7 +60,7 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
     }
 
     public componentDidMount(): void {
-        this.props.windowManager.onSplitChanged.subscribe((newSplit) => {
+        this.props.windowManager.onSplitChanged.subscribe(newSplit => {
             this.setState({
                 splitRoot: newSplit,
             })
@@ -74,7 +72,7 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
             })
         })
 
-        this.props.windowManager.onActiveSplitChanged.subscribe((newSplit) => {
+        this.props.windowManager.onActiveSplitChanged.subscribe(newSplit => {
             this.setState({
                 activeSplit: newSplit,
             })
@@ -87,10 +85,10 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
         }
 
         const containerStyle: React.CSSProperties = {
-            "display": "flex",
-            "flexDirection": "row",
-            "width": "100%",
-            "height": "100%",
+            display: "flex",
+            flexDirection: "row",
+            width: "100%",
+            height: "100%",
         }
 
         const editors = this.state.splitRoot.splits.map((splitNode, i) => {
@@ -100,20 +98,33 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
                 const split: Oni.IWindowSplit = splitNode.contents
 
                 if (!split) {
-                    return <div className="container vertical full" key={i}>TODO: Implement an editor here...</div>
+                    return (
+                        <div className="container vertical full" key={i}>
+                            TODO: Implement an editor here...
+                        </div>
+                    )
                 } else {
-                    return <WindowSplitHost containerClassName={"editor"} key={i} split={split} isFocused={split === this.state.activeSplit}/>
+                    return (
+                        <WindowSplitHost
+                            containerClassName={"editor"}
+                            key={i}
+                            split={split}
+                            isFocused={split === this.state.activeSplit}
+                        />
+                    )
                 }
             }
         })
 
         // const spacer = this.state.leftDock.length > 0 ? <div className="split-spacer vertical" /> : null
 
-        return <div style={containerStyle}>
-                    <div className="container horizontal full">
-                        <Dock splits={this.state.leftDock} activeSplit={this.state.activeSplit} />
-                        {editors}
-                    </div>
+        return (
+            <div style={containerStyle}>
+                <div className="container horizontal full">
+                    <Dock splits={this.state.leftDock} activeSplit={this.state.activeSplit} />
+                    {editors}
                 </div>
+            </div>
+        )
     }
 }

--- a/browser/src/UI/components/WindowTitle.tsx
+++ b/browser/src/UI/components/WindowTitle.tsx
@@ -18,9 +18,7 @@ export interface IWindowTitleViewProps {
 }
 
 export class WindowTitleView extends React.PureComponent<IWindowTitleViewProps, {}> {
-
     public render(): null | JSX.Element {
-
         if (!this.props.visible) {
             return null
         }
@@ -36,7 +34,11 @@ export class WindowTitleView extends React.PureComponent<IWindowTitleViewProps, 
             WebkitUserSelect: "none",
         }
 
-        return <div id={"oni-titlebar"} style={style}>{this.props.title}</div>
+        return (
+            <div id={"oni-titlebar"} style={style}>
+                {this.props.title}
+            </div>
+        )
     }
 }
 
@@ -44,7 +46,10 @@ export interface IWindowTitleProps {
     visible: boolean
 }
 
-export const mapStateToProps = (state: State.IState, props: IWindowTitleProps): IWindowTitleViewProps => {
+export const mapStateToProps = (
+    state: State.IState,
+    props: IWindowTitleProps,
+): IWindowTitleViewProps => {
     return {
         visible: props.visible && !state.isFullScreen,
         title: state.windowTitle,

--- a/browser/src/UI/components/WithWidth.tsx
+++ b/browser/src/UI/components/WithWidth.tsx
@@ -12,7 +12,8 @@ interface Props {
 
 export default function withWidth(WrappedComponent: any) {
     return class extends React.Component<Props, State> {
-        public static displayName = `WithWidth(${WrappedComponent.displayName || WrappedComponent.name})`
+        public static displayName = `WithWidth(${WrappedComponent.displayName ||
+            WrappedComponent.name})`
         private observer: any
         private _node: Element
         constructor(props: Props) {

--- a/browser/src/UI/components/common.ts
+++ b/browser/src/UI/components/common.ts
@@ -1,4 +1,3 @@
-
 import * as Color from "color"
 import * as styledComponents from "styled-components"
 import { ThemedStyledComponentsModule } from "styled-components" // tslint:disable-line no-duplicate-imports
@@ -7,12 +6,14 @@ import { IThemeColors } from "../../Services/Themes/ThemeManager"
 export const bufferScrollBarSize = "7px"
 
 const {
-  default: styled,
-  css,
-  injectGlobal,
-  keyframes,
-  ThemeProvider,
-} = styledComponents as ThemedStyledComponentsModule<any> as ThemedStyledComponentsModule<IThemeColors>
+    default: styled,
+    css,
+    injectGlobal,
+    keyframes,
+    ThemeProvider,
+} = (styledComponents as ThemedStyledComponentsModule<any>) as ThemedStyledComponentsModule<
+    IThemeColors
+>
 
 export type StyledFunction<T> = styledComponents.ThemedStyledFunction<T, IThemeColors>
 
@@ -22,14 +23,18 @@ export function withProps<T, U extends HTMLElement = HTMLElement>(
     return styledFunction
 }
 
-const darken = (c: string, deg = 0.15) => Color(c).darken(0.15).hex().toString()
+const darken = (c: string, deg = 0.15) =>
+    Color(c)
+        .darken(0.15)
+        .hex()
+        .toString()
 
 const boxShadow = css`
     box-shadow: 0 4px 8px 2px rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 `
 
 const boxShadowInset = css`
-  box-shadow: inset 0 4px 8px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: inset 0 4px 8px 2px rgba(0, 0, 0, 0.2);
 `
 
 const enableMouse = css`
@@ -52,17 +57,17 @@ const fallBackFonts = `
 `.trim()
 
 export {
-  css,
-  injectGlobal,
-  keyframes,
-  styled,
-  ThemeProvider,
-  boxShadow,
-  boxShadowInset,
-  enableMouse,
-  fontSizeSmall,
-  fallBackFonts,
-  darken,
+    css,
+    injectGlobal,
+    keyframes,
+    styled,
+    ThemeProvider,
+    boxShadow,
+    boxShadowInset,
+    enableMouse,
+    fontSizeSmall,
+    fallBackFonts,
+    darken,
 }
 
 export default styled

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -50,10 +50,12 @@ const start = async (args: string[]): Promise<void> => {
 
     const parsedArgs = minimist(args)
     const currentWorkingDirectory = process.cwd()
-    const filesToOpen = parsedArgs._.map((arg) => path.isAbsolute(arg) ? arg : path.join(currentWorkingDirectory, arg))
+    const filesToOpen = parsedArgs._.map(
+        arg => (path.isAbsolute(arg) ? arg : path.join(currentWorkingDirectory, arg)),
+    )
 
     // Helper for debugging:
-     Performance.startMeasure("Oni.Start.Config")
+    Performance.startMeasure("Oni.Start.Config")
 
     const { configuration } = await configurationPromise
 
@@ -69,7 +71,7 @@ const start = async (args: string[]): Promise<void> => {
         }
     }
 
-    configuration.onConfigurationError.subscribe((err) => {
+    configuration.onConfigurationError.subscribe(err => {
         // TODO: Better / nicer handling of error:
         alert(err)
     })
@@ -93,7 +95,7 @@ const start = async (args: string[]): Promise<void> => {
     const IconThemes = await iconThemesPromise
     await Promise.all([
         Themes.activate(configuration, pluginManager),
-        IconThemes.activate(configuration, pluginManager)
+        IconThemes.activate(configuration, pluginManager),
     ])
 
     const Colors = await colorsPromise
@@ -145,12 +147,26 @@ const start = async (args: string[]): Promise<void> => {
     const CompletionProviders = await completionProvidersPromise
     CompletionProviders.activate(languageManager)
 
-   await Promise.race([Utility.delay(5000),
-     Promise.all([
-        SharedNeovimInstance.activate(configuration, pluginManager),
-        startEditors(filesToOpen, Colors.getInstance(), CompletionProviders.getInstance(), configuration, diagnostics, languageManager, menuManager, overlayManager, pluginManager, tasks, Themes.getThemeManagerInstance(), workspace)
+    await Promise.race([
+        Utility.delay(5000),
+        Promise.all([
+            SharedNeovimInstance.activate(configuration, pluginManager),
+            startEditors(
+                filesToOpen,
+                Colors.getInstance(),
+                CompletionProviders.getInstance(),
+                configuration,
+                diagnostics,
+                languageManager,
+                menuManager,
+                overlayManager,
+                pluginManager,
+                tasks,
+                Themes.getThemeManagerInstance(),
+                workspace,
+            ),
+        ]),
     ])
-   ])
     Performance.endMeasure("Oni.Start.Editors")
 
     Performance.startMeasure("Oni.Start.Sidebar")
@@ -158,7 +174,8 @@ const start = async (args: string[]): Promise<void> => {
     Sidebar.activate(configuration, workspace)
     Performance.endMeasure("Oni.Start.Sidebar")
 
-    const createLanguageClientsFromConfiguration = LanguageManager.createLanguageClientsFromConfiguration
+    const createLanguageClientsFromConfiguration =
+        LanguageManager.createLanguageClientsFromConfiguration
 
     diagnostics.start(languageManager)
 

--- a/browser/src/neovim-client.d.ts
+++ b/browser/src/neovim-client.d.ts
@@ -1,97 +1,152 @@
 declare module "neovim-client" {
-  export default attach
-  function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: INvim) => void)
+    export default attach
+    function attach(
+        writer: NodeJS.WritableStream,
+        reader: NodeJS.ReadableStream,
+        cb: (err: Error, nvim: INvim) => void,
+    )
 
-  interface INvim {
-    uiAttach(width: number, height: boolean, enableRgb: (err: Error) => void, cb: (err: Error) => void): void
-    uiDetach(cb: (err: Error) => void): void
-    uiTryResize(width: number, height: (err: Error, res: Object) => void, cb: (err: Error, res: Object) => void): void
-    command(str: string, cb: (err: Error) => void): void
-    feedkeys(keys: string, mode: string, escapeCsi: boolean, cb: (err: Error) => void): void
-    input(keys: string, cb: (err: Error, res: number) => void): void
-    replaceTermcodes(str: string, fromPart: boolean, doLt: boolean, special: boolean, cb: (err: Error, res: string) => void): void
-    commandOutput(str: string, cb: (err: Error, res: string) => void): void
-    eval(str: string, cb: (err: Error, res: Object) => void): void
-    callFunction(fname: string, args: any[], cb: (err: Error, res: Object) => void): void
-    strwidth(str: string, cb: (err: Error, res: number) => void): void
-    listRuntimePaths(cb: (err: Error, res: string[]) => void): void
-    changeDirectory(dir: string, cb: (err: Error) => void): void
-    getCurrentLine(cb: (err: Error, res: string) => void): void
-    setCurrentLine(line: string, cb: (err: Error) => void): void
-    delCurrentLine(cb: (err: Error) => void): void
-    getVar(name: string, cb: (err: Error, res: Object) => void): void
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
-    delVar(name: string, cb: (err: Error, res: Object) => void): void
-    getVvar(name: string, cb: (err: Error, res: Object) => void): void
-    getOption(name: string, cb: (err: Error, res: Object) => void): void
-    setOption(name: string, value: Object, cb: (err: Error) => void): void
-    outWrite(str: string, cb: (err: Error) => void): void
-    errWrite(str: string, cb: (err: Error) => void): void
-    reportError(str: string, cb: (err: Error) => void): void
-    getBuffers(cb: (err: Error, res: IBuffer[]) => void): void
-    getCurrentBuffer(cb: (err: Error, res: IBuffer) => void): void
-    setCurrentBuffer(buffer: IBuffer, cb: (err: Error) => void): void
-    getWindows(cb: (err: Error, res: IWindow[]) => void): void
-    getCurrentWindow(cb: (err: Error, res: IWindow) => void): void
-    setCurrentWindow(window: IWindow, cb: (err: Error) => void): void
-    getTabpages(cb: (err: Error, res: ITabpage[]) => void): void
-    getCurrentTabpage(cb: (err: Error, res: ITabpage) => void): void
-    setCurrentTabpage(tabpage: ITabpage, cb: (err: Error) => void): void
-    subscribe(event: string, cb: (err: Error) => void): void
-    unsubscribe(event: string, cb: (err: Error) => void): void
-    nameToColor(name: string, cb: (err: Error, res: number) => void): void
-    getColorMap(cb: (err: Error, res: {}) => void): void
-    getApiInfo(cb: (err: Error, res: any[]) => void): void
-  }
+    interface INvim {
+        uiAttach(
+            width: number,
+            height: boolean,
+            enableRgb: (err: Error) => void,
+            cb: (err: Error) => void,
+        ): void
+        uiDetach(cb: (err: Error) => void): void
+        uiTryResize(
+            width: number,
+            height: (err: Error, res: Object) => void,
+            cb: (err: Error, res: Object) => void,
+        ): void
+        command(str: string, cb: (err: Error) => void): void
+        feedkeys(keys: string, mode: string, escapeCsi: boolean, cb: (err: Error) => void): void
+        input(keys: string, cb: (err: Error, res: number) => void): void
+        replaceTermcodes(
+            str: string,
+            fromPart: boolean,
+            doLt: boolean,
+            special: boolean,
+            cb: (err: Error, res: string) => void,
+        ): void
+        commandOutput(str: string, cb: (err: Error, res: string) => void): void
+        eval(str: string, cb: (err: Error, res: Object) => void): void
+        callFunction(fname: string, args: any[], cb: (err: Error, res: Object) => void): void
+        strwidth(str: string, cb: (err: Error, res: number) => void): void
+        listRuntimePaths(cb: (err: Error, res: string[]) => void): void
+        changeDirectory(dir: string, cb: (err: Error) => void): void
+        getCurrentLine(cb: (err: Error, res: string) => void): void
+        setCurrentLine(line: string, cb: (err: Error) => void): void
+        delCurrentLine(cb: (err: Error) => void): void
+        getVar(name: string, cb: (err: Error, res: Object) => void): void
+        setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
+        delVar(name: string, cb: (err: Error, res: Object) => void): void
+        getVvar(name: string, cb: (err: Error, res: Object) => void): void
+        getOption(name: string, cb: (err: Error, res: Object) => void): void
+        setOption(name: string, value: Object, cb: (err: Error) => void): void
+        outWrite(str: string, cb: (err: Error) => void): void
+        errWrite(str: string, cb: (err: Error) => void): void
+        reportError(str: string, cb: (err: Error) => void): void
+        getBuffers(cb: (err: Error, res: IBuffer[]) => void): void
+        getCurrentBuffer(cb: (err: Error, res: IBuffer) => void): void
+        setCurrentBuffer(buffer: IBuffer, cb: (err: Error) => void): void
+        getWindows(cb: (err: Error, res: IWindow[]) => void): void
+        getCurrentWindow(cb: (err: Error, res: IWindow) => void): void
+        setCurrentWindow(window: IWindow, cb: (err: Error) => void): void
+        getTabpages(cb: (err: Error, res: ITabpage[]) => void): void
+        getCurrentTabpage(cb: (err: Error, res: ITabpage) => void): void
+        setCurrentTabpage(tabpage: ITabpage, cb: (err: Error) => void): void
+        subscribe(event: string, cb: (err: Error) => void): void
+        unsubscribe(event: string, cb: (err: Error) => void): void
+        nameToColor(name: string, cb: (err: Error, res: number) => void): void
+        getColorMap(cb: (err: Error, res: {}) => void): void
+        getApiInfo(cb: (err: Error, res: any[]) => void): void
+    }
 
-  interface IBuffer {
-    lineCount(cb: (err: Error, res: number) => void): void
-    getLine(index: number, cb: (err: Error, res: string) => void): void
-    setLine(index: number, line: string, cb: (err: Error) => void): void
-    delLine(index: number, cb: (err: Error) => void): void
-    getLineSlice(start: number, end: number, includeStart: boolean, includeEnd: boolean, cb: (err: Error, res: string[]) => void): void
-    getLines(start: number, end: number, strictIndexing: boolean, cb: (err: Error, res: string[]) => void): void
-    setLineSlice(start: number, end: number, includeStart: boolean, includeEnd: boolean, replacement: string[], cb: (err: Error) => void): void
-    setLines(start: number, end: number, strictIndexing: boolean, replacement: string[], cb: (err: Error) => void): void
-    getVar(name: string, cb: (err: Error, res: Object) => void): void
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
-    delVar(name: string, cb: (err: Error, res: Object) => void): void
-    getOption(name: string, cb: (err: Error, res: Object) => void): void
-    setOption(name: string, value: Object, cb: (err: Error) => void): void
-    getNumber(cb: (err: Error, res: number) => void): void
-    getName(cb: (err: Error, res: string) => void): void
-    setName(name: string, cb: (err: Error) => void): void
-    isValid(cb: (err: Error, res: boolean) => void): void
-    insert(lnum: number, lines: string[], cb: (err: Error) => void): void
-    getMark(name: string, cb: (err: Error, res: number[]) => void): void
-    addHighlight(srcId: number, hlGroup: string, line: number, colStart: number, colEnd: number, cb: (err: Error, res: number) => void): void
-    clearHighlight(srcId: number, lineStart: number, lineEnd: number, cb: (err: Error) => void): void
-  }
+    interface IBuffer {
+        lineCount(cb: (err: Error, res: number) => void): void
+        getLine(index: number, cb: (err: Error, res: string) => void): void
+        setLine(index: number, line: string, cb: (err: Error) => void): void
+        delLine(index: number, cb: (err: Error) => void): void
+        getLineSlice(
+            start: number,
+            end: number,
+            includeStart: boolean,
+            includeEnd: boolean,
+            cb: (err: Error, res: string[]) => void,
+        ): void
+        getLines(
+            start: number,
+            end: number,
+            strictIndexing: boolean,
+            cb: (err: Error, res: string[]) => void,
+        ): void
+        setLineSlice(
+            start: number,
+            end: number,
+            includeStart: boolean,
+            includeEnd: boolean,
+            replacement: string[],
+            cb: (err: Error) => void,
+        ): void
+        setLines(
+            start: number,
+            end: number,
+            strictIndexing: boolean,
+            replacement: string[],
+            cb: (err: Error) => void,
+        ): void
+        getVar(name: string, cb: (err: Error, res: Object) => void): void
+        setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
+        delVar(name: string, cb: (err: Error, res: Object) => void): void
+        getOption(name: string, cb: (err: Error, res: Object) => void): void
+        setOption(name: string, value: Object, cb: (err: Error) => void): void
+        getNumber(cb: (err: Error, res: number) => void): void
+        getName(cb: (err: Error, res: string) => void): void
+        setName(name: string, cb: (err: Error) => void): void
+        isValid(cb: (err: Error, res: boolean) => void): void
+        insert(lnum: number, lines: string[], cb: (err: Error) => void): void
+        getMark(name: string, cb: (err: Error, res: number[]) => void): void
+        addHighlight(
+            srcId: number,
+            hlGroup: string,
+            line: number,
+            colStart: number,
+            colEnd: number,
+            cb: (err: Error, res: number) => void,
+        ): void
+        clearHighlight(
+            srcId: number,
+            lineStart: number,
+            lineEnd: number,
+            cb: (err: Error) => void,
+        ): void
+    }
 
-  interface IWindow {
-    getBuffer(cb: (err: Error, res: IBuffer) => void): void
-    getCursor(cb: (err: Error, res: number[]) => void): void
-    setCursor(pos: number[], cb: (err: Error) => void): void
-    getHeight(cb: (err: Error, res: number) => void): void
-    setHeight(height: number, cb: (err: Error) => void): void
-    getWidth(cb: (err: Error, res: number) => void): void
-    setWidth(width: number, cb: (err: Error) => void): void
-    getVar(name: string, cb: (err: Error, res: Object) => void): void
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
-    delVar(name: string, cb: (err: Error, res: Object) => void): void
-    getOption(name: string, cb: (err: Error, res: Object) => void): void
-    setOption(name: string, value: Object, cb: (err: Error) => void): void
-    getPosition(cb: (err: Error, res: number[]) => void): void
-    getTabpage(cb: (err: Error, res: ITabpage) => void): void
-    isValid(cb: (err: Error, res: boolean) => void): void
-  }
+    interface IWindow {
+        getBuffer(cb: (err: Error, res: IBuffer) => void): void
+        getCursor(cb: (err: Error, res: number[]) => void): void
+        setCursor(pos: number[], cb: (err: Error) => void): void
+        getHeight(cb: (err: Error, res: number) => void): void
+        setHeight(height: number, cb: (err: Error) => void): void
+        getWidth(cb: (err: Error, res: number) => void): void
+        setWidth(width: number, cb: (err: Error) => void): void
+        getVar(name: string, cb: (err: Error, res: Object) => void): void
+        setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
+        delVar(name: string, cb: (err: Error, res: Object) => void): void
+        getOption(name: string, cb: (err: Error, res: Object) => void): void
+        setOption(name: string, value: Object, cb: (err: Error) => void): void
+        getPosition(cb: (err: Error, res: number[]) => void): void
+        getTabpage(cb: (err: Error, res: ITabpage) => void): void
+        isValid(cb: (err: Error, res: boolean) => void): void
+    }
 
-  interface ITabpage {
-    getWindows(cb: (err: Error, res: IWindow[]) => void): void
-    getVar(name: string, cb: (err: Error, res: Object) => void): void
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
-    delVar(name: string, cb: (err: Error, res: Object) => void): void
-    getWindow(cb: (err: Error, res: IWindow) => void): void
-    isValid(cb: (err: Error, res: boolean) => void): void
-  }
+    interface ITabpage {
+        getWindows(cb: (err: Error, res: IWindow[]) => void): void
+        getVar(name: string, cb: (err: Error, res: Object) => void): void
+        setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void
+        delVar(name: string, cb: (err: Error, res: Object) => void): void
+        getWindow(cb: (err: Error, res: IWindow) => void): void
+        isValid(cb: (err: Error, res: boolean) => void): void
+    }
 }

--- a/browser/src/neovim/MsgPack.ts
+++ b/browser/src/neovim/MsgPack.ts
@@ -7,12 +7,12 @@
 import * as msgpackLite from "msgpack-lite"
 
 export class MsgPackObjectReference {
-  public id: string
+    public id: string
 }
 
-export class NeovimBufferReference extends MsgPackObjectReference { }
-export class NeovimWindowReference extends MsgPackObjectReference { }
-export class NeovimTabReference extends MsgPackObjectReference { }
+export class NeovimBufferReference extends MsgPackObjectReference {}
+export class NeovimWindowReference extends MsgPackObjectReference {}
+export class NeovimTabReference extends MsgPackObjectReference {}
 
 export const Pack = (reference: MsgPackObjectReference) => {
     return msgpackLite.encode(reference.id)

--- a/browser/src/neovim/NeovimAutoCommands.ts
+++ b/browser/src/neovim/NeovimAutoCommands.ts
@@ -75,20 +75,19 @@ export class NeovimAutoCommands {
 
     constructor(private _neovimInstance: NeovimInstance) {
         this._nameToEvent = {
-            "BufEnter": this._onBufEnterEvent,
-            "BufWritePost": this._onBufWritePostEvent,
-            "BufWinEnter": this._onBufWinEnterEvent,
-            "BufWipeout": this._onBufWipeoutEvent,
-            "CursorMoved": this._onCursorMovedEvent,
-            "CursorMovedI": this._onCursorMovedIEvent,
-            "FileType": this._onFileTypeChangedEvent,
-            "WinEnter": this._onWinEnterEvent,
-            "VimResized": this._onVimResizedEvent,
+            BufEnter: this._onBufEnterEvent,
+            BufWritePost: this._onBufWritePostEvent,
+            BufWinEnter: this._onBufWinEnterEvent,
+            BufWipeout: this._onBufWipeoutEvent,
+            CursorMoved: this._onCursorMovedEvent,
+            CursorMovedI: this._onCursorMovedIEvent,
+            FileType: this._onFileTypeChangedEvent,
+            WinEnter: this._onWinEnterEvent,
+            VimResized: this._onVimResizedEvent,
         }
     }
 
     public notifyAutocommand(autoCommandName: string, context: EventContext): void {
-
         const evt = this._nameToEvent[autoCommandName]
 
         if (!evt) {

--- a/browser/src/neovim/NeovimBufferUpdateManager.ts
+++ b/browser/src/neovim/NeovimBufferUpdateManager.ts
@@ -20,7 +20,6 @@ export interface INeovimBufferUpdate {
 }
 
 export class NeovimBufferUpdateManager {
-
     private _onBufferUpdateEvent = new Event<INeovimBufferUpdate>()
     private _lastEventContext: EventContext
 
@@ -28,15 +27,9 @@ export class NeovimBufferUpdateManager {
         return this._onBufferUpdateEvent
     }
 
-    constructor(
-        private _configuration: Configuration,
-        private _neovimInstance: NeovimInstance,
-    ) {
-
-    }
+    constructor(private _configuration: Configuration, private _neovimInstance: NeovimInstance) {}
 
     public async notifyFullBufferUpdate(eventContext: EventContext): Promise<void> {
-
         if (!this._shouldSubscribeToUpdates(eventContext)) {
             return
         }
@@ -44,7 +37,11 @@ export class NeovimBufferUpdateManager {
         this._doFullUpdate(eventContext)
     }
 
-    public notifyIncrementalBufferUpdate(eventContext: EventContext, lineNumber: number, lineContents: string): void {
+    public notifyIncrementalBufferUpdate(
+        eventContext: EventContext,
+        lineNumber: number,
+        lineContents: string,
+    ): void {
         if (!this._shouldSubscribeToUpdates(eventContext)) {
             return
         }
@@ -60,17 +57,24 @@ export class NeovimBufferUpdateManager {
 
         const update: INeovimBufferUpdate = {
             eventContext,
-            contentChanges: [{
-                range: types.Range.create(lineNumber - 1, 0, lineNumber, 0),
-                text: changedLine + os.EOL,
-            }],
+            contentChanges: [
+                {
+                    range: types.Range.create(lineNumber - 1, 0, lineNumber, 0),
+                    text: changedLine + os.EOL,
+                },
+            ],
         }
 
         this._onBufferUpdateEvent.dispatch(update)
     }
 
     private async _doFullUpdate(eventContext: EventContext): Promise<void> {
-        const bufferLines = await this._neovimInstance.request<string[]>("nvim_buf_get_lines", [eventContext.bufferNumber, 0, eventContext.bufferTotalLines, false])
+        const bufferLines = await this._neovimInstance.request<string[]>("nvim_buf_get_lines", [
+            eventContext.bufferNumber,
+            0,
+            eventContext.bufferTotalLines,
+            false,
+        ])
 
         const update: INeovimBufferUpdate = {
             eventContext,
@@ -81,7 +85,10 @@ export class NeovimBufferUpdateManager {
         this._onBufferUpdateEvent.dispatch(update)
     }
 
-    private _shouldDoFullUpdate(currentContext: EventContext, previousContext: EventContext): boolean {
+    private _shouldDoFullUpdate(
+        currentContext: EventContext,
+        previousContext: EventContext,
+    ): boolean {
         if (!previousContext) {
             return true
         }
@@ -98,7 +105,10 @@ export class NeovimBufferUpdateManager {
     }
 
     private _shouldSubscribeToUpdates(context: EventContext): boolean {
-        if (context.bufferTotalLines > this._configuration.getValue("editor.maxLinesForLanguageServices")) {
+        if (
+            context.bufferTotalLines >
+            this._configuration.getValue("editor.maxLinesForLanguageServices")
+        ) {
             return false
         }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -341,107 +341,112 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     public start(startOptions?: INeovimStartOptions): Promise<void> {
         Performance.startMeasure("NeovimInstance.Start")
-        this._initPromise = startNeovim(startOptions)
-            .then((nv) => {
-                Log.info("NeovimInstance: Neovim started")
+        this._initPromise = startNeovim(startOptions).then(nv => {
+            Log.info("NeovimInstance: Neovim started")
 
-                // Workaround for issue where UI
-                // can fail to attach if there is a UI-blocking error
-                // nv.input("<ESC>")
+            // Workaround for issue where UI
+            // can fail to attach if there is a UI-blocking error
+            // nv.input("<ESC>")
 
-                this._neovim = nv
+            this._neovim = nv
 
-                this._neovim.on("error", (err: Error) => {
-                    this._onError(err)
-                })
-
-                this._neovim.on("notification", (method: any, args: any) => {
-                    if (method === "redraw") {
-                        this._handleNotification(method, args)
-                        this._onRedrawComplete.dispatch()
-                    } else if (method === "oni_plugin_notify") {
-                        const pluginArgs = args[0]
-                        const pluginMethod = pluginArgs.shift()
-
-                        // TODO: Update pluginManager to subscribe from event here, instead of dupliating this
-
-                        if (pluginMethod === "buffer_update") {
-                            const eventContext: EventContext = args[0][0]
-
-                            this._bufferUpdateManager.notifyFullBufferUpdate(eventContext)
-                        } else if (pluginMethod === "oni_yank") {
-                            this._onYank.dispatch(args[0][0])
-                        } else if (pluginMethod === "oni_command") {
-                            this._onOniCommand.dispatch(args[0][0])
-                        } else if (pluginMethod === "event") {
-                            const eventName = args[0][0]
-                            const eventContext = args[0][1]
-
-                            if (eventName === "DirChanged") {
-                                this._updateProcessDirectory()
-                            } else if (eventName === "VimLeave") {
-                                this._isLeaving = true
-                                this._onLeave.dispatch()
-                            } else if (eventName === "ColorScheme") {
-                                this._onColorsChanged.dispatch()
-                            }
-
-                            this._autoCommands.notifyAutocommand(eventName, eventContext)
-
-                            this.emit("event", eventName, eventContext)
-
-                        } else if (pluginMethod === "incremental_buffer_update") {
-                            const eventContext = args[0][0]
-                            const lineContents = args[0][1]
-                            const lineNumber = args[0][2]
-
-                            this._bufferUpdateManager.notifyIncrementalBufferUpdate(eventContext, lineNumber, lineContents)
-                        } else {
-                            Log.warn("Unknown event from oni_plugin_notify: " + pluginMethod)
-                        }
-                    } else {
-                        Log.warn("Unknown notification: " + method)
-                    }
-                })
-
-                this._neovim.on("request", (method: any, _args: any, _resp: any) => {
-                    Log.warn("Unhandled request: " + method)
-                })
-
-                this._neovim.on("disconnect", () => {
-                    if (!this._isLeaving) {
-                        this._onError("Neovim disconnected. This likely means that the Neovim process crashed.")
-                    }
-                })
-
-                const size = this._getSize()
-                this._rows = size.rows
-                this._cols = size.cols
-
-                // Workaround for bug in neovim/node-client
-                // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
-                Performance.startMeasure("NeovimInstance.Start.Attach")
-                return this._attachUI(size.cols, size.rows)
-                    .then(async () => {
-                        Log.info("Attach success")
-                        Performance.endMeasure("NeovimInstance.Start.Attach")
-
-                        // TODO: #702 - Batch these calls via `nvim_call_atomic`
-                        // Override completeopt so Oni works correctly with external popupmenu
-                        // await this.command("set completeopt=longest,menu")
-
-                        // set title after attaching listeners so we can get the initial title
-                        await this.command("set title")
-
-                        Performance.endMeasure("NeovimInstance.Start")
-
-                        this._initComplete = true
-                    },
-                    (err: any) => {
-                        this._onError(err)
-                        this._initComplete = true
-                    })
+            this._neovim.on("error", (err: Error) => {
+                this._onError(err)
             })
+
+            this._neovim.on("notification", (method: any, args: any) => {
+                if (method === "redraw") {
+                    this._handleNotification(method, args)
+                    this._onRedrawComplete.dispatch()
+                } else if (method === "oni_plugin_notify") {
+                    const pluginArgs = args[0]
+                    const pluginMethod = pluginArgs.shift()
+
+                    // TODO: Update pluginManager to subscribe from event here, instead of dupliating this
+
+                    if (pluginMethod === "buffer_update") {
+                        const eventContext: EventContext = args[0][0]
+
+                        this._bufferUpdateManager.notifyFullBufferUpdate(eventContext)
+                    } else if (pluginMethod === "oni_yank") {
+                        this._onYank.dispatch(args[0][0])
+                    } else if (pluginMethod === "oni_command") {
+                        this._onOniCommand.dispatch(args[0][0])
+                    } else if (pluginMethod === "event") {
+                        const eventName = args[0][0]
+                        const eventContext = args[0][1]
+
+                        if (eventName === "DirChanged") {
+                            this._updateProcessDirectory()
+                        } else if (eventName === "VimLeave") {
+                            this._isLeaving = true
+                            this._onLeave.dispatch()
+                        } else if (eventName === "ColorScheme") {
+                            this._onColorsChanged.dispatch()
+                        }
+
+                        this._autoCommands.notifyAutocommand(eventName, eventContext)
+
+                        this.emit("event", eventName, eventContext)
+                    } else if (pluginMethod === "incremental_buffer_update") {
+                        const eventContext = args[0][0]
+                        const lineContents = args[0][1]
+                        const lineNumber = args[0][2]
+
+                        this._bufferUpdateManager.notifyIncrementalBufferUpdate(
+                            eventContext,
+                            lineNumber,
+                            lineContents,
+                        )
+                    } else {
+                        Log.warn("Unknown event from oni_plugin_notify: " + pluginMethod)
+                    }
+                } else {
+                    Log.warn("Unknown notification: " + method)
+                }
+            })
+
+            this._neovim.on("request", (method: any, _args: any, _resp: any) => {
+                Log.warn("Unhandled request: " + method)
+            })
+
+            this._neovim.on("disconnect", () => {
+                if (!this._isLeaving) {
+                    this._onError(
+                        "Neovim disconnected. This likely means that the Neovim process crashed.",
+                    )
+                }
+            })
+
+            const size = this._getSize()
+            this._rows = size.rows
+            this._cols = size.cols
+
+            // Workaround for bug in neovim/node-client
+            // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
+            Performance.startMeasure("NeovimInstance.Start.Attach")
+            return this._attachUI(size.cols, size.rows).then(
+                async () => {
+                    Log.info("Attach success")
+                    Performance.endMeasure("NeovimInstance.Start.Attach")
+
+                    // TODO: #702 - Batch these calls via `nvim_call_atomic`
+                    // Override completeopt so Oni works correctly with external popupmenu
+                    // await this.command("set completeopt=longest,menu")
+
+                    // set title after attaching listeners so we can get the initial title
+                    await this.command("set title")
+
+                    Performance.endMeasure("NeovimInstance.Start")
+
+                    this._initComplete = true
+                },
+                (err: any) => {
+                    this._onError(err)
+                    this._initComplete = true
+                },
+            )
+        })
 
         return this._initPromise
     }
@@ -450,12 +455,17 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this._fontFamily = fontFamily
         this._fontSize = fontSize
 
-        const { width, height, isBoldAvailable, isItalicAvailable } = measureFont(this._fontFamily, this._fontSize)
+        const { width, height, isBoldAvailable, isItalicAvailable } = measureFont(
+            this._fontFamily,
+            this._fontSize,
+        )
 
         this._fontWidthInPixels = width
         this._fontHeightInPixels = height + linePadding
 
-        this.emit("action", Actions.setFont({
+        this.emit(
+            "action",
+            Actions.setFont({
                 fontFamily,
                 fontSize,
                 fontWidthInPixels: width,
@@ -476,7 +486,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     public openInitVim(): Promise<void> {
         const loadInitVim = this._configuration.getValue("oni.loadInitVim")
 
-        if (typeof(loadInitVim) === "string") {
+        if (typeof loadInitVim === "string") {
             return this.open(loadInitVim)
         } else {
             // Use path from: https://github.com/neovim/neovim/wiki/FAQ
@@ -508,7 +518,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     public async getBufferIds(): Promise<number[]> {
         const buffers = await this._neovim.request<NeovimBufferReference[]>("nvim_list_bufs", [])
 
-        return buffers.map((b) => b.id as any)
+        return buffers.map(b => b.id as any)
     }
 
     public async getCurrentWorkingDirectory(): Promise<string> {
@@ -573,7 +583,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     private _resizeInternal(rows: number, columns: number): void {
-
         if (this._configuration.hasValue("debug.fixedSize")) {
             const fixedSize = this._configuration.getValue("debug.fixedSize")
             rows = fixedSize.rows
@@ -615,12 +624,15 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     this.emit("action", Actions.createCursorGotoAction(a[0][0], a[0][1]))
                     break
                 case "put":
-                    const charactersToPut = a.map((v) => v[0])
+                    const charactersToPut = a.map(v => v[0])
                     this.emit("action", Actions.put(charactersToPut))
                     break
                 case "set_scroll_region":
                     const param = a[0]
-                    this.emit("action", Actions.setScrollRegion(param[0], param[1], param[2], param[3]))
+                    this.emit(
+                        "action",
+                        Actions.setScrollRegion(param[0], param[1], param[2], param[3]),
+                    )
                     break
                 case "scroll":
                     this.emit("action", Actions.scroll(a[0][0]))
@@ -628,15 +640,18 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 case "highlight_set":
                     const highlightInfo = a[a.length - 1][0]
 
-                    this.emit("action", Actions.setHighlight(
-                        !!highlightInfo.bold,
-                        !!highlightInfo.italic,
-                        !!highlightInfo.reverse,
-                        !!highlightInfo.underline,
-                        !!highlightInfo.undercurl,
-                        highlightInfo.foreground,
-                        highlightInfo.background,
-                    ))
+                    this.emit(
+                        "action",
+                        Actions.setHighlight(
+                            !!highlightInfo.bold,
+                            !!highlightInfo.italic,
+                            !!highlightInfo.reverse,
+                            !!highlightInfo.underline,
+                            !!highlightInfo.undercurl,
+                            highlightInfo.foreground,
+                            highlightInfo.background,
+                        ),
+                    )
                     break
                 case "resize":
                     this.emit("action", Actions.resize(a[0][0], a[0][1]))
@@ -712,7 +727,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     break
                 case "cmdline_show":
                     {
-
                         const [content, pos, firstc, prompt, indent, level] = a[0]
                         const commandLineShowInfo: INeovimCommandLineShowEvent = {
                             content,
@@ -743,7 +757,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     this._onWildMenuShowEvent.dispatch({ options })
                     break
                 case "wildmenu_select":
-                    const [[ selection ]] = a
+                    const [[selection]] = a
                     this._onWildMenuSelectEvent.dispatch({ selected: selection })
                     break
                 case "wildmenu_hide":
@@ -769,30 +783,35 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         const version = await this.getApiVersion()
 
         const useNativeTabs = this._configuration.getValue("tabs.mode") === "native"
-        const useNativePopupWindows = this._configuration.getValue("editor.completions.mode") === "native"
+        const useNativePopupWindows =
+            this._configuration.getValue("editor.completions.mode") === "native"
 
         const externaliseTabline = !useNativeTabs
         const externalisePopupWindows = !useNativePopupWindows
 
         console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console
 
-        const startupOptions = this._getStartupOptionsForVersion(version.major,
-                                                                 version.minor,
-                                                                 version.patch,
-                                                                 externaliseTabline,
-                                                                 externalisePopupWindows)
+        const startupOptions = this._getStartupOptionsForVersion(
+            version.major,
+            version.minor,
+            version.patch,
+            externaliseTabline,
+            externalisePopupWindows,
+        )
 
         await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])
     }
 
-    private _getStartupOptionsForVersion(major: number,
-                                         minor: number,
-                                         patch: number,
-                                         shouldExtTabs: boolean,
-                                         shouldExtPopups: boolean) {
+    private _getStartupOptionsForVersion(
+        major: number,
+        minor: number,
+        patch: number,
+        shouldExtTabs: boolean,
+        shouldExtPopups: boolean,
+    ) {
         if (major >= 0 && minor >= 2 && patch >= 1) {
-            const useExtCmdLine =  this._configuration.getValue("experimental.commandline.mode")
-            const useExtWildMenu =  this._configuration.getValue("experimental.wildmenu.mode")
+            const useExtCmdLine = this._configuration.getValue("experimental.commandline.mode")
+            const useExtWildMenu = this._configuration.getValue("experimental.wildmenu.mode")
             return {
                 rgb: true,
                 popupmenu_external: shouldExtPopups,

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -49,7 +49,6 @@ export interface NeovimInactiveWindowState {
 }
 
 export class NeovimWindowManager {
-
     private _scrollObservable: Subject<EventContext>
 
     private _onWindowStateChangedEvent = new Event<NeovimTabPageState>()
@@ -58,17 +57,14 @@ export class NeovimWindowManager {
         return this._onWindowStateChangedEvent
     }
 
-    constructor(
-        private _neovimInstance: NeovimInstance,
-    ) {
-
+    constructor(private _neovimInstance: NeovimInstance) {
         this._scrollObservable = new Subject<EventContext>()
 
         const updateScroll = (evt: EventContext) => this._scrollObservable.next(evt)
         // First element of the BufEnter event is the current buffer
-        this._neovimInstance.autoCommands.onBufEnter.subscribe((bufs) => updateScroll(bufs.current))
+        this._neovimInstance.autoCommands.onBufEnter.subscribe(bufs => updateScroll(bufs.current))
         this._neovimInstance.autoCommands.onBufWinEnter.subscribe(updateScroll)
-        this._neovimInstance.onBufferUpdate.subscribe((buf) => updateScroll(buf.eventContext))
+        this._neovimInstance.onBufferUpdate.subscribe(buf => updateScroll(buf.eventContext))
         this._neovimInstance.autoCommands.onWinEnter.subscribe(updateScroll)
         this._neovimInstance.autoCommands.onCursorMoved.subscribe(updateScroll)
         this._neovimInstance.autoCommands.onVimResized.subscribe(updateScroll)
@@ -90,7 +86,6 @@ export class NeovimWindowManager {
         shouldMeasure$
             .withLatestFrom(this._scrollObservable)
             .switchMap((args: [any, EventContext]) => {
-
                 const [, evt] = args
                 return Observable.defer(() => this._remeasure(evt))
             })
@@ -111,14 +106,16 @@ export class NeovimWindowManager {
 
     private async _remeasure(context: EventContext): Promise<NeovimTabPageState> {
         const tabNumber = context.tabNumber
-        const allWindows = await this._neovimInstance.request<any[]>("nvim_tabpage_list_wins", [tabNumber])
+        const allWindows = await this._neovimInstance.request<any[]>("nvim_tabpage_list_wins", [
+            tabNumber,
+        ])
 
         const activeWindow = await this._remeasureActiveWindow(context.windowNumber, context)
 
-        const inactiveWindowIds = allWindows.filter((w) => w.id !== context.windowNumber)
+        const inactiveWindowIds = allWindows.filter(w => w.id !== context.windowNumber)
 
-        const windowPromise =  await inactiveWindowIds.map(async (window: any) => {
-                return await this._remeasureInactiveWindow(window.id)
+        const windowPromise = await inactiveWindowIds.map(async (window: any) => {
+            return await this._remeasureInactiveWindow(window.id)
         })
 
         const inactiveWindows = await Promise.all(windowPromise)
@@ -143,13 +140,18 @@ export class NeovimWindowManager {
     // - How each buffer line maps to the screen space
     //
     // We can derive these from information coming from the event handlers, along with screen width
-    private async _remeasureActiveWindow(currentWinId: number, context: EventContext): Promise<NeovimActiveWindowState> {
-
+    private async _remeasureActiveWindow(
+        currentWinId: number,
+        context: EventContext,
+    ): Promise<NeovimActiveWindowState> {
         const atomicCalls = [
             ["nvim_win_get_position", [currentWinId]],
             ["nvim_win_get_width", [currentWinId]],
             ["nvim_win_get_height", [currentWinId]],
-            ["nvim_buf_get_lines", [context.bufferNumber, context.windowTopLine - 1, context.windowBottomLine, false]],
+            [
+                "nvim_buf_get_lines",
+                [context.bufferNumber, context.windowTopLine - 1, context.windowBottomLine, false],
+            ],
         ]
 
         const response = await this._neovimInstance.request("nvim_call_atomic", [atomicCalls])
@@ -174,7 +176,9 @@ export class NeovimWindowManager {
 
             const rangesOnScreen = getBufferRanges(lines, context.windowTopLine - 1, contentWidth)
 
-            const indexWhereCursorIs = rangesOnScreen.findIndex((val: types.Range) => Utility.isInRange(context.line - 1, context.column - 1, val))
+            const indexWhereCursorIs = rangesOnScreen.findIndex((val: types.Range) =>
+                Utility.isInRange(context.line - 1, context.column - 1, val),
+            )
 
             const arrayStart = indexWhereCursorIs - (context.winline - 1)
             const arrayEnd = arrayStart + height
@@ -184,8 +188,13 @@ export class NeovimWindowManager {
             // If there is no text in the buffer, the range will be (line, 0) -> (line, 0).
             // This means we we wouldn't be able to map positions that don't exist yet,
             // so we should expand out the ranges to the full content width if they are less)
-            const expandedWidthRanges = ranges.map((r) => {
-                return types.Range.create(r.start.line, r.start.character, r.end.line, Math.max(r.end.character, contentWidth))
+            const expandedWidthRanges = ranges.map(r => {
+                return types.Range.create(
+                    r.start.line,
+                    r.start.character,
+                    r.end.line,
+                    Math.max(r.end.character, contentWidth),
+                )
             })
 
             const dimensions = {
@@ -218,8 +227,9 @@ export class NeovimWindowManager {
      * Windows that are inactive give us less state, unfortunately - so the buffer/pixel mapping
      * is unavailable. We should still measure the width/height/position for overlay scenarios, though
      */
-    private async _remeasureInactiveWindow(currentWinId: number): Promise<NeovimInactiveWindowState> {
-
+    private async _remeasureInactiveWindow(
+        currentWinId: number,
+    ): Promise<NeovimInactiveWindowState> {
         const atomicCalls = [
             ["nvim_win_get_position", [currentWinId]],
             ["nvim_win_get_width", [currentWinId]],
@@ -257,8 +267,12 @@ export class NeovimWindowManager {
     }
 }
 
-const getBufferToScreenFromRanges = (gutterOffset: number, ranges: types.Range[]) => (bufferPosition: types.Position) => {
-    const screenLine = ranges.findIndex((v) => Utility.isInRange(bufferPosition.line, bufferPosition.character, v))
+const getBufferToScreenFromRanges = (gutterOffset: number, ranges: types.Range[]) => (
+    bufferPosition: types.Position,
+) => {
+    const screenLine = ranges.findIndex(v =>
+        Utility.isInRange(bufferPosition.line, bufferPosition.character, v),
+    )
 
     if (screenLine === -1) {
         return null
@@ -275,8 +289,11 @@ const getBufferToScreenFromRanges = (gutterOffset: number, ranges: types.Range[]
 }
 
 // TODO: Need to properly handle multibyte characters here
-const getBufferRanges = (bufferLines: string[], startLine: number, width: number): types.Range[] => {
-
+const getBufferRanges = (
+    bufferLines: string[],
+    startLine: number,
+    width: number,
+): types.Range[] => {
     let ranges: types.Range[] = []
 
     for (let i = 0; i < bufferLines.length; i++) {
@@ -298,7 +315,10 @@ const getRangesForLine = (bufferLine: string, lineNumber: number, width: number)
 
     for (let i = 0; i < length; i += width) {
         const startPosition = types.Position.create(lineNumber, i)
-        const endPosition = types.Position.create(lineNumber, Math.min(bufferLine.length, i + width))
+        const endPosition = types.Position.create(
+            lineNumber,
+            Math.min(bufferLine.length, i + width),
+        )
         const range = types.Range.create(startPosition, endPosition)
         chunks.push(range)
     }

--- a/browser/src/neovim/Screen.ts
+++ b/browser/src/neovim/Screen.ts
@@ -166,8 +166,10 @@ export class NeovimScreen implements IScreen {
                 this._cursorColumn = action.col
                 break
             case Actions.PutAction: {
-                let foregroundColor = this._currentHighlight.foregroundColor || this._foregroundColor
-                let backgroundColor = this._currentHighlight.backgroundColor || this._backgroundColor
+                let foregroundColor =
+                    this._currentHighlight.foregroundColor || this._foregroundColor
+                let backgroundColor =
+                    this._currentHighlight.backgroundColor || this._backgroundColor
 
                 if (this._currentHighlight.reverse) {
                     const temp = foregroundColor
@@ -215,8 +217,10 @@ export class NeovimScreen implements IScreen {
                 break
             }
             case Actions.CLEAR_TO_END_OF_LINE: {
-                const foregroundColor = this._currentHighlight.foregroundColor || this._foregroundColor
-                const backgroundColor = this._currentHighlight.backgroundColor || this._backgroundColor
+                const foregroundColor =
+                    this._currentHighlight.foregroundColor || this._foregroundColor
+                const backgroundColor =
+                    this._currentHighlight.backgroundColor || this._backgroundColor
 
                 const row = this._cursorRow
                 for (let i = this._cursorColumn; i < this.width; i++) {
@@ -312,9 +316,11 @@ export class NeovimScreen implements IScreen {
     private _setCell(x: number, y: number, cell: ICell): void {
         const currentCell = this._grid.getCell(x, y)
         if (currentCell) {
-            if (currentCell.foregroundColor === cell.foregroundColor &&
+            if (
+                currentCell.foregroundColor === cell.foregroundColor &&
                 currentCell.backgroundColor === cell.backgroundColor &&
-                currentCell.character === cell.character) {
+                currentCell.character === cell.character
+            ) {
                 return
             }
         }

--- a/browser/src/neovim/Session.ts
+++ b/browser/src/neovim/Session.ts
@@ -55,7 +55,7 @@ export class Session extends EventEmitter {
                 case 1 /* Response */:
                     const [responseMessage, payload1, payload2] = remaining
                     const result = payload1 || payload2
-                    log("Received response - "  + responseMessage + " : " + result)
+                    log("Received response - " + responseMessage + " : " + result)
                     this._pendingRequests[responseMessage](result)
                     this._pendingRequests[responseMessage] = null
                     break
@@ -83,7 +83,7 @@ export class Session extends EventEmitter {
     public request<T>(methodName: string, args: any): Promise<T> {
         this._requestId++
         let r = null
-        const promise = new Promise<T>((resolve) => {
+        const promise = new Promise<T>(resolve => {
             r = (val: any) => {
                 resolve(val)
             }
@@ -111,7 +111,7 @@ export class Session extends EventEmitter {
         // The demo examples use `end` on the stream, but that
         // actually closes the stream - the flush is needed
         // to send the data immediately across the stream.
-        (this._encoder as any).write(args);
-        (this._encoder as any)._flush()
+        ;(this._encoder as any).write(args)
+        ;(this._encoder as any)._flush()
     }
 }

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -8,7 +8,7 @@
  * - Enabling Neovim keybindings in text input elements
  */
 
-import { Event,  IDisposable, IEvent } from "oni-types"
+import { Event, IDisposable, IEvent } from "oni-types"
 
 import { NeovimInstance } from "./NeovimInstance"
 import { INeovimStartOptions } from "./NeovimProcessSpawner"
@@ -44,9 +44,7 @@ export class Binding implements IBinding {
         return this._neovimInstance
     }
 
-    constructor(
-        private _neovimInstance: NeovimInstance,
-    ) { }
+    constructor(private _neovimInstance: NeovimInstance) {}
 
     public input(key: string): Promise<void> {
         return this._neovimInstance.input(key)
@@ -55,7 +53,7 @@ export class Binding implements IBinding {
     public release(): void {
         this._neovimInstance = null
 
-        this._subscriptions.forEach((sub) => sub.dispose())
+        this._subscriptions.forEach(sub => sub.dispose())
 
         this._onReleasedEvent.dispatch()
     }
@@ -66,7 +64,6 @@ export class Binding implements IBinding {
 }
 
 export class MenuBinding extends Binding implements IMenuBinding {
-
     private _currentOptions: string[] = []
     private _currentId: string = null
     private _onCursorMovedEvent: Event<string> = new Event<string>()
@@ -81,8 +78,7 @@ export class MenuBinding extends Binding implements IMenuBinding {
     constructor(neovimInstance: NeovimInstance) {
         super(neovimInstance)
 
-        const subscription = this.neovimInstance.autoCommands.onCursorMoved.subscribe((evt) => {
-
+        const subscription = this.neovimInstance.autoCommands.onCursorMoved.subscribe(evt => {
             if (this._isUpdating) {
                 return
             }
@@ -97,7 +93,6 @@ export class MenuBinding extends Binding implements IMenuBinding {
     }
 
     public async setItems(items: string[], activeId?: string): Promise<void> {
-
         this._promiseQueue.enqueuePromise(async () => {
             if (items === this._currentOptions && activeId === this._currentId) {
                 return
@@ -123,7 +118,13 @@ export class MenuBinding extends Binding implements IMenuBinding {
                 idx = this._currentOptions.indexOf(activeId) + 1
             }
 
-            await this.neovimInstance.request("nvim_buf_set_lines", [currentBufId, 0, bufferLength, false, elems])
+            await this.neovimInstance.request("nvim_buf_set_lines", [
+                currentBufId,
+                0,
+                bufferLength,
+                false,
+                elems,
+            ])
             await this.neovimInstance.request("nvim_win_set_cursor", [currentWinId, [idx, 1]])
             this._isUpdating = false
         })
@@ -131,7 +132,6 @@ export class MenuBinding extends Binding implements IMenuBinding {
 }
 
 class SharedNeovimInstance implements SharedNeovimInstance {
-
     private _initPromise: Promise<void>
     private _neovimInstance: NeovimInstance
 
@@ -139,10 +139,7 @@ class SharedNeovimInstance implements SharedNeovimInstance {
         return this._neovimInstance.isInitialized
     }
 
-    constructor(
-        private _configuration: Configuration,
-        private _pluginManager: PluginManager,
-    ) {
+    constructor(private _configuration: Configuration, private _pluginManager: PluginManager) {
         this._neovimInstance = new NeovimInstance(5, 5, this._configuration)
 
         this._neovimInstance.onOniCommand.subscribe((command: string) => {
@@ -168,7 +165,10 @@ class SharedNeovimInstance implements SharedNeovimInstance {
 }
 
 let _sharedInstance: SharedNeovimInstance = null
-export const activate = async (configuration: Configuration, pluginManager: PluginManager): Promise<void> => {
+export const activate = async (
+    configuration: Configuration,
+    pluginManager: PluginManager,
+): Promise<void> => {
     if (_sharedInstance) {
         return
     }

--- a/browser/src/neovim/actions.ts
+++ b/browser/src/neovim/actions.ts
@@ -92,7 +92,12 @@ export function scroll(scrollValue: number): IScrollAction {
     }
 }
 
-export function setScrollRegion(top: number, bottom: number, left: number, right: number): ISetScrollRegionAction {
+export function setScrollRegion(
+    top: number,
+    bottom: number,
+    left: number,
+    right: number,
+): ISetScrollRegionAction {
     return {
         type: SET_SCROLL_REGION,
         top,
@@ -133,7 +138,14 @@ export function setHighlight(
     return action
 }
 
-export const CommandLineShow = (content: [any, string], pos: number, firstc: string, prompt: string, indent: number, level: number) => ({
+export const CommandLineShow = (
+    content: [any, string],
+    pos: number,
+    firstc: string,
+    prompt: string,
+    indent: number,
+    level: number,
+) => ({
     type: "COMMAND_LINE_SHOW",
     payload: {
         content,

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -21,9 +21,33 @@ import { ThemeManager } from "./Services/Themes"
 import { windowManager } from "./Services/WindowManager"
 import { Workspace } from "./Services/Workspace"
 
-export const startEditors = async (args: any, colors: Colors, completionProviders: CompletionProviders, configuration: Configuration, diagnostics: IDiagnosticsDataSource, languageManager: LanguageManager, menuManager: MenuManager, overlayManager: OverlayManager, pluginManager: PluginManager, tasks: Tasks, themeManager: ThemeManager, workspace: Workspace): Promise<void> => {
-
-    const editor = new OniEditor(colors, completionProviders, configuration, diagnostics, languageManager, menuManager, overlayManager, pluginManager, tasks, themeManager, workspace)
+export const startEditors = async (
+    args: any,
+    colors: Colors,
+    completionProviders: CompletionProviders,
+    configuration: Configuration,
+    diagnostics: IDiagnosticsDataSource,
+    languageManager: LanguageManager,
+    menuManager: MenuManager,
+    overlayManager: OverlayManager,
+    pluginManager: PluginManager,
+    tasks: Tasks,
+    themeManager: ThemeManager,
+    workspace: Workspace,
+): Promise<void> => {
+    const editor = new OniEditor(
+        colors,
+        completionProviders,
+        configuration,
+        diagnostics,
+        languageManager,
+        menuManager,
+        overlayManager,
+        pluginManager,
+        tasks,
+        themeManager,
+        workspace,
+    )
     editorManager.setActiveEditor(editor)
     windowManager.split(0, editor)
 

--- a/browser/test/Editor/NeovimEditor/NeovimEditorReducerTests.ts
+++ b/browser/test/Editor/NeovimEditor/NeovimEditorReducerTests.ts
@@ -3,7 +3,10 @@ import * as assert from "assert"
 import * as Oni from "oni-api"
 
 import * as Actions from "./../../../src/Editor/NeovimEditor/NeovimEditorActions"
-import { layersReducer, windowStateReducer } from "./../../../src/Editor/NeovimEditor/NeovimEditorReducer"
+import {
+    layersReducer,
+    windowStateReducer,
+} from "./../../../src/Editor/NeovimEditor/NeovimEditorReducer"
 import * as State from "./../../../src/Editor/NeovimEditor/NeovimEditorStore"
 
 describe("NeovimEditorReducer", () => {
@@ -28,7 +31,6 @@ describe("NeovimEditorReducer", () => {
 
     describe("windowStateReducer", () => {
         it("Sets inactive window state via 'SET_INACTIVE_WINDOW_STATE'", () => {
-
             const windowState: State.IWindowState = {
                 activeWindow: -1,
                 windows: {},

--- a/browser/test/GridTests.ts
+++ b/browser/test/GridTests.ts
@@ -3,7 +3,6 @@ import * as assert from "assert"
 import { Grid } from "./../src/Grid"
 
 describe("Grid", () => {
-
     it("getCell returns correct value", () => {
         const grid = new Grid<string>()
 
@@ -22,10 +21,7 @@ describe("Grid", () => {
 
     describe("shift", () => {
         it("shift(0) does not shift", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
+            const val = [[1, 2], [3, 4]]
 
             const startGrid = createGridFromNestedArray(val)
             startGrid.shiftRows(0)
@@ -33,74 +29,47 @@ describe("Grid", () => {
         })
 
         it("shift(1) shifts upwards", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
+            const val = [[1, 2], [3, 4]]
 
             const startGrid = createGridFromNestedArray(val)
             startGrid.shiftRows(1)
 
-            const expectedOutput = [
-                [3, 4],
-                [null, null],
-            ]
+            const expectedOutput = [[3, 4], [null, null]]
             assertGridValues(startGrid, expectedOutput)
         })
 
         it("shift(-1) shifts downwards", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
+            const val = [[1, 2], [3, 4]]
 
             const startGrid = createGridFromNestedArray(val)
             startGrid.shiftRows(-1)
 
-            const expectedOutput = [
-                [null, null],
-                [1, 2],
-            ]
+            const expectedOutput = [[null, null], [1, 2]]
             assertGridValues(startGrid, expectedOutput)
         })
     })
 
     describe("setRegion", () => {
         it("sets value", () => {
-
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
+            const val = [[1, 2], [3, 4]]
 
             const startGrid = createGridFromNestedArray(val)
 
             startGrid.setRegion(0, 0, 2, 2, 5)
 
-            const expectedVal = [
-                [5, 5],
-                [5, 5],
-            ]
+            const expectedVal = [[5, 5], [5, 5]]
 
             assertGridValues(startGrid, expectedVal)
         })
 
         it("sets null correctly", () => {
-            const val = [
-                [1, 2, 3],
-                [3, 4, 5],
-                [6, 7, 8],
-            ]
+            const val = [[1, 2, 3], [3, 4, 5], [6, 7, 8]]
 
             const startGrid = createGridFromNestedArray(val)
 
             startGrid.setRegion(0, 0, 2, 2, null)
 
-            const expectedOuput = [
-                [null, null, 3],
-                [null, null, 5],
-                [6, 7, 8],
-            ]
+            const expectedOuput = [[null, null, 3], [null, null, 5], [6, 7, 8]]
 
             assertGridValues(startGrid, expectedOuput)
         })
@@ -108,10 +77,7 @@ describe("Grid", () => {
 
     describe("cloneRegion", () => {
         it("returns new grid for single item", () => {
-            const val = [
-                [1, 2],
-                [3, 4],
-            ]
+            const val = [[1, 2], [3, 4]]
 
             const startGrid = createGridFromNestedArray(val)
 
@@ -127,11 +93,7 @@ describe("Grid", () => {
         })
 
         it("returns square subsection", () => {
-            const val = [
-                [1, 2, 3],
-                [3, 4, 5],
-                [6, 7, 8],
-            ]
+            const val = [[1, 2, 3], [3, 4, 5], [6, 7, 8]]
 
             const startGrid = createGridFromNestedArray(val)
 
@@ -139,28 +101,18 @@ describe("Grid", () => {
             assert.strictEqual(topLeftGrid.width, 2)
             assert.strictEqual(topLeftGrid.height, 2)
 
-            const expectedOutput = [
-                [1, 2],
-                [3, 4],
-            ]
+            const expectedOutput = [[1, 2], [3, 4]]
 
             assertGridValues(topLeftGrid, expectedOutput)
         })
 
         it("handles null & undefined correctly", () => {
-            const val = [
-                [null, undefined, 3],
-                [0, 1, 5],
-                [6, 7, 8],
-            ]
+            const val = [[null, undefined, 3], [0, 1, 5], [6, 7, 8]]
 
             const startGrid = createGridFromNestedArray(val)
             const outGrid = startGrid.cloneRegion(0, 0, 2, 2)
 
-            const expectedOutput = [
-                [null, null],
-                [0, 1],
-            ]
+            const expectedOutput = [[null, null], [0, 1]]
 
             assertGridValues(outGrid, expectedOutput)
         })
@@ -168,7 +120,6 @@ describe("Grid", () => {
 })
 
 function createGridFromNestedArray<T>(array: T[][]): Grid<T> {
-
     const grid = new Grid<T>()
 
     for (let row = 0; row < array.length; row++) {
@@ -185,7 +136,6 @@ function createGridFromNestedArray<T>(array: T[][]): Grid<T> {
 }
 
 function assertGridValues<T>(grid: Grid<T>, array: T[][]): void {
-
     for (let row = 0; row < array.length; row++) {
         const rowItems = array[row]
 

--- a/browser/test/Input/InputManagerTests.ts
+++ b/browser/test/Input/InputManagerTests.ts
@@ -5,24 +5,28 @@ import { InputManager } from "./../../src/Services/InputManager"
 describe("InputManager", () => {
     describe("bind", () => {
         it("adds a key handler", () => {
-
             const im = new InputManager()
 
             let count = 0
-            im.bind("<c-a>", () => { count++; return true })
+            im.bind("<c-a>", () => {
+                count++
+                return true
+            })
 
             const handled = im.handleKey("<c-a>")
 
             assert.strictEqual(count, 1, "Validate handler was called")
             assert.strictEqual(handled, true)
-
         })
 
         it("removes key handler when calling dispose", () => {
             const im = new InputManager()
 
             let count = 0
-            const dispose = im.bind("<c-a>", () => { count++; return true })
+            const dispose = im.bind("<c-a>", () => {
+                count++
+                return true
+            })
             dispose()
 
             const handled = im.handleKey("<c-a>")
@@ -35,7 +39,10 @@ describe("InputManager", () => {
             const im = new InputManager()
 
             let count = 0
-            const dispose = im.bind("{", () => { count++; return true })
+            const dispose = im.bind("{", () => {
+                count++
+                return true
+            })
 
             im.unbindAll()
 

--- a/browser/test/Input/Keyboard/ResolverTests.ts
+++ b/browser/test/Input/Keyboard/ResolverTests.ts
@@ -1,6 +1,11 @@
 import * as assert from "assert"
 
-import { createMetaKeyResolver, ignoreMetaKeyResolver, KeyResolver, remapResolver } from "./../../../src/Input/Keyboard/Resolvers"
+import {
+    createMetaKeyResolver,
+    ignoreMetaKeyResolver,
+    KeyResolver,
+    remapResolver,
+} from "./../../../src/Input/Keyboard/Resolvers"
 
 describe("Resolvers", () => {
     describe("ignoreMetaResolver", () => {
@@ -33,7 +38,7 @@ describe("Resolvers", () => {
         describe("*", () => {
             it("Handles <s- > (shift+space)", () => {
                 const layout = {
-                    "Space": {
+                    Space: {
                         unmodified: " ",
                         withShift: " ",
                     },
@@ -95,14 +100,14 @@ describe("Resolvers", () => {
 })
 
 const englishLayout = {
-    "KeyP": {
+    KeyP: {
         unmodified: "p",
         withShift: "P",
     },
 }
 
 const englishInternationalLayout = {
-    "KeyS": {
+    KeyS: {
         unmodified: "s",
         withShift: "S",
         withAltGraph: "ß",
@@ -111,7 +116,7 @@ const englishInternationalLayout = {
 }
 
 const germanLayout = {
-    "Semicolon": {
+    Semicolon: {
         unmodified: "ö",
         withShift: "Ö",
     },
@@ -123,7 +128,7 @@ const createKeyEvent = (key: string, code: string): any => ({
     ctrlKey: false,
     altKey: false,
     shiftKey: false,
-    preventDefault: () => { }, // tslint:disable-line no-empty
+    preventDefault: () => {}, // tslint:disable-line no-empty
 })
 
 const control = (keyEvent: KeyboardEvent): KeyboardEvent => ({

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -20,16 +20,13 @@ import { HighlightInfo } from "./../../src/Services/SyntaxHighlighting"
 import { IWorkspace } from "./../../src/Services/Workspace"
 
 export class MockConfiguration {
-
     private _currentConfigurationFiles: string[] = []
 
     public get currentConfigurationFiles(): string[] {
         return this._currentConfigurationFiles
     }
 
-    constructor(
-        private _configurationValues: any = {},
-    ) {}
+    constructor(private _configurationValues: any = {}) {}
 
     public getValue(key: string): any {
         return this._configurationValues[key]
@@ -44,7 +41,9 @@ export class MockConfiguration {
     }
 
     public removeConfigurationFile(filePath: string): void {
-        this._currentConfigurationFiles = this._currentConfigurationFiles.filter((fp) => fp !== filePath)
+        this._currentConfigurationFiles = this._currentConfigurationFiles.filter(
+            fp => fp !== filePath,
+        )
     }
 }
 
@@ -83,7 +82,6 @@ export class MockWorkspace implements IWorkspace {
 }
 
 export class MockStatusBarItem implements Oni.StatusBarItem {
-
     public show(): void {
         // tslint:disable-line
     }
@@ -112,7 +110,6 @@ export class MockStatusBar implements Oni.StatusBar {
 }
 
 export class MockEditor extends Editor {
-
     private _activeBuffer: MockBuffer = null
 
     public get activeBuffer(): Oni.Buffer {
@@ -140,17 +137,18 @@ export class MockEditor extends Editor {
 
         this.notifyBufferChanged({
             buffer: this._activeBuffer as any,
-            contentChanges: [{
-                range: types.Range.create(line, 0, line + 1, 0),
-                text: lineContents,
-            }],
+            contentChanges: [
+                {
+                    range: types.Range.create(line, 0, line + 1, 0),
+                    text: lineContents,
+                },
+            ],
         })
     }
 }
 
 export class MockBuffer {
-
-    private _mockHighlights = new  MockBufferHighlightsUpdater()
+    private _mockHighlights = new MockBufferHighlightsUpdater()
     private _cursorPosition = types.Position.create(0, 0)
 
     public get id(): string {
@@ -177,8 +175,7 @@ export class MockBuffer {
         private _language: string = "test_language",
         private _filePath: string = "test_filepath",
         private _lines: string[] = [],
-    ) {
-    }
+    ) {}
 
     public async getCursorPosition(): Promise<types.Position> {
         return this._cursorPosition
@@ -193,7 +190,6 @@ export class MockBuffer {
     }
 
     public setLineSync(line: number, lineContents: string): void {
-
         while (this._lines.length <= line) {
             this._lines.push("")
         }
@@ -225,7 +221,6 @@ export class MockBuffer {
 }
 
 export class MockBufferHighlightsUpdater implements IBufferHighlightsUpdater {
-
     private _linesToHighlights: { [line: number]: HighlightInfo[] } = {}
 
     public setHighlightsForLine(line: number, highlights: HighlightInfo[]): void {
@@ -255,7 +250,6 @@ export class MockLanguageManager {
 }
 
 export class MockRequestor<T> {
-
     private _completablePromises: Array<ICompletablePromise<T>> = []
 
     public get pendingCallCount(): number {
@@ -263,7 +257,6 @@ export class MockRequestor<T> {
     }
 
     public get(...args: any[]): Promise<T> {
-
         const newPromise = createCompletablePromise<T>()
 
         this._completablePromises.push(newPromise)
@@ -277,14 +270,26 @@ export class MockRequestor<T> {
     }
 }
 
-export class MockDefinitionRequestor extends MockRequestor<Language.IDefinitionResult> implements Language.IDefinitionRequestor {
-    public getDefinition(language: string, filePath: string, line: number, column: number): Promise<Language.IDefinitionResult> {
+export class MockDefinitionRequestor extends MockRequestor<Language.IDefinitionResult>
+    implements Language.IDefinitionRequestor {
+    public getDefinition(
+        language: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<Language.IDefinitionResult> {
         return this.get(language, filePath, line, column)
     }
 }
 
-export class MockHoverRequestor extends MockRequestor<Language.IHoverResult> implements Language.IHoverRequestor {
-    public getHover(language: string, filePath: string, line: number, column: number): Promise<Language.IHoverResult> {
+export class MockHoverRequestor extends MockRequestor<Language.IHoverResult>
+    implements Language.IHoverRequestor {
+    public getHover(
+        language: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<Language.IHoverResult> {
         return this.get(language, filePath, line, column)
     }
 }

--- a/browser/test/Mocks/neovim.ts
+++ b/browser/test/Mocks/neovim.ts
@@ -8,13 +8,12 @@
 import * as Neovim from "./../../src/neovim"
 
 export class MockScreen implements Neovim.IScreen {
-
     public backgroundColor: string
     public foregroundColor: string
     public cursorColumn: number = 0
     public cursorRow: number = 0
 
-    private _cells: { [row: number]: { [col: number]: Neovim.ICell }} = { }
+    private _cells: { [row: number]: { [col: number]: Neovim.ICell } } = {}
 
     public get currentBackgroundColor(): string {
         return null
@@ -65,7 +64,7 @@ export class MockScreen implements Neovim.IScreen {
     }
 
     public setCell(x: number, y: number, cell: Neovim.ICell): void {
-        const row = this._cells[y] || { }
+        const row = this._cells[y] || {}
 
         const updatedRow = {
             ...row,

--- a/browser/test/Renderer/SpanTests.ts
+++ b/browser/test/Renderer/SpanTests.ts
@@ -3,19 +3,19 @@ import * as assert from "assert"
 import * as Span from "./../../src/Renderer/Span"
 
 describe("Span", () => {
-
     describe("flattenSpansToArray", () => {
         it("simple test", () => {
-
-            const output = Span.flattenSpansToArray([{startX: 1, endX: 2}, {startX: 3, endX: 5}])
+            const output = Span.flattenSpansToArray([
+                { startX: 1, endX: 2 },
+                { startX: 3, endX: 5 },
+            ])
             assert.deepEqual(output, [null, true, false, true, true])
         })
     })
 
     describe("expandArrayToSpans", () => {
         it("simple test", () => {
-
-            const input = [{startX: 1, endX: 2}, {startX: 3, endX: 5}]
+            const input = [{ startX: 1, endX: 2 }, { startX: 3, endX: 5 }]
             const array = Span.flattenSpansToArray(input)
             const expanded = Span.expandArrayToSpans(array)
 
@@ -25,17 +25,17 @@ describe("Span", () => {
 
     describe("collapeSpans", () => {
         it("does not collapse spans that are not adjacent", () => {
-            const spans = [{startX: 1, endX: 4}, {startX: 5, endX: 6}]
+            const spans = [{ startX: 1, endX: 4 }, { startX: 5, endX: 6 }]
             const outSpans = Span.collapseSpans(spans)
 
             assert.deepEqual(outSpans, spans)
         })
 
         it("does collapse spans that overlap", () => {
-            const spans = [{startX: 1, endX: 4}, {startX: 3, endX: 5}]
+            const spans = [{ startX: 1, endX: 4 }, { startX: 3, endX: 5 }]
             const outSpans = Span.collapseSpans(spans)
 
-            assert.deepEqual(outSpans, [{startX: 1, endX: 5}])
+            assert.deepEqual(outSpans, [{ startX: 1, endX: 5 }])
         })
     })
 })

--- a/browser/test/Services/Completion/CompletionTests.ts
+++ b/browser/test/Services/Completion/CompletionTests.ts
@@ -11,9 +11,12 @@ import * as Mocks from "./../../Mocks"
 import * as TestHelpers from "./../../TestHelpers"
 
 export class MockCompletionRequestor implements Completion.ICompletionsRequestor {
-
-    private _completionsRequestor: Mocks.MockRequestor<types.CompletionItem[]> = new Mocks.MockRequestor<types.CompletionItem[]>()
-    private _completionDetailsRequestor: Mocks.MockRequestor<types.CompletionItem> = new Mocks.MockRequestor<types.CompletionItem>()
+    private _completionsRequestor: Mocks.MockRequestor<
+        types.CompletionItem[]
+    > = new Mocks.MockRequestor<types.CompletionItem[]>()
+    private _completionDetailsRequestor: Mocks.MockRequestor<
+        types.CompletionItem
+    > = new Mocks.MockRequestor<types.CompletionItem>()
 
     public get completionsRequestor(): Mocks.MockRequestor<types.CompletionItem[]> {
         return this._completionsRequestor
@@ -23,14 +26,22 @@ export class MockCompletionRequestor implements Completion.ICompletionsRequestor
         return this._completionDetailsRequestor
     }
 
-    public getCompletions(fileLanguage: string, filePath: string, line: number, column: number): Promise<types.CompletionItem[]> {
+    public getCompletions(
+        fileLanguage: string,
+        filePath: string,
+        line: number,
+        column: number,
+    ): Promise<types.CompletionItem[]> {
         return this._completionsRequestor.get(fileLanguage, filePath, line, column)
     }
 
-    public getCompletionDetails(fileLanguage: string, filePath: string, completionItem: types.CompletionItem): Promise<types.CompletionItem> {
+    public getCompletionDetails(
+        fileLanguage: string,
+        filePath: string,
+        completionItem: types.CompletionItem,
+    ): Promise<types.CompletionItem> {
         return this._completionDetailsRequestor.get(fileLanguage, filePath, completionItem)
     }
-
 }
 
 const createMockCompletionItem = (label: string): types.CompletionItem => {
@@ -59,7 +70,12 @@ describe("Completion", () => {
         mockEditor = new Mocks.MockEditor()
         mockLanguageManager = new Mocks.MockLanguageManager()
         mockCompletionRequestor = new MockCompletionRequestor()
-        completion = new Completion.Completion(mockEditor, mockConfiguration as any, mockCompletionRequestor, mockLanguageManager as any)
+        completion = new Completion.Completion(
+            mockEditor,
+            mockConfiguration as any,
+            mockCompletionRequestor,
+            mockLanguageManager as any,
+        )
     })
 
     afterEach(() => {
@@ -79,10 +95,14 @@ describe("Completion", () => {
         TestHelpers.runAllTimers()
 
         let lastItems: Completion.ICompletionShowEventArgs = null
-        completion.onShowCompletionItems.subscribe((items) => lastItems = items)
+        completion.onShowCompletionItems.subscribe(items => (lastItems = items))
 
         // Validate we have a request for completions
-        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 1, "There should be a request for completions queued")
+        assert.strictEqual(
+            mockCompletionRequestor.completionsRequestor.pendingCallCount,
+            1,
+            "There should be a request for completions queued",
+        )
 
         const completionResults = [
             createMockCompletionItem("win"),
@@ -93,12 +113,15 @@ describe("Completion", () => {
 
         await TestHelpers.waitForAllAsyncOperations()
 
-        assert.deepEqual(lastItems.filteredCompletions, completionResults, "There should now be completion results available")
+        assert.deepEqual(
+            lastItems.filteredCompletions,
+            completionResults,
+            "There should now be completion results available",
+        )
         assert.deepEqual(lastItems.base, "w", "The base should be set correctly")
     })
 
     it("doesn't fetch completions if 'editor.completions.mode' === 'hidden'", () => {
-
         mockConfiguration.setValue("editor.completions.mode", "hidden")
 
         mockEditor.simulateBufferEnter(new Mocks.MockBuffer("typescript", "test1.ts", []))
@@ -113,11 +136,14 @@ describe("Completion", () => {
         TestHelpers.runAllTimers()
 
         // Validate we do not have requests for completion, because completions are turned off.
-        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 0, "There should be no completion requests, because 'editor.completions.mode' is set to 'hidden'")
+        assert.strictEqual(
+            mockCompletionRequestor.completionsRequestor.pendingCallCount,
+            0,
+            "There should be no completion requests, because 'editor.completions.mode' is set to 'hidden'",
+        )
     })
 
     it("doesn't fetch completions if 'editor.completions.enabled' === 'false'", () => {
-
         mockConfiguration.setValue("editor.completions.enabled", false)
 
         mockEditor.simulateBufferEnter(new Mocks.MockBuffer("typescript", "test1.ts", []))
@@ -132,11 +158,14 @@ describe("Completion", () => {
         TestHelpers.runAllTimers()
 
         // Validate we do not have requests for completion, because completions are turned off.
-        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 0, "There should be no completion requests, because 'editor.completions.enabled' is set to 'false'")
+        assert.strictEqual(
+            mockCompletionRequestor.completionsRequestor.pendingCallCount,
+            0,
+            "There should be no completion requests, because 'editor.completions.enabled' is set to 'false'",
+        )
     })
 
     it("if there is a completion matching the base, it should be the first shown", async () => {
-
         mockEditor.simulateBufferEnter(new Mocks.MockBuffer("typescript", "test1.ts", []))
 
         // Switch to insert mode
@@ -149,10 +178,14 @@ describe("Completion", () => {
         TestHelpers.runAllTimers()
 
         let lastItems: Completion.ICompletionShowEventArgs = null
-        completion.onShowCompletionItems.subscribe((items) => lastItems = items)
+        completion.onShowCompletionItems.subscribe(items => (lastItems = items))
 
         // Validate we have a request for completions
-        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 1, "There should be a request for completions queued")
+        assert.strictEqual(
+            mockCompletionRequestor.completionsRequestor.pendingCallCount,
+            1,
+            "There should be a request for completions queued",
+        )
 
         const completionResults = [
             createMockCompletionItem("window"),
@@ -163,8 +196,16 @@ describe("Completion", () => {
 
         await TestHelpers.waitForAllAsyncOperations()
 
-        assert.strictEqual(lastItems.filteredCompletions.length, 2, "Completions were resolved successfully")
-        assert.deepEqual(lastItems.filteredCompletions[0], completionResults[1], "The second completion should be the first one shown, as it matches the base")
+        assert.strictEqual(
+            lastItems.filteredCompletions.length,
+            2,
+            "Completions were resolved successfully",
+        )
+        assert.deepEqual(
+            lastItems.filteredCompletions[0],
+            completionResults[1],
+            "The second completion should be the first one shown, as it matches the base",
+        )
     })
 
     it("if mode changed while a request was in progress, there should be no completions shown", async () => {
@@ -180,10 +221,14 @@ describe("Completion", () => {
         TestHelpers.runAllTimers()
 
         let lastItems: Completion.ICompletionShowEventArgs = null
-        completion.onShowCompletionItems.subscribe((items) => lastItems = items)
+        completion.onShowCompletionItems.subscribe(items => (lastItems = items))
 
         // Validate we have a request for completions
-        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 1, "There should be a request for completions queued")
+        assert.strictEqual(
+            mockCompletionRequestor.completionsRequestor.pendingCallCount,
+            1,
+            "There should be a request for completions queued",
+        )
 
         // While the result is pending, we'll leave insert mode -
         // we shouldn't get any completions, now!
@@ -202,7 +247,11 @@ describe("Completion", () => {
 
         await TestHelpers.waitForAllAsyncOperations()
 
-        assert.strictEqual(lastItems, null, "Completions should be null, as we shouldn't have received them after the mode change")
+        assert.strictEqual(
+            lastItems,
+            null,
+            "Completions should be null, as we shouldn't have received them after the mode change",
+        )
     })
 
     it("if meet changed while the request was in progress, there should be no completions shown", async () => {
@@ -218,10 +267,14 @@ describe("Completion", () => {
         TestHelpers.runAllTimers()
 
         let lastItems: Completion.ICompletionShowEventArgs = null
-        completion.onShowCompletionItems.subscribe((items) => lastItems = items)
+        completion.onShowCompletionItems.subscribe(items => (lastItems = items))
 
         // Validate we have a request for completions
-        assert.strictEqual(mockCompletionRequestor.completionsRequestor.pendingCallCount, 1, "There should be a request for completions queued")
+        assert.strictEqual(
+            mockCompletionRequestor.completionsRequestor.pendingCallCount,
+            1,
+            "There should be a request for completions queued",
+        )
 
         // While the result is pending, we'll keep typing...
         // That first result should be ignored
@@ -241,7 +294,11 @@ describe("Completion", () => {
 
         await TestHelpers.waitForAllAsyncOperations()
 
-        assert.strictEqual(lastItems, null, "Completions should be null, as the only request that was completed was outdated")
+        assert.strictEqual(
+            lastItems,
+            null,
+            "Completions should be null, as the only request that was completed was outdated",
+        )
     })
 
     it("#1076 - should not crash if buffer change comes before first cursor move", () => {

--- a/browser/test/Services/Completion/CompletionUtilityTests.ts
+++ b/browser/test/Services/Completion/CompletionUtilityTests.ts
@@ -6,25 +6,32 @@ const DefaultCursorMatchRegEx = /[a-z]/i
 const DefaultTriggerCharacters = ["."]
 
 describe("CompletionUtility", () => {
-
     describe("getCompletionStart", () => {
         it("rewinds back to first character", () => {
             const bufferLine = "abc"
             const cursorColumn = 5
             const completion = "c"
 
-            const completionStart = CompletionUtility.getCompletionStart(bufferLine, cursorColumn, completion)
+            const completionStart = CompletionUtility.getCompletionStart(
+                bufferLine,
+                cursorColumn,
+                completion,
+            )
             assert.strictEqual(completionStart, 2)
         })
     })
 
     describe("getCompletionMeet", () => {
         it("shouldExpandCompletions is true when at end of word", () => {
-
             const line = "const"
             const cursorPosition = 5 // const|
 
-            const meet = CompletionUtility.getCompletionMeet(line, cursorPosition, DefaultCursorMatchRegEx, DefaultTriggerCharacters)
+            const meet = CompletionUtility.getCompletionMeet(
+                line,
+                cursorPosition,
+                DefaultCursorMatchRegEx,
+                DefaultTriggerCharacters,
+            )
 
             const expectedResult = {
                 position: 0,
@@ -40,7 +47,12 @@ describe("CompletionUtility", () => {
             const line = "const"
             const cursorPosition = 3 // con|st
 
-            const meet = CompletionUtility.getCompletionMeet(line, cursorPosition, DefaultCursorMatchRegEx, DefaultTriggerCharacters)
+            const meet = CompletionUtility.getCompletionMeet(
+                line,
+                cursorPosition,
+                DefaultCursorMatchRegEx,
+                DefaultTriggerCharacters,
+            )
 
             const expectedResult = {
                 position: 0,

--- a/browser/test/Services/Configuration/ConfigurationTests.ts
+++ b/browser/test/Services/Configuration/ConfigurationTests.ts
@@ -3,7 +3,12 @@ import * as assert from "assert"
 import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 
-import { Configuration, GenericConfigurationValues, IConfigurationProvider, IPersistedConfiguration } from "./../../../src/Services/Configuration"
+import {
+    Configuration,
+    GenericConfigurationValues,
+    IConfigurationProvider,
+    IPersistedConfiguration,
+} from "./../../../src/Services/Configuration"
 
 describe("Configuration", () => {
     it("has default configuration values set on instantiation", () => {
@@ -26,7 +31,7 @@ describe("Configuration", () => {
         const configuration = new Configuration({})
 
         const errors: Error[] = []
-        configuration.onConfigurationError.subscribe((err) => {
+        configuration.onConfigurationError.subscribe(err => {
             errors.push(err)
         })
 
@@ -49,10 +54,14 @@ describe("Configuration", () => {
             hitCount++
         })
 
-        configProvider.simulateConfigChange({ "test.config": 3})
+        configProvider.simulateConfigChange({ "test.config": 3 })
 
         assert.strictEqual(hitCount, 1, "Validate 'onConfigurationChanged' was dispatched")
-        assert.strictEqual(configuration.getValue("test.config"), 3, "Validate configuration was updated")
+        assert.strictEqual(
+            configuration.getValue("test.config"),
+            3,
+            "Validate configuration was updated",
+        )
     })
 
     describe("removeConfiguratioProvider", () => {
@@ -63,7 +72,11 @@ describe("Configuration", () => {
             configuration.addConfigurationProvider(configProvider)
             configuration.removeConfigurationProvider(configProvider)
 
-            assert.strictEqual(configuration.getValue("test.config"), 1, "Value should now be 1 since the provider was removed")
+            assert.strictEqual(
+                configuration.getValue("test.config"),
+                1,
+                "Value should now be 1 since the provider was removed",
+            )
         })
 
         it("doesn't listen to events from removed provider", () => {
@@ -80,19 +93,34 @@ describe("Configuration", () => {
 
             configuration.removeConfigurationProvider(configProvider)
 
-            assert.strictEqual(changeHitCount, 1, "Should've been one change when applying settings after remove")
+            assert.strictEqual(
+                changeHitCount,
+                1,
+                "Should've been one change when applying settings after remove",
+            )
 
             configProvider.simulateConfigChange({ "test.config": 3 })
-            assert.strictEqual(changeHitCount, 1, "Validate change hit count is still 1, since we shouldn't be listening to the removed config provider")
-            assert.strictEqual(configuration.getValue("test.config"), 1, "Validate the value is still at 1")
+            assert.strictEqual(
+                changeHitCount,
+                1,
+                "Validate change hit count is still 1, since we shouldn't be listening to the removed config provider",
+            )
+            assert.strictEqual(
+                configuration.getValue("test.config"),
+                1,
+                "Validate the value is still at 1",
+            )
 
             configProvider.simulateError(new Error("some error"))
-            assert.strictEqual(errorHitCount, 0, "Validate there was no event triggered for the removed providers error event")
+            assert.strictEqual(
+                errorHitCount,
+                0,
+                "Validate there was no event triggered for the removed providers error event",
+            )
         })
     })
 
     describe("persisted configuration", () => {
-
         let persistedConfiguration: IPersistedConfiguration
 
         beforeEach(() => {
@@ -104,7 +132,11 @@ describe("Configuration", () => {
                 "test.config": 2,
             })
             const configuration = new Configuration({ "test.config": 1 }, persistedConfiguration)
-            assert.strictEqual(configuration.getValue("test.config"), 2, "Validate persisted configuration value is read")
+            assert.strictEqual(
+                configuration.getValue("test.config"),
+                2,
+                "Validate persisted configuration value is read",
+            )
         })
 
         it("are overwritten by explicitly set configuration values", () => {
@@ -116,7 +148,11 @@ describe("Configuration", () => {
 
             const configuration = new Configuration({ "test.config": 1 }, persistedConfiguration)
             configuration.addConfigurationProvider(configProvider)
-            assert.strictEqual(configuration.getValue("test.config"), 3, "Validate persisted configuration is overwrittten by explicitly set configuration")
+            assert.strictEqual(
+                configuration.getValue("test.config"),
+                3,
+                "Validate persisted configuration is overwrittten by explicitly set configuration",
+            )
         })
 
         it("doesn't set values when 'persist' argument is false", () => {
@@ -124,29 +160,36 @@ describe("Configuration", () => {
                 "test.config": 1,
             })
 
-            const configuration = new Configuration({ "test.config": 1}, persistedConfiguration)
+            const configuration = new Configuration({ "test.config": 1 }, persistedConfiguration)
 
-            configuration.setValues({"test.config": 2}, false)
+            configuration.setValues({ "test.config": 2 }, false)
 
-            assert.deepEqual(persistedConfiguration.getPersistedValues(), {
-                "test.config": 1,
-            }, "Validate persisted configuration wasn't overwritten since persist was false")
+            assert.deepEqual(
+                persistedConfiguration.getPersistedValues(),
+                {
+                    "test.config": 1,
+                },
+                "Validate persisted configuration wasn't overwritten since persist was false",
+            )
         })
 
         it("does set values when 'persist' argument is true", () => {
-            const configuration = new Configuration({ "test.config": 1}, persistedConfiguration)
+            const configuration = new Configuration({ "test.config": 1 }, persistedConfiguration)
 
-            configuration.setValues({"test.config": 2}, true)
+            configuration.setValues({ "test.config": 2 }, true)
 
-            assert.deepEqual(persistedConfiguration.getPersistedValues(), {
-                "test.config": 2,
-            }, "Validate persisted configuration was overwritten since persist was true")
+            assert.deepEqual(
+                persistedConfiguration.getPersistedValues(),
+                {
+                    "test.config": 2,
+                },
+                "Validate persisted configuration was overwritten since persist was true",
+            )
         })
     })
 })
 
 export class MockPersistedConfiguration implements IPersistedConfiguration {
-
     private _values: GenericConfigurationValues = {}
 
     public getPersistedValues(): GenericConfigurationValues {

--- a/browser/test/Services/Explorer/ExplorerSelectorsTests.ts
+++ b/browser/test/Services/Explorer/ExplorerSelectorsTests.ts
@@ -13,21 +13,21 @@ const createTestFile = (filePath: string): ExplorerState.IFileState => ({
 
 describe("ExplorerSelectors", () => {
     describe("flattenFolderTree", () => {
-
         it("flattens a single file", () => {
-
             const file: ExplorerState.IFileState = createTestFile("/test/files/testFile.txt")
 
             const result = ExplorerSelectors.flattenFolderTree(file, [], {}, 1)
 
-            const expectedResult = [{
-                id: "explorer:/test/files/testFile.txt",
-                type: "file",
-                filePath: "/test/files/testFile.txt",
-                name: "testFile.txt",
-                modified: false,
-                indentationLevel: 1,
-            }]
+            const expectedResult = [
+                {
+                    id: "explorer:/test/files/testFile.txt",
+                    type: "file",
+                    filePath: "/test/files/testFile.txt",
+                    name: "testFile.txt",
+                    modified: false,
+                    indentationLevel: 1,
+                },
+            ]
 
             assert.deepEqual(result, expectedResult)
         })
@@ -40,14 +40,16 @@ describe("ExplorerSelectors", () => {
 
             const result = ExplorerSelectors.flattenFolderTree(folder, [], {}, 1)
 
-            const expectedResult = [{
-                type: "folder",
-                id: "explorer:/test/folder/folderPath",
-                folderPath: "/test/folder/folderPath",
-                name: "folderPath",
-                expanded: false,
-                indentationLevel: 1,
-            }]
+            const expectedResult = [
+                {
+                    type: "folder",
+                    id: "explorer:/test/folder/folderPath",
+                    folderPath: "/test/folder/folderPath",
+                    name: "folderPath",
+                    expanded: false,
+                    indentationLevel: 1,
+                },
+            ]
 
             assert.deepEqual(result, expectedResult)
         })
@@ -59,26 +61,29 @@ describe("ExplorerSelectors", () => {
             }
 
             const expandedFolders = {
-                "/test/folder1/folderPath": [ createTestFile("/test/files/file1")],
+                "/test/folder1/folderPath": [createTestFile("/test/files/file1")],
             }
 
             const result = ExplorerSelectors.flattenFolderTree(folder, [], expandedFolders, 1)
 
-            const expectedResult = [{
-                type: "folder",
-                id: "explorer:/test/folder1/folderPath",
-                folderPath: "/test/folder1/folderPath",
-                name: "folderPath",
-                expanded: true,
-                indentationLevel: 1,
-            }, {
-                type: "file",
-                id: "explorer:/test/files/file1",
-                filePath: "/test/files/file1",
-                name: "file1",
-                modified: false,
-                indentationLevel: 2,
-            }]
+            const expectedResult = [
+                {
+                    type: "folder",
+                    id: "explorer:/test/folder1/folderPath",
+                    folderPath: "/test/folder1/folderPath",
+                    name: "folderPath",
+                    expanded: true,
+                    indentationLevel: 1,
+                },
+                {
+                    type: "file",
+                    id: "explorer:/test/files/file1",
+                    filePath: "/test/files/file1",
+                    name: "file1",
+                    modified: false,
+                    indentationLevel: 2,
+                },
+            ]
 
             assert.deepEqual(result, expectedResult)
         })

--- a/browser/test/Services/Explorer/ExplorerStoreTests.ts
+++ b/browser/test/Services/Explorer/ExplorerStoreTests.ts
@@ -15,7 +15,6 @@ import * as TestHelpers from "./../../TestHelpers"
 const MemoryFileSystem = require("memory-fs") // tslint:disable-line
 
 describe("ExplorerStore", () => {
-
     let fileSystem: any
     let store: Store<ExplorerState.IExplorerState>
 
@@ -32,7 +31,6 @@ describe("ExplorerStore", () => {
     })
 
     describe("SET_ROOT_DIRECTORY", () => {
-
         it("expands directory automatically", async () => {
             store.dispatch({
                 type: "SET_ROOT_DIRECTORY",
@@ -44,9 +42,11 @@ describe("ExplorerStore", () => {
             // At this point, the FS operations are synchronous
             const state = store.getState()
 
-            assert.deepEqual(state.expandedFolders[rootPath], [
-                { type: "file", fullPath: filePath },
-            ], "Validate expanded folders is set")
+            assert.deepEqual(
+                state.expandedFolders[rootPath],
+                [{ type: "file", fullPath: filePath }],
+                "Validate expanded folders is set",
+            )
         })
     })
 })

--- a/browser/test/Services/FileMappingsTests.ts
+++ b/browser/test/Services/FileMappingsTests.ts
@@ -7,26 +7,23 @@ const MemoryFileSystem = require("memory-fs") // tslint:disable-line
 import * as FileMappings from "./../../src/Services/FileMappings"
 
 describe("FileMappings", () => {
-
     let rootPath: string
     let srcPath: string
     let testPath: string
     let fileSystem: any
 
     beforeEach(() => {
+        rootPath = path.join("C:/", "oni-unit-test-container")
+        srcPath = path.join(rootPath, "browser", "src")
+        testPath = path.join(rootPath, "browser", "test")
 
-            rootPath = path.join("C:/", "oni-unit-test-container")
-            srcPath = path.join(rootPath, "browser", "src")
-            testPath = path.join(rootPath, "browser", "test")
-
-            fileSystem = new MemoryFileSystem()
-            fileSystem.mkdirpSync(srcPath)
-            fileSystem.mkdirpSync(testPath)
+        fileSystem = new MemoryFileSystem()
+        fileSystem.mkdirpSync(srcPath)
+        fileSystem.mkdirpSync(testPath)
     })
 
     describe("getMappedFile", () => {
         it("returns simple mapping", () => {
-
             const srcFile = path.join(srcPath, "source.ts")
             const testFile = path.join(testPath, "sourceTest.ts")
 

--- a/browser/test/Services/Language/EditTests.ts
+++ b/browser/test/Services/Language/EditTests.ts
@@ -6,7 +6,6 @@ import { sortTextEdits } from "./../../../src/Services/Language/Edits"
 
 describe("sortTextEdits", () => {
     it("sorts descending by lines", () => {
-
         const rangeLine1 = types.Range.create(1, 0, 1, 0)
         const rangeLine2 = types.Range.create(2, 0, 2, 0)
 
@@ -34,7 +33,6 @@ describe("sortTextEdits", () => {
     })
 
     it("sorts first by lines, then by characters", () => {
-
         const rangeLine1 = types.Range.create(1, 1, 1, 5)
         const rangeLine2 = types.Range.create(1, 10, 1, 15)
         const rangeLine3 = types.Range.create(2, 1, 2, 5)

--- a/browser/test/Services/Language/LanguageEditorIntegrationTests.ts
+++ b/browser/test/Services/Language/LanguageEditorIntegrationTests.ts
@@ -43,7 +43,13 @@ describe("LanguageEditorIntegration", () => {
         mockEditor = new Mocks.MockEditor()
         mockDefinitionRequestor = new Mocks.MockDefinitionRequestor()
         mockHoverRequestor = new Mocks.MockHoverRequestor()
-        languageEditorIntegration = new Language.LanguageEditorIntegration(mockEditor, mockConfiguration as any, null, mockDefinitionRequestor, mockHoverRequestor)
+        languageEditorIntegration = new Language.LanguageEditorIntegration(
+            mockEditor,
+            mockConfiguration as any,
+            null,
+            mockDefinitionRequestor,
+            mockHoverRequestor,
+        )
     })
 
     afterEach(() => {
@@ -79,7 +85,6 @@ describe("LanguageEditorIntegration", () => {
     })
 
     it("respects editor.quickInfo.delay setting for hover", () => {
-
         // Get the editor primed for a request
         mockEditor.simulateModeChange("normal")
         mockEditor.simulateBufferEnter(new Mocks.MockBuffer())
@@ -87,18 +92,30 @@ describe("LanguageEditorIntegration", () => {
 
         // There shouldn't be any requests yet, because
         // we haven't hit the delay..
-        assert.strictEqual(mockHoverRequestor.pendingCallCount, 0, "Should be no request queued yet...")
+        assert.strictEqual(
+            mockHoverRequestor.pendingCallCount,
+            0,
+            "Should be no request queued yet...",
+        )
 
         // Tick just before the delay....
         clock.tick(499)
 
-        assert.strictEqual(mockHoverRequestor.pendingCallCount, 0, "Should be no request queued, right before the time limit..")
+        assert.strictEqual(
+            mockHoverRequestor.pendingCallCount,
+            0,
+            "Should be no request queued, right before the time limit..",
+        )
 
         // Tick just after the delay...
         clock.tick(2)
 
         // There should now be a request queued up
-        assert.strictEqual(mockHoverRequestor.pendingCallCount, 1, "Should now be a request pending, because we've exceeded the limit")
+        assert.strictEqual(
+            mockHoverRequestor.pendingCallCount,
+            1,
+            "Should now be a request pending, because we've exceeded the limit",
+        )
     })
 
     it("doesn't show slow hover response that completes after cursor moves", async () => {
@@ -113,7 +130,11 @@ describe("LanguageEditorIntegration", () => {
         // Go past the clock timer, so we should get a request now
         clock.tick(501)
 
-        assert.strictEqual(mockHoverRequestor.pendingCallCount, 1, "Verify we have a request queued up")
+        assert.strictEqual(
+            mockHoverRequestor.pendingCallCount,
+            1,
+            "Verify we have a request queued up",
+        )
 
         // While the request is pending, lets move the cursor
 
@@ -126,7 +147,11 @@ describe("LanguageEditorIntegration", () => {
         // Let clock drain as well
         clock.runAll()
 
-        assert.strictEqual(hoverShowCount, 0, "Hover should never be shown, because the cursor moved.")
+        assert.strictEqual(
+            hoverShowCount,
+            0,
+            "Hover should never be shown, because the cursor moved.",
+        )
     })
 
     it("doesn't show slow hover response that completes after mode changes", async () => {
@@ -141,7 +166,11 @@ describe("LanguageEditorIntegration", () => {
         // Go past the clock timer, so we should get a request now
         clock.tick(501)
 
-        assert.strictEqual(mockHoverRequestor.pendingCallCount, 1, "Verify we have a request queued up")
+        assert.strictEqual(
+            mockHoverRequestor.pendingCallCount,
+            1,
+            "Verify we have a request queued up",
+        )
 
         // While the request is pending, lets move the cursor
 
@@ -154,7 +183,11 @@ describe("LanguageEditorIntegration", () => {
         // Let clock drain as well
         clock.runAll()
 
-        assert.strictEqual(hoverShowCount, 0, "Hover should never be shown, because the cursor moved.")
+        assert.strictEqual(
+            hoverShowCount,
+            0,
+            "Hover should never be shown, because the cursor moved.",
+        )
     })
 
     it("hides hover on mode change", async () => {
@@ -245,7 +278,11 @@ describe("LanguageEditorIntegration", () => {
 
         clock.runAll()
 
-        assert.strictEqual(showDefinitionCount, 1, "Definition should be shown, even if 'editor.quickInfo.enabled' is false.")
+        assert.strictEqual(
+            showDefinitionCount,
+            1,
+            "Definition should be shown, even if 'editor.quickInfo.enabled' is false.",
+        )
     })
 
     it("#1247 - doesn't show definition if 'editor.definition.enabled' is false", async () => {
@@ -257,6 +294,10 @@ describe("LanguageEditorIntegration", () => {
 
         clock.tick(501) // Account for the quickInfo.delay
 
-        assert.strictEqual(mockDefinitionRequestor.pendingCallCount, 0, "Validate no request pending for definitions")
+        assert.strictEqual(
+            mockDefinitionRequestor.pendingCallCount,
+            0,
+            "Validate no request pending for definitions",
+        )
     })
 })

--- a/browser/test/Services/Language/LanguageManagerTests.ts
+++ b/browser/test/Services/Language/LanguageManagerTests.ts
@@ -15,7 +15,6 @@ import * as Mocks from "./../../Mocks"
 import * as TestHelpers from "./../../TestHelpers"
 
 export class MockLanguageClient implements Language.ILanguageClient {
-
     public serverCapabilities: any = {}
 
     public subscribe(notificationName: string, evt: Event<any>): void {
@@ -26,11 +25,19 @@ export class MockLanguageClient implements Language.ILanguageClient {
         // tslint: disable-line
     }
 
-    public sendRequest<T>(fileName: string, requestName: string, protocolArguments: Language.NotificationValueOrThunk): Promise<T> {
+    public sendRequest<T>(
+        fileName: string,
+        requestName: string,
+        protocolArguments: Language.NotificationValueOrThunk,
+    ): Promise<T> {
         return Promise.resolve(null)
     }
 
-    public sendNotification(fileName: string, notificationName: string, protocolArguments: Language.NotificationValueOrThunk): void {
+    public sendNotification(
+        fileName: string,
+        notificationName: string,
+        protocolArguments: Language.NotificationValueOrThunk,
+    ): void {
         // tslint: disable-line
     }
 }
@@ -65,7 +72,12 @@ describe("LanguageManager", () => {
 
         const mockStatusBar = new Mocks.MockStatusBar()
 
-        languageManager = new Language.LanguageManager(mockConfiguration as any, editorManager, mockStatusBar, mockWorkspace)
+        languageManager = new Language.LanguageManager(
+            mockConfiguration as any,
+            editorManager,
+            mockStatusBar,
+            mockWorkspace,
+        )
     })
 
     it("sends didOpen request if language server is registered after enter event", async () => {

--- a/browser/test/Services/Snippets/OniSnippetTests.ts
+++ b/browser/test/Services/Snippets/OniSnippetTests.ts
@@ -7,7 +7,7 @@ describe("getLineCharacterFromOffset", () => {
         const lines = ["foo"]
 
         const result = getLineCharacterFromOffset(1, lines)
-        assert.deepEqual(result, { line: 0, character: 1})
+        assert.deepEqual(result, { line: 0, character: 1 })
     })
 
     it("handles multi-line case", () => {

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -12,7 +12,6 @@ import { SnippetSession } from "./../../../src/Services/Snippets/SnippetSession"
 import * as Mocks from "./../../Mocks"
 
 describe("SnippetSession", () => {
-
     let mockEditor: Mocks.MockEditor
     let mockBuffer: Mocks.MockBuffer
     let snippetSession: SnippetSession

--- a/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReconcilerTests.ts
+++ b/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReconcilerTests.ts
@@ -4,10 +4,14 @@ import * as types from "vscode-languageserver-types"
 
 import * as Mocks from "./../../Mocks"
 
-import { HighlightInfo, ISyntaxHighlightLineInfo, ISyntaxHighlightState, SyntaxHighlightReconciler } from "./../../../src/Services/SyntaxHighlighting"
+import {
+    HighlightInfo,
+    ISyntaxHighlightLineInfo,
+    ISyntaxHighlightState,
+    SyntaxHighlightReconciler,
+} from "./../../../src/Services/SyntaxHighlighting"
 
 describe("SyntaxHighlightReconciler", () => {
-
     let syntaxHighlightReconciler: SyntaxHighlightReconciler
     let mockConfiguration: Mocks.MockConfiguration
     let mockEditor: Mocks.MockEditor
@@ -17,12 +21,17 @@ describe("SyntaxHighlightReconciler", () => {
         mockConfiguration = new Mocks.MockConfiguration()
         mockEditor = new Mocks.MockEditor()
 
-        mockConfiguration.setValue("editor.tokenColors", [{
-            scope: "scope.test",
-            settings: "Identifier",
-        }])
+        mockConfiguration.setValue("editor.tokenColors", [
+            {
+                scope: "scope.test",
+                settings: "Identifier",
+            },
+        ])
 
-        syntaxHighlightReconciler = new SyntaxHighlightReconciler(mockConfiguration as any, mockEditor as any)
+        syntaxHighlightReconciler = new SyntaxHighlightReconciler(
+            mockConfiguration as any,
+            mockEditor as any,
+        )
 
         mockBuffer = new Mocks.MockBuffer("javascript", "test.js", [])
         mockEditor.simulateBufferEnter(mockBuffer)
@@ -59,7 +68,6 @@ describe("SyntaxHighlightReconciler", () => {
     }
 
     it("sets tokens", () => {
-
         const tokenInfo = {
             scopes: ["scope.test"],
             range: types.Range.create(0, 0, 0, 5),
@@ -71,16 +79,21 @@ describe("SyntaxHighlightReconciler", () => {
 
         const highlights = mockBuffer.mockHighlights.getHighlightsForLine(0)
 
-        const expectedHighlights: HighlightInfo[] = [{
+        const expectedHighlights: HighlightInfo[] = [
+            {
                 highlightGroup: "Identifier",
                 range: types.Range.create(0, 0, 0, 5),
-            }]
+            },
+        ]
 
-        assert.deepEqual(highlights, expectedHighlights, "Validate highlightsAfterClearing are correct")
+        assert.deepEqual(
+            highlights,
+            expectedHighlights,
+            "Validate highlightsAfterClearing are correct",
+        )
     })
 
     it("clears tokens", () => {
-
         const tokenInfo = {
             scopes: ["scope.test"],
             range: types.Range.create(0, 0, 0, 5),
@@ -96,6 +109,10 @@ describe("SyntaxHighlightReconciler", () => {
 
         const highlightsAfterClearing = mockBuffer.mockHighlights.getHighlightsForLine(0)
         const expectedHighlights: HighlightInfo[] = []
-        assert.deepEqual(highlightsAfterClearing, expectedHighlights, "Validate highlightsAfterClearing are cleared")
+        assert.deepEqual(
+            highlightsAfterClearing,
+            expectedHighlights,
+            "Validate highlightsAfterClearing are cleared",
+        )
     })
 })

--- a/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReducerTests.ts
+++ b/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReducerTests.ts
@@ -3,11 +3,8 @@ import * as assert from "assert"
 import * as SyntaxHighlighting from "./../../../src/Services/SyntaxHighlighting"
 
 describe("SyntaxHighlightingReducer", () => {
-
     describe("linesReducer", () => {
-
         describe("SYNTAX_UPDATE_BUFFER", () => {
-
             it("sets buffer lines if they don't exist yet", () => {
                 const originalState: SyntaxHighlighting.SyntaxHighlightLines = {}
 
@@ -16,10 +13,7 @@ describe("SyntaxHighlightingReducer", () => {
                     extension: "ts",
                     language: "any",
                     bufferId: "1",
-                    lines: [
-                        "line1",
-                        "line2",
-                    ],
+                    lines: ["line1", "line2"],
                 }
 
                 const newState = SyntaxHighlighting.linesReducer(originalState, updateBufferAction)
@@ -60,10 +54,7 @@ describe("SyntaxHighlightingReducer", () => {
                     extension: "ts",
                     language: "any",
                     bufferId: "1",
-                    lines: [
-                        "line1",
-                        "line2_update",
-                    ],
+                    lines: ["line1", "line2_update"],
                 }
 
                 const newState = SyntaxHighlighting.linesReducer(originalState, updateBufferAction)

--- a/browser/test/Services/TypingPredictionManagerTests.ts
+++ b/browser/test/Services/TypingPredictionManagerTests.ts
@@ -6,11 +6,13 @@ import * as assert from "assert"
 
 import * as Neovim from "./../../src/neovim"
 
-import { ITypingPrediction, TypingPredictionManager } from "./../../src/Services/TypingPredictionManager"
+import {
+    ITypingPrediction,
+    TypingPredictionManager,
+} from "./../../src/Services/TypingPredictionManager"
 import { MockScreen } from "./../Mocks/neovim"
 
 describe("TypingPredictionManager", () => {
-
     let mockScreen: MockScreen
     let typingPredictionManager: TypingPredictionManager
 
@@ -30,7 +32,7 @@ describe("TypingPredictionManager", () => {
 
         let callCount = 0
         let lastResult: ITypingPrediction = null
-        typingPredictionManager.onPredictionsChanged.subscribe((pd) => {
+        typingPredictionManager.onPredictionsChanged.subscribe(pd => {
             lastResult = pd
             callCount++
         })
@@ -38,11 +40,31 @@ describe("TypingPredictionManager", () => {
         typingPredictionManager.addPrediction("a")
 
         assert.strictEqual(callCount, 1, "Verify prediction handler was fired exactly once")
-        assert.strictEqual(lastResult.backgroundColor, "black", "Verify background color came from the screen")
-        assert.strictEqual(lastResult.foregroundColor, "white", "Verify foreground color came from the screen")
-        assert.strictEqual(lastResult.predictedCursorColumn, 2, "Verify predictedCursorColumn is correct")
-        assert.strictEqual(lastResult.predictedCharacters.length, 1, "Verify there is exactly one prediction in lastResult")
-        assert.deepEqual(lastResult.predictedCharacters[0].character, "a", "Verify predicted character is correct")
+        assert.strictEqual(
+            lastResult.backgroundColor,
+            "black",
+            "Verify background color came from the screen",
+        )
+        assert.strictEqual(
+            lastResult.foregroundColor,
+            "white",
+            "Verify foreground color came from the screen",
+        )
+        assert.strictEqual(
+            lastResult.predictedCursorColumn,
+            2,
+            "Verify predictedCursorColumn is correct",
+        )
+        assert.strictEqual(
+            lastResult.predictedCharacters.length,
+            1,
+            "Verify there is exactly one prediction in lastResult",
+        )
+        assert.deepEqual(
+            lastResult.predictedCharacters[0].character,
+            "a",
+            "Verify predicted character is correct",
+        )
     })
 
     it("#1039 - Doesn't add a prediction if it overlaps with an existing character on the screen", () => {
@@ -63,7 +85,7 @@ describe("TypingPredictionManager", () => {
         let callCount = 0
         let lastResult: ITypingPrediction = null
 
-        typingPredictionManager.onPredictionsChanged.subscribe((pd) => {
+        typingPredictionManager.onPredictionsChanged.subscribe(pd => {
             callCount++
             lastResult = pd
         })
@@ -71,8 +93,20 @@ describe("TypingPredictionManager", () => {
         typingPredictionManager.addPrediction("a") // First prediction should succeed
         typingPredictionManager.addPrediction("b") // Second prediction doesn't succeed
 
-        assert.strictEqual(callCount, 1, "Verify only a single call to the prediction handler was made")
-        assert.strictEqual(lastResult.predictedCharacters.length, 1, "Verify there is exactly one prediction in last result")
-        assert.strictEqual(lastResult.predictedCharacters[0].character, "a", "Verify it was the first character entered that got predicted")
+        assert.strictEqual(
+            callCount,
+            1,
+            "Verify only a single call to the prediction handler was made",
+        )
+        assert.strictEqual(
+            lastResult.predictedCharacters.length,
+            1,
+            "Verify there is exactly one prediction in last result",
+        )
+        assert.strictEqual(
+            lastResult.predictedCharacters[0].character,
+            "a",
+            "Verify it was the first character entered that got predicted",
+        )
     })
 })

--- a/browser/test/Services/WindowSplitTests.ts
+++ b/browser/test/Services/WindowSplitTests.ts
@@ -2,32 +2,33 @@ import * as assert from "assert"
 
 import * as WindowSplit from "./../../src/Services/WindowSplit"
 
-function getRoot<T>() { return WindowSplit.createSplitRoot<T>(WindowSplit.SplitDirection.Horizontal, null) }
+function getRoot<T>() {
+    return WindowSplit.createSplitRoot<T>(WindowSplit.SplitDirection.Horizontal, null)
+}
 
 describe("WindowSplit", () => {
-
     describe("applySplit", () => {
         it("adds split to empty root", () => {
-             const root = getRoot<number>()
+            const root = getRoot<number>()
 
-             const leaf = WindowSplit.createSplitLeaf(1)
+            const leaf = WindowSplit.createSplitLeaf(1)
 
-             const result = WindowSplit.applySplit(root, WindowSplit.SplitDirection.Horizontal, leaf)
+            const result = WindowSplit.applySplit(root, WindowSplit.SplitDirection.Horizontal, leaf)
 
-             assert.strictEqual(result.splits.length, 1)
-             assert.strictEqual(result.splits[0], leaf)
+            assert.strictEqual(result.splits.length, 1)
+            assert.strictEqual(result.splits[0], leaf)
         })
     })
 
     describe("closeSplit", () => {
         it("removes split from array", () => {
-             const root = getRoot<number>()
-             const leaf = WindowSplit.createSplitLeaf(1)
-             const result = WindowSplit.applySplit(root, WindowSplit.SplitDirection.Horizontal, leaf)
+            const root = getRoot<number>()
+            const leaf = WindowSplit.createSplitLeaf(1)
+            const result = WindowSplit.applySplit(root, WindowSplit.SplitDirection.Horizontal, leaf)
 
-             const resultAfterClose = WindowSplit.closeSplit(result, 1)
+            const resultAfterClose = WindowSplit.closeSplit(result, 1)
 
-             assert.strictEqual(resultAfterClose.splits.length, 0)
+            assert.strictEqual(resultAfterClose.splits.length, 0)
         })
     })
 })

--- a/browser/test/Services/Workspace/WorkspaceConfigurationTests.ts
+++ b/browser/test/Services/Workspace/WorkspaceConfigurationTests.ts
@@ -10,7 +10,6 @@ import * as TestHelpers from "./../../TestHelpers"
 const MemoryFileSystem = require("memory-fs") // tslint:disable-line
 
 describe("WorkspaceConfiguration", () => {
-
     let mockConfiguration: Mocks.MockConfiguration
     let mockWorkspace: Mocks.MockWorkspace
     let fileSystem: typeof fs | any
@@ -28,8 +27,12 @@ describe("WorkspaceConfiguration", () => {
         workspace1WithConfigPath = path.join(TestHelpers.getRootDirectory(), "workspace1")
         workspace2WithConfigPath = path.join(TestHelpers.getRootDirectory(), "workspace2")
 
-        const dirsToCreate = [workspace1WithConfigPath, workspace2WithConfigPath, workspaceWithNoConfigPath]
-        dirsToCreate.forEach((p) => fileSystem.mkdirpSync(p))
+        const dirsToCreate = [
+            workspace1WithConfigPath,
+            workspace2WithConfigPath,
+            workspaceWithNoConfigPath,
+        ]
+        dirsToCreate.forEach(p => fileSystem.mkdirpSync(p))
 
         const createConfig = (workspacePath: string): string => {
             const configFolderPath = path.join(workspacePath, ".oni")
@@ -42,17 +45,24 @@ describe("WorkspaceConfiguration", () => {
         workspace1ConfigFilePath = createConfig(workspace1WithConfigPath)
         workspace2ConfigFilePath = createConfig(workspace2WithConfigPath)
 
-        mockConfiguration =  new Mocks.MockConfiguration()
+        mockConfiguration = new Mocks.MockConfiguration()
         mockWorkspace = new Mocks.MockWorkspace()
-
     })
 
     it("setting directory before WorkspaceConfiguration is initialized loads configuration", () => {
         mockWorkspace.changeDirectory(workspace1WithConfigPath)
 
         const ws = new WorkspaceConfiguration(mockConfiguration as any, mockWorkspace, fileSystem)
-        assert.strictEqual(ws.activeWorkspaceConfiguration, workspace1ConfigFilePath, "Validate correct workspace is picked up")
-        assert.deepEqual(mockConfiguration.currentConfigurationFiles, [workspace1ConfigFilePath], "Validate configuration file was added")
+        assert.strictEqual(
+            ws.activeWorkspaceConfiguration,
+            workspace1ConfigFilePath,
+            "Validate correct workspace is picked up",
+        )
+        assert.deepEqual(
+            mockConfiguration.currentConfigurationFiles,
+            [workspace1ConfigFilePath],
+            "Validate configuration file was added",
+        )
     })
 
     it("changing from one workspace to another causes first config to be removed", () => {
@@ -61,8 +71,16 @@ describe("WorkspaceConfiguration", () => {
         mockWorkspace.changeDirectory(workspace1WithConfigPath)
         mockWorkspace.changeDirectory(workspace2WithConfigPath)
 
-        assert.strictEqual(ws.activeWorkspaceConfiguration, workspace2ConfigFilePath, "Validate correct workspace is picked up")
-        assert.deepEqual(mockConfiguration.currentConfigurationFiles, [workspace2ConfigFilePath], "Validate configuration file was added")
+        assert.strictEqual(
+            ws.activeWorkspaceConfiguration,
+            workspace2ConfigFilePath,
+            "Validate correct workspace is picked up",
+        )
+        assert.deepEqual(
+            mockConfiguration.currentConfigurationFiles,
+            [workspace2ConfigFilePath],
+            "Validate configuration file was added",
+        )
     })
 
     it("changing directory causes new config to be loaded", () => {
@@ -70,7 +88,15 @@ describe("WorkspaceConfiguration", () => {
 
         mockWorkspace.changeDirectory(workspace1WithConfigPath)
 
-        assert.strictEqual(ws.activeWorkspaceConfiguration, workspace1ConfigFilePath, "Validate correct workspace is picked up")
-        assert.deepEqual(mockConfiguration.currentConfigurationFiles, [workspace1ConfigFilePath], "Validate configuration file was added")
+        assert.strictEqual(
+            ws.activeWorkspaceConfiguration,
+            workspace1ConfigFilePath,
+            "Validate correct workspace is picked up",
+        )
+        assert.deepEqual(
+            mockConfiguration.currentConfigurationFiles,
+            [workspace1ConfigFilePath],
+            "Validate configuration file was added",
+        )
     })
 })

--- a/browser/test/UtilityTests.ts
+++ b/browser/test/UtilityTests.ts
@@ -4,8 +4,15 @@ import * as rxjs from "rxjs"
 
 import * as Utility from "./../src/Utility"
 
-interface PromiseInfo { resolve: (val: any) => void, reject: (err: Error) => void }
-interface PromiseCreationResult { info: PromiseInfo[], inputs: any[], promiseCreator: (input: any) => Promise<any> }
+interface PromiseInfo {
+    resolve: (val: any) => void
+    reject: (err: Error) => void
+}
+interface PromiseCreationResult {
+    info: PromiseInfo[]
+    inputs: any[]
+    promiseCreator: (input: any) => Promise<any>
+}
 const createPromiseFunction = (): PromiseCreationResult => {
     const info: any[] = []
     const inputs: any[] = []
@@ -27,57 +34,69 @@ const createPromiseFunction = (): PromiseCreationResult => {
 
 describe("Utility", () => {
     describe("ignoreWhilePendingPromise", () => {
+        let subject: rxjs.Subject<any>
 
-            let subject: rxjs.Subject<any>
+        beforeEach(() => {
+            subject = new rxjs.Subject()
+        })
 
-            beforeEach(() => {
-                subject = new rxjs.Subject()
+        it("Executes promise function in response to observable input", () => {
+            const promiseFunction = createPromiseFunction()
+
+            const outputObservable$ = Utility.ignoreWhilePendingPromise(
+                subject,
+                promiseFunction.promiseCreator,
+            )
+
+            const outputs: any[] = []
+            outputObservable$.subscribe(val => {
+                outputs.push(val)
             })
 
-            it("Executes promise function in response to observable input", () => {
-                const promiseFunction = createPromiseFunction()
+            // Resolve the promise that gets fired as a result of subject triggered
+            subject.next(5)
+            promiseFunction.info[0].resolve("a")
 
-                const outputObservable$ = Utility.ignoreWhilePendingPromise(subject, promiseFunction.promiseCreator)
+            return outputObservable$
+                .take(1)
+                .toPromise()
+                .then(() => {
+                    assert.deepEqual(promiseFunction.inputs, [5])
+                    assert.deepEqual(outputs, ["a"])
+                })
+        })
 
-                const outputs: any[] = []
-                outputObservable$.subscribe((val) => { outputs.push(val) })
+        it("Does not dispatch promise function while previous is still pending", () => {
+            const promiseFunction = createPromiseFunction()
 
-                // Resolve the promise that gets fired as a result of subject triggered
-                subject.next(5)
-                promiseFunction.info[0].resolve("a")
+            const outputObservable$ = Utility.ignoreWhilePendingPromise(
+                subject,
+                promiseFunction.promiseCreator,
+            )
 
-                return outputObservable$.take(1).toPromise()
-                    .then(() => {
-                        assert.deepEqual(promiseFunction.inputs, [5])
-                        assert.deepEqual(outputs, ["a"])
-                    })
+            const outputs: any[] = []
+            outputObservable$.subscribe(val => {
+                outputs.push(val)
             })
 
-            it("Does not dispatch promise function while previous is still pending", () => {
-                const promiseFunction = createPromiseFunction()
+            // Bring in multiple inputs
+            subject.next(5)
+            subject.next(6)
+            subject.next(7)
+            subject.next(8)
+            promiseFunction.info[0].resolve("a")
 
-                const outputObservable$ = Utility.ignoreWhilePendingPromise(subject, promiseFunction.promiseCreator)
-
-                const outputs: any[] = []
-                outputObservable$.subscribe((val) => { outputs.push(val) })
-
-                // Bring in multiple inputs
-                subject.next(5)
-                subject.next(6)
-                subject.next(7)
-                subject.next(8)
-                promiseFunction.info[0].resolve("a")
-
-                return outputObservable$.take(1).toPromise()
-                    .then(() => {
-                        // Only 5 & 7 should've been dispatched to the function,
-                        // because the observable should've been held
-                        // while the first promise was in flight,
-                        // and 8 would've been dispatched when the promise for 5 was completed.
-                        assert.deepEqual(promiseFunction.inputs, [5, 8])
-                        assert.deepEqual(outputs, ["a"])
-                    })
-            })
-
+            return outputObservable$
+                .take(1)
+                .toPromise()
+                .then(() => {
+                    // Only 5 & 7 should've been dispatched to the function,
+                    // because the observable should've been held
+                    // while the first promise was in flight,
+                    // and 8 would've been dispatched when the promise for 5 was completed.
+                    assert.deepEqual(promiseFunction.inputs, [5, 8])
+                    assert.deepEqual(outputs, ["a"])
+                })
+        })
     })
 })

--- a/main/src/ProcessLifecycle.ts
+++ b/main/src/ProcessLifecycle.ts
@@ -14,7 +14,7 @@ const pendingAppReadyCallbacks = []
 app.on("ready", () => {
     isAppReady = true
 
-    pendingAppReadyCallbacks.forEach((callback) => callback())
+    pendingAppReadyCallbacks.forEach(callback => callback())
 })
 
 app.on("will-quit", () => {
@@ -28,7 +28,7 @@ app.on("will-quit", () => {
     }
 })
 
-const waitForAppReady = (callback) => {
+const waitForAppReady = callback => {
     if (isAppReady) {
         callback()
     } else {
@@ -38,7 +38,6 @@ const waitForAppReady = (callback) => {
 
 // Inspired by atom's workaround in `atom-application.coffee`
 export const makeSingleInstance = (options, callbackFunction) => {
-
     const socketPath = getSocketPath()
 
     const initializePrimaryInstance = () => {
@@ -49,10 +48,10 @@ export const makeSingleInstance = (options, callbackFunction) => {
 
         deleteSocketFile(socketPath)
 
-        const server = net.createServer((connection) => {
+        const server = net.createServer(connection => {
             let data = ""
 
-            connection.on("data", (chunk) => {
+            connection.on("data", chunk => {
                 data = data + chunk
             })
 
@@ -93,7 +92,7 @@ export const makeSingleInstance = (options, callbackFunction) => {
     })
 }
 
-const deleteSocketFile = (socketPath) => {
+const deleteSocketFile = socketPath => {
     if (process.platform === "win32") {
         return
     }
@@ -110,7 +109,6 @@ const deleteSocketFile = (socketPath) => {
                 throw error
             }
         }
-
     }
 }
 
@@ -121,7 +119,6 @@ const getSocketFileName = () => {
 }
 
 const getSocketPath = () => {
-
     const socketFile = getSocketFileName()
 
     if (process.platform === "win32") {
@@ -129,7 +126,6 @@ const getSocketPath = () => {
     } else {
         return path.join(os.tmpdir(), socketFile + ".sock")
     }
-
 }
 
 const getUserName = () => {

--- a/main/src/installDevTools.ts
+++ b/main/src/installDevTools.ts
@@ -7,7 +7,11 @@
 import * as Log from "./Log"
 export default async () => {
     try {
-        const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS, default: installExtension } = require("electron-devtools-installer")
+        const {
+            REACT_DEVELOPER_TOOLS,
+            REDUX_DEVTOOLS,
+            default: installExtension,
+        } = require("electron-devtools-installer")
         try {
             const reduxExt = await installExtension(REDUX_DEVTOOLS)
             Log.info(`Added extension: ${reduxExt}`)
@@ -17,6 +21,8 @@ export default async () => {
             Log.info(`An error occurred: ${e}`)
         }
     } catch (ex) {
-        Log.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
+        Log.warn(
+            "Unable to install developer tools. `electron-devtools-installer` may not be available in this environment",
+        )
     }
 }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -16,12 +16,12 @@ const isDebug = process.argv.filter(arg => arg.indexOf("--debug") >= 0).length >
 
 interface IWindowState {
     bounds?: {
-        x: number,
-        y: number,
-        height: number,
-        width: number,
+        x: number
+        y: number
+        height: number
+        width: number
     }
-    isMaximized?: boolean,
+    isMaximized?: boolean
 }
 
 let windowState: IWindowState = {
@@ -69,11 +69,10 @@ let mainWindow: BrowserWindow = null
 // Only enable 'single-instance' mode when we're not in the hot-reload mode
 // Otherwise, all other open instances will also pick up the webpack bundle
 if (!isDevelopment && !isDebug) {
-
     let processArgs = process.argv || []
 
     // If running from spectron, ignore the arguments
-    if (processArgs.find((f) => f.indexOf("--test-type=webdriver") >= 0)) {
+    if (processArgs.find(f => f.indexOf("--test-type=webdriver") >= 0)) {
         Log.warn("Clearing arguments because running from automation!")
         processArgs = []
     }
@@ -84,7 +83,7 @@ if (!isDevelopment && !isDebug) {
     }
 
     Log.info("Making single instance...")
-    makeSingleInstance(currentOptions, (options) => {
+    makeSingleInstance(currentOptions, options => {
         Log.info("Creating single instance")
         loadFileFromArguments(process.platform, options.args, options.workingDirectory)
     })
@@ -108,17 +107,22 @@ export function createWindow(
     workingDirectory,
     delayedEvent: IDelayedEvent = null,
 ) {
-    Log.info(`Creating window with arguments: ${commandLineArguments} and working directory: ${workingDirectory}`)
+    Log.info(
+        `Creating window with arguments: ${commandLineArguments} and working directory: ${workingDirectory}`,
+    )
     const webPreferences = {
         blinkFeatures: "ResizeObserver,Accelerated2dCanvas,Canvas2dFixedRenderingMode",
     }
 
-    const backgroundColor = (PersistentSettings.get("_internal.lastBackgroundColor") as string) || "#1E2127"
+    const backgroundColor =
+        (PersistentSettings.get("_internal.lastBackgroundColor") as string) || "#1E2127"
 
     try {
         const internalWindowState = PersistentSettings.get("_internal.windowState") as IWindowState
-        if (internalWindowState &&
-            (internalWindowState.bounds || internalWindowState.isMaximized)) {
+        if (
+            internalWindowState &&
+            (internalWindowState.bounds || internalWindowState.isMaximized)
+        ) {
             windowState = internalWindowState
         }
     } catch (e) {
@@ -135,7 +139,7 @@ export function createWindow(
         webPreferences,
         backgroundColor,
         titleBarStyle: "hidden",
-        x:  windowState.bounds.x,
+        x: windowState.bounds.x,
         y: windowState.bounds.y,
         height: windowState.bounds.height,
         width: windowState.bounds.width,
@@ -153,7 +157,7 @@ export function createWindow(
         })
     })
 
-    ipcMain.once("Oni.started", (evt) => {
+    ipcMain.once("Oni.started", evt => {
         Log.info("Oni started")
 
         if (delayedEvent) {

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -29,7 +29,7 @@ export const buildMenu = (mainWindow, loadInit) => {
         createWindow([], process.cwd(), delayedEvent)
     }
 
-    const normalizePath = (fileName) => fileName.split("\\").join("/")
+    const normalizePath = fileName => fileName.split("\\").join("/")
 
     const executeVimCommand = (browserWindow: BrowserWindow, command: string) => {
         executeMenuAction(browserWindow, { evt: "menu-item-click", cmd: [command] })
@@ -44,7 +44,7 @@ export const buildMenu = (mainWindow, loadInit) => {
     }
 
     const executeOniCommand = (browserWindow: BrowserWindow, command: string) => {
-            executeMenuAction(browserWindow, { evt: "execute-command", cmd: [command] })
+        executeMenuAction(browserWindow, { evt: "execute-command", cmd: [command] })
     }
 
     const openUrl = (browserWindow: BrowserWindow, url: string) => {
@@ -56,7 +56,9 @@ export const buildMenu = (mainWindow, loadInit) => {
             return
         }
 
-        files.forEach((fileName) => executeVimCommand(browserWindow, `${command} ${normalizePath(fileName)}`))
+        files.forEach(fileName =>
+            executeVimCommand(browserWindow, `${command} ${normalizePath(fileName)}`),
+        )
     }
 
     const isWindows = os.platform() === "win32"
@@ -74,14 +76,12 @@ export const buildMenu = (mainWindow, loadInit) => {
     }
 
     if (loadInit) {
-        preferences.submenu.push(
-            {
-                label: "Edit Neovim config",
-                click(item, focusedWindow) {
-                    executeOniCommand(focusedWindow, "oni.config.openInitVim")
-                },
+        preferences.submenu.push({
+            label: "Edit Neovim config",
+            click(item, focusedWindow) {
+                executeOniCommand(focusedWindow, "oni.config.openInitVim")
             },
-        )
+        })
     }
 
     const reopenWithEncoding = {
@@ -91,7 +91,50 @@ export const buildMenu = (mainWindow, loadInit) => {
 
     // TODO: Maybe better show normal encoding name in submenu?
     // Encoding list from http://vimdoc.sourceforge.net/htmldoc/mbyte.html#encoding-values
-    const encodingList = ["utf-8", "utf-16le", "utf-16be", "utf-32le", "utf-32be", "latin1", "koi8-r", "koi8-u", "macroman", "cp437", "cp737", "cp775", "cp850", "cp852", "cp855", "cp857", "cp860", "cp861", "cp862", "cp863", "cp865", "cp866", "cp869", "cp874", "cp1250", "cp1251", "cp1253", "cp1254", "cp1255", "cp1256", "cp1257", "cp1258", "cp932", "euc-jp", "sjis", "cp949", "euc-kr", "cp936", "euc-cn", "cp950", "big5", "euc-tw"].map((val) => {
+    const encodingList = [
+        "utf-8",
+        "utf-16le",
+        "utf-16be",
+        "utf-32le",
+        "utf-32be",
+        "latin1",
+        "koi8-r",
+        "koi8-u",
+        "macroman",
+        "cp437",
+        "cp737",
+        "cp775",
+        "cp850",
+        "cp852",
+        "cp855",
+        "cp857",
+        "cp860",
+        "cp861",
+        "cp862",
+        "cp863",
+        "cp865",
+        "cp866",
+        "cp869",
+        "cp874",
+        "cp1250",
+        "cp1251",
+        "cp1253",
+        "cp1254",
+        "cp1255",
+        "cp1256",
+        "cp1257",
+        "cp1258",
+        "cp932",
+        "euc-jp",
+        "sjis",
+        "cp949",
+        "euc-kr",
+        "cp936",
+        "euc-cn",
+        "cp950",
+        "big5",
+        "euc-tw",
+    ].map(val => {
         return {
             label: val.toUpperCase(),
             click(item, focusedWindow) {
@@ -119,7 +162,8 @@ export const buildMenu = (mainWindow, loadInit) => {
                     dialog.showOpenDialog(
                         focusedWindow,
                         { properties: ["openFile", "multiSelections"] },
-                        (files) => executeVimCommandForMultipleFiles(focusedWindow, ":tabnew ", files),
+                        files =>
+                            executeVimCommandForMultipleFiles(focusedWindow, ":tabnew ", files),
                     )
                 },
             },
@@ -133,9 +177,8 @@ export const buildMenu = (mainWindow, loadInit) => {
             {
                 label: "Split Open…",
                 click(item, focusedWindow) {
-                    dialog.showOpenDialog(
-                        focusedWindow, { properties: ["openFile"] },
-                        (files) => executeVimCommandForFiles(focusedWindow, ":sp", files),
+                    dialog.showOpenDialog(focusedWindow, { properties: ["openFile"] }, files =>
+                        executeVimCommandForFiles(focusedWindow, ":sp", files),
                     )
                 },
             },
@@ -166,7 +209,7 @@ export const buildMenu = (mainWindow, loadInit) => {
             {
                 label: "Save As…",
                 click(item, focusedWindow) {
-                    dialog.showSaveDialog(focusedWindow, {}, (name) => {
+                    dialog.showSaveDialog(focusedWindow, {}, name => {
                         if (name) {
                             executeVimCommand(focusedWindow, ":save " + normalizePath(name))
                         }
@@ -277,37 +320,61 @@ export const buildMenu = (mainWindow, loadInit) => {
                     {
                         label: "Full Path",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":let @" + (isWindows ? "*" : "+") + "=expand('%:p')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":let @" + (isWindows ? "*" : "+") + "=expand('%:p')",
+                            )
                         },
                     },
                     {
                         label: "Full Path with Line Number",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":let @" + (isWindows ? "*" : "+") + "=expand('%:p') . ':' . line('.')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":let @" +
+                                    (isWindows ? "*" : "+") +
+                                    "=expand('%:p') . ':' . line('.')",
+                            )
                         },
                     },
                     {
                         label: "Relative Path",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":let @" + (isWindows ? "*" : "+") + "=expand('%')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":let @" + (isWindows ? "*" : "+") + "=expand('%')",
+                            )
                         },
                     },
                     {
                         label: "Relative Path with Line Number",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":let @" + (isWindows ? "*" : "+") + "=expand('%') . ':' . line('.')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":let @" +
+                                    (isWindows ? "*" : "+") +
+                                    "=expand('%') . ':' . line('.')",
+                            )
                         },
                     },
                     {
                         label: "File Name",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":let @" + (isWindows ? "*" : "+") + "=expand('%:t')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":let @" + (isWindows ? "*" : "+") + "=expand('%:t')",
+                            )
                         },
                     },
                     {
                         label: "File Name with Line Number",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":let @" + (isWindows ? "*" : "+") + "=expand('%:t') . ':' . line('.')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":let @" +
+                                    (isWindows ? "*" : "+") +
+                                    "=expand('%:t') . ':' . line('.')",
+                            )
                         },
                     },
                 ],
@@ -389,7 +456,6 @@ export const buildMenu = (mainWindow, loadInit) => {
                         click(item, focusedWindow) {
                             executeVimCommand(focusedWindow, "J")
                         },
-
                     },
                 ],
             },
@@ -450,8 +516,8 @@ export const buildMenu = (mainWindow, loadInit) => {
                     {
                         label: "Strip Trailings Blanks",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":%s/^\s\+//")
-                            executeVimCommand(focusedWindow, ":%s/\s\+$//")
+                            executeVimCommand(focusedWindow, ":%s/^s+//")
+                            executeVimCommand(focusedWindow, ":%s/s+$//")
                         },
                     },
                     {
@@ -500,7 +566,10 @@ export const buildMenu = (mainWindow, loadInit) => {
                     {
                         label: "Date / Time (Long)",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":put =strftime('%a, %d %b %Y %H:%M:%S')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":put =strftime('%a, %d %b %Y %H:%M:%S')",
+                            )
                         },
                     },
                     {
@@ -521,7 +590,10 @@ export const buildMenu = (mainWindow, loadInit) => {
                     {
                         label: "File Name with Line Number",
                         click(item, focusedWindow) {
-                            executeVimCommand(focusedWindow, ":put =expand('%:t') . ':' . line('.')")
+                            executeVimCommand(
+                                focusedWindow,
+                                ":put =expand('%:t') . ':' . line('.')",
+                            )
                         },
                     },
                 ],
@@ -541,7 +613,7 @@ export const buildMenu = (mainWindow, loadInit) => {
     // Window menu
     menu.push({
         label: "Split",
-        submenu : [
+        submenu: [
             {
                 label: "New Horizontal Split",
                 click(item, focusedWindow) {

--- a/package.json
+++ b/package.json
@@ -1,309 +1,312 @@
 {
-  "name": "oni",
-  "author": "",
-  "email": "bryphe@outlook.com",
-  "homepage": "https://www.onivim.io",
-  "version": "0.2.21",
-  "description": "NeoVim front-end with IDE-style extensibility",
-  "keywords": [
-    "vim",
-    "neovim",
-    "text",
-    "editor",
-    "ide",
-    "vim"
-  ],
-  "main": "./lib/main/src/main.js",
-  "bin": {
-    "oni": "./cli/oni",
-    "oni-vim": "./cli/oni"
-  },
-  "build": {
-    "asar": false,
-    "productName": "Oni",
-    "appId": "com.extropy.oni",
-    "files": [
-      "**/*",
-      "!**/*.oni",
-      "!**/*.vscode",
-      "!app",
-      "!assets",
-      "!browser",
-      "!bin",
-      "!build",
-      "!examples",
-      "!lib_test",
-      "!test",
-      "!node_modules/typescript"
-    ],
-    "extraResources": [
-      {
-        "from": "node_modules/typescript",
-        "to": "app/node_modules/typescript"
-      }
-    ],
-    "mac": {
-      "artifactName": "${productName}-${version}-osx.${ext}",
-      "category": "public.app-category.developer-tools",
-      "target": [
-        "dmg"
-      ],
-      "files": [
-        "bin/osx/**/*"
-      ]
+    "name": "oni",
+    "author": "",
+    "email": "bryphe@outlook.com",
+    "homepage": "https://www.onivim.io",
+    "version": "0.2.21",
+    "description": "NeoVim front-end with IDE-style extensibility",
+    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
+    "main": "./lib/main/src/main.js",
+    "bin": {
+        "oni": "./cli/oni",
+        "oni-vim": "./cli/oni"
     },
-    "linux": {
-      "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
-      "maintainer": "bryphe@outlook.com",
-      "target": [
-        "tar.gz",
-        "deb",
-        "rpm"
-      ]
+    "build": {
+        "asar": false,
+        "productName": "Oni",
+        "appId": "com.extropy.oni",
+        "files": [
+            "**/*",
+            "!**/*.oni",
+            "!**/*.vscode",
+            "!app",
+            "!assets",
+            "!browser",
+            "!bin",
+            "!build",
+            "!examples",
+            "!lib_test",
+            "!test",
+            "!node_modules/typescript"
+        ],
+        "extraResources": [
+            {
+                "from": "node_modules/typescript",
+                "to": "app/node_modules/typescript"
+            }
+        ],
+        "mac": {
+            "artifactName": "${productName}-${version}-osx.${ext}",
+            "category": "public.app-category.developer-tools",
+            "target": ["dmg"],
+            "files": ["bin/osx/**/*"]
+        },
+        "linux": {
+            "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
+            "maintainer": "bryphe@outlook.com",
+            "target": ["tar.gz", "deb", "rpm"]
+        },
+        "win": {
+            "target": ["zip", "dir"],
+            "files": ["bin/x86/**/*"]
+        },
+        "fileAssociations": [
+            {
+                "ext": "js",
+                "name": "javascript",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "json",
+                "name": "JSON",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "jsx",
+                "name": "JSX",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "py",
+                "name": "Python",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "go",
+                "name": "Go Lang",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "re",
+                "name": "Reason",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "vim",
+                "name": "VimL",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "ts",
+                "name": "Typescript",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "tsx",
+                "name": "Typescript",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "css",
+                "name": "CSS",
+                "role": "Editor",
+                "isPackage": true
+            }
+        ]
     },
-    "win": {
-      "target": [
-        "zip",
-        "dir"
-      ],
-      "files": [
-        "bin/x86/**/*"
-      ]
+    "scripts": {
+        "precommit": "pretty-quick --staged",
+        "prepush": "npm run build && npm run lint",
+        "build": "npm run build:browser && npm run build:main && npm run build:plugins",
+        "build-debug": "npm run build:browser-debug && npm run build:plugins",
+        "build:browser": "webpack --config browser/webpack.production.config.js",
+        "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
+        "build:main": "cd main && tsc -p tsconfig.json",
+        "build:plugins":
+            "npm run build:plugin:oni-layer-browser && npm run build:plugin:oni-plugin-typescript && npm run build:plugin:oni-plugin-markdown-preview",
+        "build:plugin:oni-layer-browser": "cd extensions/oni-layer-browser && npm run build",
+        "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && npm run build",
+        "build:plugin:oni-plugin-markdown-preview":
+            "cd extensions/oni-plugin-markdown-preview && npm run build",
+        "build:test": "npm run build:test:unit && npm run build:test:integration",
+        "build:test:integration": "cd test && tsc -p tsconfig.json",
+        "build:test:unit": "cd browser && tsc -p tsconfig.test.json",
+        "copy-icons": "node build/CopyIcons.js",
+        "debug:test:unit:browser":
+            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo": "npm run build:test && mocha -t 30000 lib_test/test/Demo.js",
+        "dist:win":
+            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "pack:win":
+            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "test": "npm run test:unit && npm run test:integration",
+        "test:integration": "npm run build:test && mocha -t 120000 lib_test/test/CiTests.js",
+        "test:unit": "npm run test:unit:browser",
+        "test:unit:browser":
+            "npm run build:test:unit && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "fix-lint":
+            "npm run fix-lint:browser && npm run fix-lint:main && npm run fix-lint:test && npm run fix-lint:plugins",
+        "fix-lint:browser":
+            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:plugins": "npm run fix-lint:plugins:oni-layer-browser",
+        "fix-lint:plugins:oni-layer-browser":
+            "tslint --fix --project extensions/oni-layer-browser/tsconfig.json --config tslint.json",
+        "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
+        "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
+        "lint":
+            "npm run lint:browser && npm run lint:main && npm run lint:test && npm run lint:plugins",
+        "lint:plugins": "npm run lint:plugin:oni-layer-browser",
+        "lint:plugin:oni-layer-browser":
+            "tslint --project extensions/oni-layer-browser/tsconfig.json --config tslint.json",
+        "lint:browser":
+            "tslint --project browser/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
+        "lint:test":
+            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
+        "prettier": "prettier ./browser && prettier ./main && prettier ./test",
+        "ccov:instrument":
+            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser":
+            "cd browser && cross-env ONI_CCOV=1 electron-mocha --renderer --require testHelpers.js -R testCoverageReporter --recursive ../lib_test/browser/test",
+        "ccov:report": "nyc report && nyc report --reporter=html && nyc report --reporter=lcov",
+        "start":
+            "concurrently --kill-others \"npm run start-hot\" \"npm run watch:browser\" \"npm run watch:plugins\"",
+        "start-hot":
+            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start-not-dev": "cross-env electron main.js",
+        "watch:browser":
+            "webpack-dev-server --config browser/webpack.debug.config.js --host localhost --port 8191",
+        "watch:plugins":
+            "npm run watch:plugins:oni-layer-browser && npm run watch:plugins:oni-plugin-typescript && npm run watch:plugins:oni-plugin-markdown-preview",
+        "watch:plugins:oni-layer-browser": "cd extensions/oni-layer-browser && tsc --watch",
+        "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
+        "watch:plugins:oni-plugin-markdown-preview":
+            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "uninstall-global": "npm rm -g oni-vim",
+        "install-global": "npm install -g oni-vim",
+        "install:plugins": "npm run install:plugins:oni-plugin-markdown-preview",
+        "install:plugins:oni-plugin-markdown-preview":
+            "cd extensions/oni-plugin-markdown-preview && npm install --prod",
+        "postinstall": "npm run install:plugins && electron-rebuild && opencollective postinstall",
+        "profile:webpack":
+            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
-    "fileAssociations": [
-      {
-        "ext": "js",
-        "name": "javascript",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "json",
-        "name": "JSON",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "jsx",
-        "name": "JSX",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "py",
-        "name": "Python",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "go",
-        "name": "Go Lang",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "re",
-        "name": "Reason",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "vim",
-        "name": "VimL",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "ts",
-        "name": "Typescript",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "tsx",
-        "name": "Typescript",
-        "role": "Editor",
-        "isPackage": true
-      },
-      {
-        "ext": "css",
-        "name": "CSS",
-        "role": "Editor",
-        "isPackage": true
-      }
-    ]
-  },
-  "scripts": {
-    "precommit": "pretty-quick --staged",
-    "prepush": "npm run build && npm run lint",
-    "build": "npm run build:browser && npm run build:main && npm run build:plugins",
-    "build-debug": "npm run build:browser-debug && npm run build:plugins",
-    "build:browser": "webpack --config browser/webpack.production.config.js",
-    "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
-    "build:main": "cd main && tsc -p tsconfig.json",
-    "build:plugins": "npm run build:plugin:oni-layer-browser && npm run build:plugin:oni-plugin-typescript && npm run build:plugin:oni-plugin-markdown-preview",
-    "build:plugin:oni-layer-browser": "cd extensions/oni-layer-browser && npm run build",
-    "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && npm run build",
-    "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && npm run build",
-    "build:test": "npm run build:test:unit && npm run build:test:integration",
-    "build:test:integration": "cd test && tsc -p tsconfig.json",
-    "build:test:unit": "cd browser && tsc -p tsconfig.test.json",
-    "copy-icons": "node build/CopyIcons.js",
-    "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-    "demo": "npm run build:test && mocha -t 30000 lib_test/test/Demo.js",
-    "dist:win": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-    "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
-    "test": "npm run test:unit && npm run test:integration",
-    "test:integration": "npm run build:test && mocha -t 120000 lib_test/test/CiTests.js",
-    "test:unit": "npm run test:unit:browser",
-    "test:unit:browser": "npm run build:test:unit && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-    "fix-lint": "npm run fix-lint:browser && npm run fix-lint:main && npm run fix-lint:test && npm run fix-lint:plugins",
-    "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
-    "fix-lint:plugins": "npm run fix-lint:plugins:oni-layer-browser",
-    "fix-lint:plugins:oni-layer-browser": "tslint --fix --project extensions/oni-layer-browser/tsconfig.json --config tslint.json",
-    "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
-    "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
-    "lint": "npm run lint:browser && npm run lint:main && npm run lint:test && npm run lint:plugins",
-    "lint:plugins": "npm run lint:plugin:oni-layer-browser",
-    "lint:plugin:oni-layer-browser": "tslint --project extensions/oni-layer-browser/tsconfig.json --config tslint.json",
-    "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
-    "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-    "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
-    "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-    "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-    "ccov:test:browser": "cd browser && cross-env ONI_CCOV=1 electron-mocha --renderer --require testHelpers.js -R testCoverageReporter --recursive ../lib_test/browser/test",
-    "ccov:report": "nyc report && nyc report --reporter=html && nyc report --reporter=lcov",
-    "start": "concurrently --kill-others \"npm run start-hot\" \"npm run watch:browser\" \"npm run watch:plugins\"",
-    "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
-    "start-not-dev": "cross-env electron main.js",
-    "watch:browser": "webpack-dev-server --config browser/webpack.debug.config.js --host localhost --port 8191",
-    "watch:plugins": "npm run watch:plugins:oni-layer-browser && npm run watch:plugins:oni-plugin-typescript && npm run watch:plugins:oni-plugin-markdown-preview",
-    "watch:plugins:oni-layer-browser": "cd extensions/oni-layer-browser && tsc --watch",
-    "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-    "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
-    "uninstall-global": "npm rm -g oni-vim",
-    "install-global": "npm install -g oni-vim",
-    "install:plugins": "npm run install:plugins:oni-plugin-markdown-preview",
-    "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && npm install --prod",
-    "postinstall": "npm run install:plugins && electron-rebuild && opencollective postinstall",
-    "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bryphe/oni"
-  },
-  "license": "MIT",
-  "dependencies": {
-    "@types/marked": "^0.3.0",
-    "@types/redux-batched-subscribe": "^0.1.2",
-    "dompurify": "1.0.2",
-    "electron-settings": "^3.1.4",
-    "find-up": "2.1.0",
-    "keyboard-layout": "2.0.13",
-    "marked": "^0.3.6",
-    "minimist": "1.2.0",
-    "msgpack-lite": "0.1.26",
-    "ocaml-language-server": "1.0.12",
-    "oni-api": "0.0.24",
-    "oni-neovim-binaries": "0.1.0",
-    "oni-ripgrep": "0.0.3",
-    "oni-types": "0.0.4",
-    "react": "16.0.0",
-    "react-dom": "16.0.0",
-    "react-electron-web-view": "^2.0.1",
-    "redux-batched-subscribe": "^0.1.6",
-    "shell-env": "^0.3.0",
-    "shelljs": "0.7.7",
-    "styled-components": "^2.3.0",
-    "typescript": "2.6.1",
-    "vscode-css-languageserver-bin": "^1.2.1",
-    "vscode-html-languageserver-bin": "^1.1.0",
-    "vscode-jsonrpc": "3.5.0",
-    "vscode-languageserver": "3.5.0",
-    "vscode-languageserver-types": "3.5.0",
-    "vscode-textmate": "3.2.0"
-  },
-  "devDependencies": {
-    "@types/classnames": "0.0.32",
-    "@types/color": "2.0.0",
-    "@types/electron-settings": "^3.1.1",
-    "@types/jsdom": "11.0.0",
-    "@types/lodash": "4.14.38",
-    "@types/lolex": "2.1.0",
-    "@types/memory-fs": "^0.3.0",
-    "@types/minimatch": "3.0.1",
-    "@types/minimist": "1.1.29",
-    "@types/mkdirp": "0.3.29",
-    "@types/mocha": "2.2.33",
-    "@types/msgpack-lite": "0.1.4",
-    "@types/node": "8.0.53",
-    "@types/react-dom": "16.0.3",
-    "@types/react-motion": "0.0.23",
-    "@types/react-redux": "5.0.12",
-    "@types/react-transition-group": "2.0.6",
-    "@types/shelljs": "^0.7.7",
-    "@types/sinon": "1.16.32",
-    "autoprefixer": "6.4.0",
-    "babili-webpack-plugin": "0.1.2",
-    "bs-platform": "1.8.0",
-    "classnames": "2.2.5",
-    "color": "2.0.0",
-    "concurrently": "3.1.0",
-    "coveralls": "^3.0.0",
-    "cross-env": "3.1.3",
-    "css-loader": "0.28.4",
-    "electron": "1.8.1",
-    "electron-builder": "19.46.4",
-    "electron-devtools-installer": "2.2.1",
-    "electron-mocha": "5.0.0",
-    "electron-rebuild": "1.6.0",
-    "extract-zip": "1.6.0",
-    "fs-extra": "4.0.2",
-    "fuse.js": "2.6.2",
-    "github-releases": "^0.4.1",
-    "husky": "^0.14.3",
-    "innosetup-compiler": "5.5.9",
-    "jsdom": "11.0.0",
-    "less": "2.7.1",
-    "less-loader": "4.0.5",
-    "less-plugin-autoprefix": "1.5.1",
-    "lodash": "4.17.0",
-    "lolex": "2.3.1",
-    "memory-fs": "^0.4.1",
-    "minimatch": "3.0.4",
-    "mkdirp": "0.5.1",
-    "mocha": "3.1.2",
-    "nyc": "^11.4.1",
-    "oni-release-downloader": "0.0.8",
-    "opencollective": "1.0.3",
-    "optimize-js-plugin": "0.0.4",
-    "prettier": "^1.10.2",
-    "pretty-quick": "^1.2.2",
-    "react-hot-loader": "1.3.1",
-    "react-motion": "0.5.2",
-    "react-redux": "5.0.6",
-    "react-transition-group": "2.2.1",
-    "redux": "3.7.2",
-    "redux-observable": "0.17.0",
-    "redux-thunk": "2.2.0",
-    "reselect": "3.0.1",
-    "rxjs": "5.5.0",
-    "sinon": "1.17.6",
-    "spectron": "3.6.2",
-    "style-loader": "0.18.2",
-    "sudo-prompt": "7.1.1",
-    "ts-loader": "2.3.2",
-    "tslint": "5.7.0",
-    "vscode-snippet-parser": "0.0.5",
-    "wcwidth": "1.0.1",
-    "webdriverio": "4.8.0",
-    "webpack": "3.5.3",
-    "webpack-bundle-analyzer": "^2.9.1",
-    "webpack-dev-server": "2.7.1"
-  },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/oni",
-    "logo": "https://opencollective.com/opencollective/logo.txt"
-  }
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bryphe/oni"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "@types/marked": "^0.3.0",
+        "@types/redux-batched-subscribe": "^0.1.2",
+        "dompurify": "1.0.2",
+        "electron-settings": "^3.1.4",
+        "find-up": "2.1.0",
+        "keyboard-layout": "2.0.13",
+        "marked": "^0.3.6",
+        "minimist": "1.2.0",
+        "msgpack-lite": "0.1.26",
+        "ocaml-language-server": "1.0.12",
+        "oni-api": "0.0.24",
+        "oni-neovim-binaries": "0.1.0",
+        "oni-ripgrep": "0.0.3",
+        "oni-types": "0.0.4",
+        "react": "16.0.0",
+        "react-dom": "16.0.0",
+        "react-electron-web-view": "^2.0.1",
+        "redux-batched-subscribe": "^0.1.6",
+        "shell-env": "^0.3.0",
+        "shelljs": "0.7.7",
+        "styled-components": "^2.3.0",
+        "typescript": "2.6.1",
+        "vscode-css-languageserver-bin": "^1.2.1",
+        "vscode-html-languageserver-bin": "^1.1.0",
+        "vscode-jsonrpc": "3.5.0",
+        "vscode-languageserver": "3.5.0",
+        "vscode-languageserver-types": "3.5.0",
+        "vscode-textmate": "3.2.0"
+    },
+    "devDependencies": {
+        "@types/classnames": "0.0.32",
+        "@types/color": "2.0.0",
+        "@types/electron-settings": "^3.1.1",
+        "@types/jsdom": "11.0.0",
+        "@types/lodash": "4.14.38",
+        "@types/lolex": "2.1.0",
+        "@types/memory-fs": "^0.3.0",
+        "@types/minimatch": "3.0.1",
+        "@types/minimist": "1.1.29",
+        "@types/mkdirp": "0.3.29",
+        "@types/mocha": "2.2.33",
+        "@types/msgpack-lite": "0.1.4",
+        "@types/node": "8.0.53",
+        "@types/react-dom": "16.0.3",
+        "@types/react-motion": "0.0.23",
+        "@types/react-redux": "5.0.12",
+        "@types/react-transition-group": "2.0.6",
+        "@types/shelljs": "^0.7.7",
+        "@types/sinon": "1.16.32",
+        "autoprefixer": "6.4.0",
+        "babili-webpack-plugin": "0.1.2",
+        "bs-platform": "1.8.0",
+        "classnames": "2.2.5",
+        "color": "2.0.0",
+        "concurrently": "3.1.0",
+        "coveralls": "^3.0.0",
+        "cross-env": "3.1.3",
+        "css-loader": "0.28.4",
+        "electron": "1.8.1",
+        "electron-builder": "19.46.4",
+        "electron-devtools-installer": "2.2.1",
+        "electron-mocha": "5.0.0",
+        "electron-rebuild": "1.6.0",
+        "extract-zip": "1.6.0",
+        "fs-extra": "4.0.2",
+        "fuse.js": "2.6.2",
+        "github-releases": "^0.4.1",
+        "husky": "^0.14.3",
+        "innosetup-compiler": "5.5.9",
+        "jsdom": "11.0.0",
+        "less": "2.7.1",
+        "less-loader": "4.0.5",
+        "less-plugin-autoprefix": "1.5.1",
+        "lodash": "4.17.0",
+        "lolex": "2.3.1",
+        "memory-fs": "^0.4.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "mocha": "3.1.2",
+        "nyc": "^11.4.1",
+        "oni-release-downloader": "0.0.8",
+        "opencollective": "1.0.3",
+        "optimize-js-plugin": "0.0.4",
+        "prettier": "^1.10.2",
+        "pretty-quick": "^1.2.2",
+        "react-hot-loader": "1.3.1",
+        "react-motion": "0.5.2",
+        "react-redux": "5.0.6",
+        "react-transition-group": "2.2.1",
+        "redux": "3.7.2",
+        "redux-observable": "0.17.0",
+        "redux-thunk": "2.2.0",
+        "reselect": "3.0.1",
+        "rxjs": "5.5.0",
+        "sinon": "1.17.6",
+        "spectron": "3.6.2",
+        "style-loader": "0.18.2",
+        "sudo-prompt": "7.1.1",
+        "ts-loader": "2.3.2",
+        "tslint": "5.7.0",
+        "vscode-snippet-parser": "0.0.5",
+        "wcwidth": "1.0.1",
+        "webdriverio": "4.8.0",
+        "webpack": "3.5.3",
+        "webpack-bundle-analyzer": "^2.9.1",
+        "webpack-dev-server": "2.7.1"
+    },
+    "collective": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/oni",
+        "logo": "https://opencollective.com/opencollective/logo.txt"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     },
     "scripts": {
         "precommit": "pretty-quick --staged",
+        "prepush": "npm run build && npm run lint",
         "build": "npm run build:browser && npm run build:main && npm run build:plugins",
         "build-debug": "npm run build:browser-debug && npm run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     },
     "scripts": {
         "precommit": "pretty-quick --staged",
-        "prepush": "npm run build && npm run lint",
         "build": "npm run build:browser && npm run build:main && npm run build:plugins",
         "build-debug": "npm run build:browser-debug && npm run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
@@ -163,7 +162,6 @@
         "lint:test":
             "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "prettier": "prettier ./browser && prettier ./main && prettier ./test",
         "ccov:instrument":
             "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
         "ccov:test:browser":

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -49,9 +49,8 @@ export interface ITestCase {
     configPath: string
 }
 
+// tslint:disable-next-line only-arrow-functions
 describe("ci tests", function() {
-    // tslint:disable-line only-arrow-functions
-
     const tests = Platform.isWindows()
         ? [...CiTests, ...WindowsOnlyTests]
         : Platform.isMac() ? [...CiTests, ...OSXOnlyTests] : CiTests

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -37,9 +37,7 @@ const WindowsOnlyTests = [
     "PaintPerformanceTest",
 ]
 
-const OSXOnlyTests = [
-    "OSX.WindowTitleTest",
-]
+const OSXOnlyTests = ["OSX.WindowTitleTest"]
 
 // tslint:disable:no-console
 
@@ -51,11 +49,14 @@ export interface ITestCase {
     configPath: string
 }
 
-describe("ci tests", function() { // tslint:disable-line only-arrow-functions
+describe("ci tests", function() {
+    // tslint:disable-line only-arrow-functions
 
-    const tests = Platform.isWindows() ? [...CiTests, ...WindowsOnlyTests] : Platform.isMac() ? [...CiTests, ...OSXOnlyTests] : CiTests
+    const tests = Platform.isWindows()
+        ? [...CiTests, ...WindowsOnlyTests]
+        : Platform.isMac() ? [...CiTests, ...OSXOnlyTests] : CiTests
 
-    CiTests.forEach((test) => {
+    CiTests.forEach(test => {
         runInProcTest(path.join(__dirname, "ci"), test)
     })
 })

--- a/test/Demo.ts
+++ b/test/Demo.ts
@@ -10,11 +10,12 @@ const DemoTests = [
 
 // tslint:disable:no-console
 
-describe("demo tests", function() { // tslint:disable-line only-arrow-functions
+describe("demo tests", function() {
+    // tslint:disable-line only-arrow-functions
     // Retry up to two times
     this.retries(2)
 
-    DemoTests.forEach((test) => {
+    DemoTests.forEach(test => {
         runInProcTest(path.join(__dirname, "demo"), test)
     })
 })

--- a/test/ci/AutoClosingPairsTest.ts
+++ b/test/ci/AutoClosingPairsTest.ts
@@ -41,7 +41,7 @@ export const test = async (oni: Oni.Plugin.Api) => {
     // for them to complete.
     await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.lineCount === 5)
 
-    const lines: string[]  = await oni.editors.activeEditor.activeBuffer.getLines(0, 5)
+    const lines: string[] = await oni.editors.activeEditor.activeBuffer.getLines(0, 5)
 
     const expectedResult = [
         "const test = {",

--- a/test/ci/AutoCompletionTest-CSS.ts
+++ b/test/ci/AutoCompletionTest-CSS.ts
@@ -24,5 +24,8 @@ export const test = async (oni: Oni.Plugin.Api) => {
     const completionElement = getCompletionElement()
     const textContent = completionElement.textContent
 
-    assert.ok(textContent.indexOf("position") >= 0, "Verify 'position' was presented as a completion")
+    assert.ok(
+        textContent.indexOf("position") >= 0,
+        "Verify 'position' was presented as a completion",
+    )
 }

--- a/test/ci/Common.ts
+++ b/test/ci/Common.ts
@@ -12,7 +12,6 @@ export const getCompletionElement = () => {
 }
 
 export const getElementByClassName = (className: string) => {
-
     const elements = document.body.getElementsByClassName(className)
 
     if (!elements || !elements.length) {
@@ -23,7 +22,6 @@ export const getElementByClassName = (className: string) => {
 }
 
 export const createNewFile = async (fileExtension: string, oni: Oni.Plugin.Api): Promise<void> => {
-
     const tempFilePath = getTemporaryFilePath(fileExtension)
     await navigateToFile(tempFilePath, oni)
 }
@@ -45,5 +43,8 @@ export const navigateToFile = async (filePath: string, oni: Oni.Plugin.Api): Pro
     oni.automation.sendKeys(":e " + filePath)
     oni.automation.sendKeys("<cr>")
 
-    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.filePath === filePath, 10000)
+    await oni.automation.waitFor(
+        () => oni.editors.activeEditor.activeBuffer.filePath === filePath,
+        10000,
+    )
 }

--- a/test/ci/LargeFileTest.ts
+++ b/test/ci/LargeFileTest.ts
@@ -15,13 +15,22 @@ export const test = async (oni: Oni.Plugin.Api) => {
     navigateToFile(filePath, oni)
 
     oni.automation.sendKeys("G")
-    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 99999, 30000)
+    await oni.automation.waitFor(
+        () => oni.editors.activeEditor.activeBuffer.cursor.line === 99999,
+        30000,
+    )
 
     oni.automation.sendKeys(":50000<CR>")
-    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 49999, 30000)
+    await oni.automation.waitFor(
+        () => oni.editors.activeEditor.activeBuffer.cursor.line === 49999,
+        30000,
+    )
 
     oni.automation.sendKeys("gg")
-    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.cursor.line === 0, 30000)
+    await oni.automation.waitFor(
+        () => oni.editors.activeEditor.activeBuffer.cursor.line === 0,
+        30000,
+    )
 }
 
 import * as fs from "fs"
@@ -29,7 +38,8 @@ import * as os from "os"
 
 const createLargeTestFile = (): string => {
     const filePath = getTemporaryFilePath("js")
-    const line = "window.alert('hello world from a very very very very extremely large javascript file'); // testing testing testing to make the line very long"
+    const line =
+        "window.alert('hello world from a very very very very extremely large javascript file'); // testing testing testing to make the line very long"
 
     const lineCount = 100 * 1000
 

--- a/test/ci/NoInstalledNeovim.ts
+++ b/test/ci/NoInstalledNeovim.ts
@@ -11,7 +11,6 @@ import * as path from "path"
 import * as Oni from "oni-api"
 
 const getInstallHelpElement = () => {
-
     const elements = document.body.getElementsByClassName("install-help")
 
     if (!elements || !elements.length) {

--- a/test/ci/OSX.WindowTitleTest.ts
+++ b/test/ci/OSX.WindowTitleTest.ts
@@ -16,6 +16,9 @@ export const test = async (oni: any) => {
     // Validate that the titlebar element eventually shows ONI + the file name
     await oni.automation.waitFor(() => {
         const titleBar = document.getElementById("oni-titlebar")
-        return titleBar.textContent.indexOf("ONI") >= 0 && titleBar.textContent.indexOf("test_file") >= 0
+        return (
+            titleBar.textContent.indexOf("ONI") >= 0 &&
+            titleBar.textContent.indexOf("test_file") >= 0
+        )
     })
 }

--- a/test/ci/PaintPerformanceTest.ts
+++ b/test/ci/PaintPerformanceTest.ts
@@ -61,8 +61,16 @@ export const test = async (oni: Oni.Plugin.Api) => {
     const endHeadCount = document.head.querySelectorAll("*").length
     const endBodyCount = document.body.querySelectorAll("*").length
 
-    assert.strictEqual(startHeadCount, endHeadCount, "There should be no items added to the head over the course of typing.")
-    assert.strictEqual(startBodyCount, endBodyCount, "There should be no items added to the body over the course of typing.")
+    assert.strictEqual(
+        startHeadCount,
+        endHeadCount,
+        "There should be no items added to the head over the course of typing.",
+    )
+    assert.strictEqual(
+        startBodyCount,
+        endBodyCount,
+        "There should be no items added to the body over the course of typing.",
+    )
 
     // TODO: Unfortunately, the `beginFrameSubscription` events don't seem to come through
     // on the OSX TravisCI machine. It would be great to unblock this, but for now,
@@ -79,7 +87,7 @@ export const test = async (oni: Oni.Plugin.Api) => {
     // We'll still test for it, as it can still catch cases where we'd have larger repaint errors.
     const maxHeight = gpuCompositingEnabled ? 20 : 256
 
-    paintRectangles.forEach((pr) => {
+    paintRectangles.forEach(pr => {
         // TODO: #1129 - Validate width as well!
 
         assert.ok(pr.height <= maxHeight, "Validate rectangle height is less than the max height")

--- a/test/ci/Regression.1296.SettingColorsTest.ts
+++ b/test/ci/Regression.1296.SettingColorsTest.ts
@@ -10,7 +10,10 @@ export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
 
     // Validate that setting the configuration via 'colors' actually sets the color...
-    oni.configuration.setValues({"colors.foreground": "magenta", "colors.editor.foreground": "magenta" })
+    oni.configuration.setValues({
+        "colors.foreground": "magenta",
+        "colors.editor.foreground": "magenta",
+    })
 
     // Wait for it to be set on the body..
     oni.automation.waitFor(() => {

--- a/test/ci/StatusBar-Mode.ts
+++ b/test/ci/StatusBar-Mode.ts
@@ -19,5 +19,8 @@ export const test = async (oni: Oni.Plugin.Api) => {
     const statusBarModeElement = getElementByClassName("mode")
     const textContent = statusBarModeElement.textContent
 
-    assert.ok(textContent.indexOf("normal") >= 0, "Verify 'normal' was present in the statusbar mode item")
+    assert.ok(
+        textContent.indexOf("normal") >= 0,
+        "Verify 'normal' was present in the statusbar mode item",
+    )
 }

--- a/test/ci/Workspace.ConfigurationTest.ts
+++ b/test/ci/Workspace.ConfigurationTest.ts
@@ -11,7 +11,7 @@ import * as mkdirp from "mkdirp"
 
 import * as Oni from "oni-api"
 
-import { getTemporaryFolder  } from "./Common"
+import { getTemporaryFolder } from "./Common"
 
 export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -12,10 +12,29 @@ const getExecutablePath = () => {
         case "win32":
             return path.join(__dirname, "..", "..", "..", "dist", "win-ia32-unpacked", "Oni.exe")
         case "darwin":
-            return path.join(__dirname, "..", "..", "..", "dist", "mac", "Oni.app", "Contents", "MacOS", "Oni")
+            return path.join(
+                __dirname,
+                "..",
+                "..",
+                "..",
+                "dist",
+                "mac",
+                "Oni.app",
+                "Contents",
+                "MacOS",
+                "Oni",
+            )
         case "linux":
             const archFlag = process.arch === "x64" ? "" : "ia32-"
-            return path.join(__dirname, "..", "..", "..", "dist", `linux-${archFlag}unpacked`, "oni")
+            return path.join(
+                __dirname,
+                "..",
+                "..",
+                "..",
+                "dist",
+                `linux-${archFlag}unpacked`,
+                "oni",
+            )
         default:
             throw new Error(`Unable to find Oni executable for platform ${process.platform}`)
     }
@@ -40,7 +59,7 @@ export class Oni {
 
         this._app = new Application({
             path: executablePath,
-            env: options.configurationPath ? { "ONI_CONFIG_FILE": options.configurationPath } : {},
+            env: options.configurationPath ? { ONI_CONFIG_FILE: options.configurationPath } : {},
         })
 
         log("Oni starting...")

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -12,7 +12,7 @@ export interface ITestCase {
     configPath: string
 }
 
-const normalizePath = (p) => p.split("\\").join("/")
+const normalizePath = p => p.split("\\").join("/")
 
 const loadTest = (rootPath: string, testName: string): ITestCase => {
     const testPath = path.join(rootPath, testName + ".js")
@@ -23,7 +23,9 @@ const loadTest = (rootPath: string, testName: string): ITestCase => {
     const normalizedMeta: ITestCase = {
         name: testDescription.name || testName,
         testPath: normalizePath(testPath),
-        configPath: testDescription.configPath ? normalizePath(path.join(rootPath, testDescription.configPath)) : "",
+        configPath: testDescription.configPath
+            ? normalizePath(path.join(rootPath, testDescription.configPath))
+            : "",
     }
 
     return normalizedMeta
@@ -41,7 +43,6 @@ const logWithTimeStamp = (message: string) => {
 
 export const runInProcTest = (rootPath: string, testName: string, timeout: number = 5000) => {
     describe(testName, () => {
-
         const testCase = loadTest(rootPath, testName)
 
         let oni: Oni
@@ -83,7 +84,7 @@ export const runInProcTest = (rootPath: string, testName: string, timeout: numbe
 
             console.log("Retrieving logs...")
             const writeLogs = (logs: any[]): void => {
-                logs.forEach((log) => {
+                logs.forEach(log => {
                     console.log(`[${log.level}] ${log.message}`)
                 })
             }

--- a/test/demo/HeroDemo.ts
+++ b/test/demo/HeroDemo.ts
@@ -30,11 +30,11 @@ export const test = async (oni: any) => {
     await shortDelay()
 
     oni.automation.sendKeys("i")
-    await simulateTyping("const greeting = \"Hello World\";")
+    await simulateTyping('const greeting = "Hello World";')
 
     oni.automation.sendKeys("<CR>")
 
-    await simulateTyping("greeting = \"Hello again\";")
+    await simulateTyping('greeting = "Hello again";')
 
     await shortDelay()
 

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -11,7 +11,6 @@ import { remote } from "electron"
 import { getDistPath, getRootPath } from "./DemoCommon"
 
 const getCompletionElement = () => {
-
     const elements = document.body.getElementsByClassName("autocompletion")
 
     if (!elements || !elements.length) {
@@ -25,16 +24,23 @@ export const test = async (oni: any) => {
     await oni.automation.waitForEditors()
 
     let lastAlertText = null
-    window.alert = (myText) => lastAlertText = myText
+    window.alert = myText => (lastAlertText = myText)
 
     // Use the `Completion.ts` file as the screenshot source
     remote.getCurrentWindow().setSize(800, 600)
 
     const outputPath = getDistPath()
 
-    oni.configuration.setValues({"recorder.outputPath": outputPath})
+    oni.configuration.setValues({ "recorder.outputPath": outputPath })
 
-    const filePath = path.join(getRootPath(), "browser", "src", "Services", "Language", "LanguageStore.ts")
+    const filePath = path.join(
+        getRootPath(),
+        "browser",
+        "src",
+        "Services",
+        "Language",
+        "LanguageStore.ts",
+    )
 
     oni.automation.sendKeys(":e WELCOME.md<CR>")
 

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,7 @@
         "no-namespace": false,
         "object-literal-key-quotes": false,
         "object-literal-sort-keys": false,
-        "semicolon": [true, "never"],
+        "semicolon": false,
         "interface-name": [false],
         "variable-name": [
             true,
@@ -19,14 +19,7 @@
             "ban-keywords",
             "check-format"
         ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ],
+        "whitespace": false,
         "trailing-comma": [
             true,
             {

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "tslint:latest",
     "rules": {
+        "align": false,
         "arrow-parens": [false],
         "max-classes-per-file": [false],
         "max-line-length": [false],


### PR DESCRIPTION
- Run `prettier` on all files in the repo, to minimize changes for incoming PRs

@Akin909 , I noticed that `prettier` moves the `tslint:disable-line` comments to a different line:
```
+            this._resizeObserver = new window["ResizeObserver"]((entries: any) => {
+                // tslint:disable-line no-string-literal
```

Which causes the lint checks to fail:
```
ERROR: E:/oni/browser/src/Redux/createStore.ts[33, 22]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/neovim/Session.ts[114, 9]: Unnecessary semicolon
ERROR: E:/oni/browser/src/neovim/Session.ts[114, 10]: missing whitespace
ERROR: E:/oni/browser/src/neovim/Session.ts[115, 10]: missing whitespace
ERROR: E:/oni/browser/src/Renderer/CanvasRenderer.ts[274, 30]: members are not aligned
ERROR: E:/oni/browser/src/Services/Themes/ThemeManager.ts[157, 9]: Expected property shorthand in object literal ('{foreground}').
ERROR: E:/oni/browser/src/Input/Keyboard/KeyboardLayout.ts[22, 16]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/Services/InputManager.ts[86, 9]: Expected a 'for-of' loop instead of a 'for' loop with this simple iteration
ERROR: E:/oni/browser/src/UI/components/StatusResize.tsx[66, 36]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/UI/Shell/Shell.tsx[77, 12]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/UI/components/CursorPositioner.tsx[89, 47]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx[32, 47]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/Services/Recorder.ts[49, 31]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/Services/Recorder.ts[42, 13]: Expected a 'for-of' loop instead of a 'for' loop with this simple iteration
ERROR: E:/oni/browser/src/Plugins/PackageMetadataParser.ts[57, 48]: object access via string literals is disallowed
ERROR: E:/oni/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts[29, 14]: statements are not aligned
ERROR: E:/oni/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts[29, 14]: missing whitespace
```

Do you have a suggestion on how to handle this? Any config setting for prettier or something? We can also turn off these rules in `tslint`. Let me know what you think.

(I temporarily turned off the `npm run prepush` check in this PR to get this out 😄 )