### PR TITLE
Build: Enable OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ matrix:
     sudo: required
     dist: trusty
     node_js: 8
-  # temporarily remove OSX due to instability with TravisCI
-  # - os: osx
-  #   node_js: 8
+  - os: osx
+    node_js: 8
 addons:
   apt:
     packages:


### PR DESCRIPTION
Looks like TravisCI is back up, so re-enabling OSX builds.