### PR TITLE
bugfix: Ocaml-lang-server path

### DIFF
--- a/browser/src/Services/Configuration/ReasonConfiguration.ts
+++ b/browser/src/Services/Configuration/ReasonConfiguration.ts
@@ -8,9 +8,14 @@ import * as path from "path"
 
 import * as Platform from "./../../Platform"
 
-export const ocamlLanguageServerPath = Platform.isWindows()
-    ? path.join(__dirname, "node_modules", ".bin", "ocaml-language-server.cmd")
-    : path.join(__dirname, "node_modules", ".bin", "ocaml-language-server")
+export const ocamlLanguageServerPath = path.join(
+    __dirname,
+    "node_modules",
+    "ocaml-language-server",
+    "bin",
+    "server",
+    "index.js",
+)
 
 // If Windows, wrap in `bash -ic` to support WSL
 const wrapCommand = Platform.isWindows() ? (str: string) => "bash -ic " + str : (str: string) => str

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -14,8 +14,6 @@ const codeBlockStyle = css`
     color: ${p => p.theme.foreground};
     padding: 0.4em 0.4em 0.4em 0.4em;
     margin: 0.4em 0.4em 0.4em 0.4em;
-    /* necessary to prevent overflow */
-    max-width: 55vw;
 
     > code {
         background-color: inherit;
@@ -24,7 +22,9 @@ const codeBlockStyle = css`
 
 const childStyles = css`
     > * {
+        /* necessary to prevent overflow */
         margin: 0.2rem;
+        max-width: 55vw;
 
         a {
             color: ${p => p.theme["highlight.mode.normal.background"]};
@@ -35,7 +35,7 @@ const childStyles = css`
         }
 
         /* All code blocks are set to black but
-    this overriden for code block INSIDE a Pre element */
+    this is overriden for code blocks INSIDE a Pre element */
 
         code {
             background-color: ${p => p.theme["editor.hover.contents.codeblock.background"]};


### PR DESCRIPTION
@bryphe I've changed the path to point towards `node_modules/ocaml-language-server/bin/server/index.js` as by looking at the `.app` directory in the packaged app this was the only initialisation point I found, no executable. This works on my mac when built although I have not been able to test it works on `windows` (as I dont have a windows machine) but as there is no executable I use the same entry point for both windows and mac