### PR TITLE
Bugfix/check path exists workspace

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -397,8 +397,8 @@ export class NeovimEditor extends Editor implements IEditor {
             this._actions.setNeovimError(true)
         })
 
-        this._neovimInstance.onDirectoryChanged.subscribe(newDirectory => {
-            this._workspace.changeDirectory(newDirectory)
+        this._neovimInstance.onDirectoryChanged.subscribe(async newDirectory => {
+            await this._workspace.changeDirectory(newDirectory)
         })
 
         this._neovimInstance.on("action", (action: any) => {

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -6,6 +6,8 @@
  */
 
 import { remote } from "electron"
+import { access } from "fs"
+import { promisify } from "util"
 import "rxjs/add/observable/defer"
 import "rxjs/add/observable/from"
 import "rxjs/add/operator/concatMap"
@@ -25,6 +27,8 @@ import { convertTextDocumentEditsToFileMap } from "./../Language/Edits"
 
 import * as WorkspaceCommands from "./WorkspaceCommands"
 import { WorkspaceConfiguration } from "./WorkspaceConfiguration"
+
+const fsAccess = promisify(access)
 
 // Candidate interface to promote to Oni API
 export interface IWorkspace extends Oni.Workspace {
@@ -61,12 +65,14 @@ export class Workspace implements IWorkspace {
     }
 
     public changeDirectory(newDirectory: string) {
-        if (newDirectory) {
+        const dirExists = fsAccess(newDirectory)
+        console.log("dirExists: ", dirExists)
+        if (newDirectory && dirExists) {
             process.chdir(newDirectory)
-        }
 
-        this._activeWorkspace = newDirectory
-        this._onDirectoryChangedEvent.dispatch(newDirectory)
+            this._activeWorkspace = newDirectory
+            this._onDirectoryChangedEvent.dispatch(newDirectory)
+        }
     }
 
     public async applyEdits(edits: types.WorkspaceEdit): Promise<void> {

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -30,13 +30,13 @@ export const activateCommands = (
         remote.dialog.showOpenDialog(
             remote.getCurrentWindow(),
             dialogOptions,
-            (folder: string[]) => {
+            async (folder: string[]) => {
                 if (!folder || !folder[0]) {
                     return
                 }
 
                 const folderToOpen = folder[0]
-                workspace.changeDirectory(folderToOpen)
+                await workspace.changeDirectory(folderToOpen)
             },
         )
     }
@@ -117,7 +117,7 @@ export const activateCommands = (
             "workspace.closeFolder",
             "Workspace: Close Folder",
             "Close the current folder",
-            () => workspace.changeDirectory(null),
+            async () => await workspace.changeDirectory(null),
             () => !!workspace.activeWorkspace,
         ),
     ]

--- a/vim/core/oni-plugin-git/index.js
+++ b/vim/core/oni-plugin-git/index.js
@@ -1,111 +1,97 @@
-const fs = require('fs');
-const path = require('path');
-const { promisify } = require('util');
-const fsStat = promisify(fs.stat);
+const fs = require("fs")
+const path = require("path")
+const { promisify } = require("util")
+const fsStat = promisify(fs.stat)
 
 const activate = Oni => {
-  const React = Oni.dependencies.React;
-  let isLoaded = false;
-  try {
+    const React = Oni.dependencies.React
+    let isLoaded = false
+    try {
+        const updateBranchIndicator = async evt => {
+            if (!evt) {
+                return
+            }
+            const filePath = evt.filePath || evt.bufferFullPath
+            const gitId = "oni.status.git"
+            const gitBranchIndicator = Oni.statusBar.createItem(1, gitId)
 
-    const pathIsDir = async p => {
-      try {
-        const stats = await fsStat(p);
-        return stats.isDirectory();
-      } catch (error) {
-        return error;
-      }
-    };
+            isLoaded = true
+            let dir
+            try {
+                const isDir = await Oni.workspace.pathIsDir(filePath)
+                const dir = isDir ? filePath : path.dirname(filePath)
+                let branchName
+                try {
+                    branchName = await Oni.services.git.getBranch(dir)
+                } catch (e) {
+                    gitBranchIndicator.hide()
+                    return
+                    // return console.warn('[Oni.plugin.git]: No branch name found', e);
+                    // branchName = 'Not a Git Repo';
+                }
 
-    const updateBranchIndicator = async evt => {
-      if (!evt) {
-        return;
-      }
-      const filePath = evt.filePath || evt.bufferFullPath;
-      const gitId = 'oni.status.git'
-      const gitBranchIndicator = Oni.statusBar.createItem(1, gitId);
+                const props = {
+                    style: {
+                        height: "100%",
+                        width: "100%",
+                        display: "flex",
+                        alignItems: "center",
+                    },
+                }
 
-      isLoaded = true;
-      let dir;
-      try {
-        const isDir = await pathIsDir(filePath);
-        const dir = isDir ? filePath : path.dirname(filePath);
-        let branchName;
-        try {
-          branchName = await Oni.services.git.getBranch(dir);
-        } catch (e) {
-          gitBranchIndicator.hide();
-          return;
-          // return console.warn('[Oni.plugin.git]: No branch name found', e);
-          // branchName = 'Not a Git Repo';
+                const branchContainerProps = {
+                    style: {
+                        minWidth: "10px",
+                        textAlign: "center",
+                        padding: "2px 4px 0 0",
+                    },
+                }
+
+                const branchIcon = Oni.ui.createIcon({
+                    name: "code-fork",
+                    size: Oni.ui.iconSize.Default,
+                })
+
+                const branchContainer = React.createElement(
+                    "span",
+                    branchContainerProps,
+                    branchIcon,
+                )
+
+                const branchNameContainer = React.createElement(
+                    "div",
+                    { width: "100%" },
+                    " " + branchName,
+                )
+
+                const gitBranch = React.createElement(
+                    "div",
+                    props,
+                    branchContainer,
+                    branchNameContainer,
+                )
+
+                gitBranchIndicator.setContents(gitBranch)
+                gitBranchIndicator.show()
+            } catch (e) {
+                console.log("[Oni.plugin.git]: ", e)
+                return gitBranchIndicator.hide()
+            }
         }
 
-        const props = {
-          style: {
-            height: '100%',
-            width: '100%',
-            display: 'flex',
-            alignItems: 'center',
-          },
-        };
+        if (!isLoaded) {
+            updateBranchIndicator(Oni.editors.activeEditor.activeBuffer)
+        }
 
-        const branchContainerProps = {
-          style: {
-            minWidth: '10px',
-            textAlign: 'center',
-            padding: '2px 4px 0 0',
-          }
-        };
-
-        const branchIcon = Oni.ui.createIcon({
-          name: 'code-fork',
-          size: Oni.ui.iconSize.Default,
-        });
-
-        const branchContainer = React.createElement(
-          'span',
-          branchContainerProps,
-          branchIcon,
-        );
-
-        const branchNameContainer = React.createElement(
-          'div',
-          { width: '100%'},
-          ' ' + branchName,
-        );
-
-        const gitBranch = React.createElement(
-          'div',
-          props,
-          branchContainer,
-          branchNameContainer,
-        );
-
-
-        gitBranchIndicator.setContents(gitBranch);
-        gitBranchIndicator.show();
-      } catch (e) {
-        console.log('[Oni.plugin.git]: ', e);
-        return gitBranchIndicator.hide();
-      }
-    };
-
-    if (!isLoaded) {
-      updateBranchIndicator(Oni.editors.activeEditor.activeBuffer);
+        Oni.editors.activeEditor.onBufferEnter.subscribe(
+            async evt => await updateBranchIndicator(evt),
+        )
+        Oni.workspace.onFocusGained.subscribe(async buffer => await updateBranchIndicator(buffer))
+    } catch (e) {
+        console.warn("[Oni.plugin.git] ERROR", e)
     }
-
-    Oni.editors.activeEditor.onBufferEnter.subscribe(
-      async evt => await updateBranchIndicator(evt)
-    );
-    Oni.workspace.onFocusGained.subscribe(
-      async buffer => await updateBranchIndicator(buffer)
-    );
-
-  } catch (e) {
-    console.warn('[Oni.plugin.git] ERROR', e);
-  }
-};
+}
 
 module.exports = {
-  activate,
-};
+    activate,
+}


### PR DESCRIPTION
This PR hopefully fixes #1381, adds a check to the `changeDirectory` function in the workspace service, to check if the directory is valid, if not it changes the directory to null and passes null to the event it does not however call the `process.cwd` function.

I was unclear on what the desired functionality should be if an invalid directory was passed my thinking was to not dispatch an event or change the active workspace but rather ignore the call entirely i.e. return early except I notice that to close the folder you explicitly pass `null` to the function so not sure if its best to emulate that (which is what I've currently done).