### PR TITLE
Upgrade tslint to 5.9.1

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -62,8 +62,8 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<f5>", "browser.reload")
     }
 
-    input.bind("<f2>", "editor.rename", () => isNormalMode()),
-        input.bind("<esc>", "editor.rename.cancel")
+    input.bind("<f2>", "editor.rename", () => isNormalMode())
+    input.bind("<esc>", "editor.rename.cancel")
     input.bind("<enter>", "editor.rename.commit")
 
     input.bind("<f3>", "language.format")

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -172,7 +172,7 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
             "WARNING: `OniApi.execNodeScript` is deprecated. Please use `OniApi.process.execNodeScript` instead",
         )
 
-        return await Process.execNodeScript(scriptPath, args, options, callback)
+        return Process.execNodeScript(scriptPath, args, options, callback)
     }
 
     /**
@@ -187,6 +187,6 @@ export class Oni extends EventEmitter implements OniApi.Plugin.Api {
             "WARNING: `OniApi.spawnNodeScript` is deprecated. Please use `OniApi.process.spawnNodeScript` instead",
         )
 
-        return await Process.spawnNodeScript(scriptPath, args, options)
+        return Process.spawnNodeScript(scriptPath, args, options)
     }
 }

--- a/browser/src/Services/Language/SignatureHelp.ts
+++ b/browser/src/Services/Language/SignatureHelp.ts
@@ -28,12 +28,7 @@ export const initUI = (
     // Show signature help as the cursor moves
     latestCursorAndBufferInfo$
         .flatMap(async val => {
-            return await showSignatureHelp(
-                val.language,
-                val.filePath,
-                val.cursorLine,
-                val.cursorColumn,
-            )
+            return showSignatureHelp(val.language, val.filePath, val.cursorLine, val.cursorColumn)
         })
         .subscribe(result => {
             if (result) {

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -117,7 +117,7 @@ export const activateCommands = (
             "workspace.closeFolder",
             "Workspace: Close Folder",
             "Close the current folder",
-            async () => await workspace.changeDirectory(null),
+            async () => workspace.changeDirectory(null),
             () => !!workspace.activeWorkspace,
         ),
     ]

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -119,5 +119,5 @@ export const startNeovim = async (
 
     Log.info(`[NeovimProcessSpawner::startNeovim] Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
 
-    return await getSessionFromProcess(nvimProc, options.transport)
+    return getSessionFromProcess(nvimProc, options.transport)
 }

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -115,7 +115,7 @@ export class NeovimWindowManager {
         const inactiveWindowIds = allWindows.filter(w => w.id !== context.windowNumber)
 
         const windowPromise = await inactiveWindowIds.map(async (window: any) => {
-            return await this._remeasureInactiveWindow(window.id)
+            return this._remeasureInactiveWindow(window.id)
         })
 
         const inactiveWindows = await Promise.all(windowPromise)

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
         "style-loader": "0.18.2",
         "sudo-prompt": "7.1.1",
         "ts-loader": "2.3.2",
-        "tslint": "5.7.0",
+        "tslint": "5.9.1",
         "vscode-snippet-parser": "0.0.5",
         "wcwidth": "1.0.1",
         "webdriverio": "4.8.0",

--- a/test/demo/HeroDemo.ts
+++ b/test/demo/HeroDemo.ts
@@ -9,9 +9,9 @@ import * as path from "path"
 import { remote } from "electron"
 
 export const test = async (oni: any) => {
-    const shortDelay = async () => await oni.automation.sleep(500)
+    const shortDelay = async () => oni.automation.sleep(500)
 
-    const longDelay = async () => await oni.automation.sleep(1000)
+    const longDelay = async () => oni.automation.sleep(1000)
 
     const simulateTyping = async (keys: string) => {
         for (const key of keys) {

--- a/tslint.json
+++ b/tslint.json
@@ -1,10 +1,14 @@
 {
     "extends": "tslint:latest",
+    "cliOptions": {
+        "exclude": ["test/ci/*.js"]
+    },
     "rules": {
         "align": false,
         "arrow-parens": [false],
         "max-classes-per-file": [false],
         "max-line-length": [false],
+        "no-implicit-dependencies": false,
         "no-object-literal-type-assertion": false,
         "no-submodule-imports": false,
         "no-reference": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1124,7 +1124,7 @@ builder-util@^3.4.0, builder-util@^3.4.1:
     temp-file "^3.0.0"
     tunnel-agent "^0.6.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1408,6 +1408,10 @@ commander@2.9.0:
 commander@^2.11.0:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
+commander@^2.12.1:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commander@^2.9.0:
   version "2.12.1"
@@ -3563,7 +3567,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.6.1:
+js-yaml@^3.10.0, js-yaml@^3.6.1, js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -6457,30 +6461,32 @@ ts-loader@2.3.2:
     loader-utils "^1.0.2"
     semver "^5.0.1"
 
-tslib@^1.7.1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-tslint@5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.7.0.tgz#c25e0d0c92fa1201c2bc30e844e08e682b4f3552"
+tslint@5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
   dependencies:
     babel-code-frame "^6.22.0"
-    colors "^1.1.2"
-    commander "^2.9.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
     diff "^3.2.0"
     glob "^7.1.1"
+    js-yaml "^3.7.0"
     minimatch "^3.0.4"
     resolve "^1.3.2"
     semver "^5.3.0"
-    tslib "^1.7.1"
-    tsutils "^2.8.1"
+    tslib "^1.8.0"
+    tsutils "^2.12.1"
 
-tsutils@^2.8.1:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.12.2.tgz#ad58a4865d17ec3ddb6631b6ca53be14a5656ff3"
+tsutils@^2.12.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.19.1.tgz#76d7ebdea9d7a7bf4a05f50ead3701b0168708d7"
   dependencies:
-    tslib "^1.7.1"
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
`tslint` and `prettier` were in conflict for some settings (we already have the `semicolon` rule disabled, so wasn't clear why there were still flags on the js files).

I did some research and it looks like we can have `tslint` ignore files, but need to upgrade. The new version of `tslint` picked up a few extra errors, like unnecessary `awaits`, so I ran `fix-lint` over the codebase too.