### PR TITLE
Buffer Layers: Restrict to window

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimActiveWindow.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimActiveWindow.tsx
@@ -24,6 +24,8 @@ export class NeovimActiveWindow extends React.PureComponent<IActiveWindowProps, 
             top: px(this.props.pixelY),
             width: px(this.props.pixelWidth),
             height: px(this.props.pixelHeight),
+            overflowY: "hidden",
+            overflowX: "hidden",
         }
 
         return <div style={style}>{this.props.children}</div>

--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -21,6 +21,16 @@ export interface NeovimBufferLayersViewProps {
     layers: State.Layers
 }
 
+const InnerLayerStyle: React.CSSProperties = {
+    position: "absolute",
+    top: "0px",
+    left: "0px",
+    right: "0px",
+    bottom: "0px",
+    overflowY: "auto",
+    overflowX: "auto",
+}
+
 export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLayersViewProps, {}> {
     public render(): JSX.Element {
         const containers = this.props.windows.map(windowState => {
@@ -37,7 +47,11 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
             }
 
             const layerElements = layers.map(l => {
-                return <div key={l.id}>{l.render(layerContext)}</div>
+                return (
+                    <div key={l.id} style={InnerLayerStyle}>
+                        {l.render(layerContext)}
+                    </div>
+                )
             })
 
             const dimensions = getWindowPixelDimensions(windowState)


### PR DESCRIPTION
__Issue:__ The welcome screen buffer overflows into other window spaces, so if you try to `:sp` while the welcome buffer is up, the welcome buffer from the other split will overtake the new split.

__Fix:__ Restrict the buffer layers to the size of the window, by enforcing `overflow: hidden`