### PR TITLE
Fix Open Workspace / Folder regressions

### DIFF
--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -97,7 +97,6 @@ export const activateCommands = (
             "Workspace: Open Folder",
             "Set a folder as the working directory for Oni",
             () => openFolder(),
-            () => !!!workspace.activeWorkspace,
         ),
         new CallbackCommand(
             "workspace.openTestFile",

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -170,7 +170,7 @@ export const buildMenu = (mainWindow, loadInit) => {
             {
                 label: "Open Folder…",
                 click(item, focusedWindow) {
-                    executeOniCommand(focusedWindow, "oni.openFolder")
+                    executeOniCommand(focusedWindow, "workspace.openFolder")
                 },
             },
             reopenWithEncoding,


### PR DESCRIPTION
Thanks for catching these, @CrossR !

This fixes two issues:
- Hooks the 'Open Folder' option in the menu back up
- Always enables the 'Workspace: Open Folder' command, even if there is a workspace already open