### PR TITLE
Revert nord's mode colors, in favor of the previous colors

### DIFF
--- a/extensions/theme-nord/colors/nord.json
+++ b/extensions/theme-nord/colors/nord.json
@@ -35,16 +35,16 @@
         "statusBar.background": "#282828",
         "statusBar.foreground": "#c8c8c8",
 
-        "highlight.mode.insert.background": "#A3BE8C",
+        "highlight.mode.insert.background": "#98c379",
         "highlight.mode.insert.foreground": "#282c34",
 
-        "highlight.mode.normal.background": "#5E81AC",
+        "highlight.mode.normal.background": "#61afef",
         "highlight.mode.normal.foreground": "#282c34",
 
-        "highlight.mode.operator.background": "#EBCB8B",
+        "highlight.mode.operator.background": "#d19a66",
         "highlight.mode.operator.foreground": "#282c34",
 
-        "highlight.mode.visual.background": "#B48EAD",
+        "highlight.mode.visual.background": "#56b6c2",
         "highlight.mode.visual.foreground": "#282c34"
     }
 }


### PR DESCRIPTION
This brightens up the highlight colors in the nord theme - important since we use them in so many places.