### PR TITLE
feature(tiny): add margin right to explorer icons

### DIFF
--- a/browser/src/Services/Explorer/Explorer.less
+++ b/browser/src/Services/Explorer/Explorer.less
@@ -32,6 +32,7 @@
                 flex: 0 0 auto;
                 width: 20px;
                 text-align: center;
+                margin-right: 7px;
             }
 
             .name {


### PR DESCRIPTION
With the explorer now open as default my eye was immediately caught by the icons sitting very close/right beside the node name which might be the intention but if not I've added a `margin-right: 7px` to allow a little more space between these, added this locally which hasn't broken the aesthetic I think.