### PR TITLE
Automation: Inline configuration settings, instead of needing to specify an external file

### DIFF
--- a/test/ci/Editor.ExternalCommandLine.config.js
+++ b/test/ci/Editor.ExternalCommandLine.config.js
@@ -1,7 +1,0 @@
-// For more information on customizing Oni,
-// check out our wiki page:
-// https://github.com/onivim/oni/wiki/Configuration
-
-module.exports = {
-    "experimental.commandline.mode": true,
-};

--- a/test/ci/Editor.ExternalCommandLineTest.ts
+++ b/test/ci/Editor.ExternalCommandLineTest.ts
@@ -19,5 +19,7 @@ export const test = async (oni: Oni.Plugin.Api) => {
 
 // Bring in custom config to turn off animations, in order to reduce noise.
 export const settings = {
-    configPath: "Editor.ExternalCommandLine.config.js",
+    config: {
+        "experimental.commandline.mode": true,
+    },
 }

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -47,10 +47,10 @@ const getConfigPath = (settings: any, rootPath: string) => {
 // Returns the path to the serialized config
 const serializeConfig = (configValues: { [key: string]: any }): string => {
     const stringifiedConfig = Object.keys(configValues).map(
-        key => `"${key}": "${configValues[key]}",`,
+        key => `"${key}": ${configValues[key]},`,
     )
 
-    const outputConfig = `module.exports = {${stringifiedConfig.join(os.EOL)}`
+    const outputConfig = `module.exports = {${stringifiedConfig.join(os.EOL)}}`
 
     const folder = os.tmpdir()
     const fileName = "config_" + new Date().getTime().toString() + ".js"

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -32,7 +32,9 @@ const loadTest = (rootPath: string, testName: string): ITestCase => {
 import * as os from "os"
 
 const getConfigPath = (settings: any, rootPath: string) => {
-    if (settings.configPath) {
+    if (!settings) {
+        return ""
+    } else if (settings.configPath) {
         return normalizePath(path.join(rootPath, settings.configPath))
     } else if (settings.config) {
         return normalizePath(serializeConfig(settings.config))


### PR DESCRIPTION
This change lets us inline configuration for the CiTests - it writes the configuration to a temporary file, and uses that. This is important for cases where we'll need to pass in paths, so that we can generate it on the fly when we run the test.