### PR TITLE
Automation: Change screenshot automation to navigate to root directory

### DIFF
--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -77,7 +77,6 @@ export const test = async (oni: any) => {
 
     oni.recorder.takeScreenshot(`screenshot-${process.platform}.png`)
 
-    console.log("Alert text: " + lastAlertText)
-
     await oni.automation.waitFor(() => lastAlertText !== null, 20000)
+    console.log("Alert text (screenshot output path): " + lastAlertText)
 }

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -33,8 +33,6 @@ export const test = async (oni: any) => {
 
     const outputPath = getDistPath()
 
-    oni.configuration.setValues({ "recorder.outputPath": outputPath })
-
     await oni.workspace.changeDirectory(getRootPath())
 
     const filePath = path.join(
@@ -74,6 +72,8 @@ export const test = async (oni: any) => {
     await oni.automation.waitFor(() => getCompletionElement() !== null, 20000)
 
     await oni.automation.sleep(500)
+
+    oni.configuration.setValues({ "recorder.outputPath": outputPath })
 
     oni.recorder.takeScreenshot(`screenshot-${process.platform}.png`)
 

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -10,6 +10,8 @@ import { remote } from "electron"
 
 import { getDistPath, getRootPath } from "./DemoCommon"
 
+// tslint:disable:no-console
+
 const getCompletionElement = () => {
     const elements = document.body.getElementsByClassName("autocompletion")
 
@@ -74,6 +76,8 @@ export const test = async (oni: any) => {
     await oni.automation.sleep(500)
 
     oni.recorder.takeScreenshot(`screenshot-${process.platform}.png`)
+
+    console.log("Alert text: " + lastAlertText)
 
     await oni.automation.waitFor(() => lastAlertText !== null, 20000)
 }

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -33,6 +33,8 @@ export const test = async (oni: any) => {
 
     oni.configuration.setValues({ "recorder.outputPath": outputPath })
 
+    await oni.workspace.changeDirectory(getRootPath())
+
     const filePath = path.join(
         getRootPath(),
         "browser",


### PR DESCRIPTION
Using the root directory will do a better job showcasing the new explorer capabilities