### PR TITLE
Refactoring: Remove props for colors in TextInputView

### DIFF
--- a/browser/src/Services/Language/RenameView.tsx
+++ b/browser/src/Services/Language/RenameView.tsx
@@ -6,19 +6,31 @@
 
 import * as React from "react"
 
-import { TextInput } from "./../../UI/components/LightweightText"
+import styled from "styled-components"
+
+import { TextInputView } from "./../../UI/components/LightweightText"
 
 export interface IRenameViewProps {
     tokenName: string
     onComplete: (val: string) => void
 }
 
+const ToolTipWrapper = styled.div`
+    background-color: ${props => props.theme["toolTip.background"]};
+    color: ${props => props.theme["toolTip.foreground"]};
+
+    input {
+        background-color: ${props => props.theme["toolTip.background"]};
+        color: ${props => props.theme["toolTip.foreground"]};
+    }
+`
+
 export class RenameView extends React.PureComponent<IRenameViewProps, {}> {
     public render(): JSX.Element {
         return (
-            <div className="rename">
-                <TextInput {...this.props} defaultValue={this.props.tokenName} />
-            </div>
+            <ToolTipWrapper className="rename">
+                <TextInputView {...this.props} defaultValue={this.props.tokenName} />
+            </ToolTipWrapper>
         )
     }
 }

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -32,10 +32,17 @@ export interface IMenuProps {
 
     rowHeight: number
     maxItemsToShow: number
-
-    backgroundColor: string
-    foregroundColor: string
 }
+
+const MenuStyleWrapper = styled.div`
+    background-color: ${props => props.theme["menu.background"]};
+    color: ${props => props.theme["menu.foreground"]};
+
+    & input {
+        color: ${props => props.theme["menu.foreground"]};
+        background-color: rgba(0, 0, 0.2);
+    }
+`
 
 export class MenuView extends React.PureComponent<IMenuProps, {}> {
     private _inputElement: HTMLInputElement = null
@@ -66,11 +73,6 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
             )
         }
 
-        const menuStyle = {
-            backgroundColor: this.props.backgroundColor,
-            color: this.props.foregroundColor,
-        }
-
         const footerClassName = "footer " + (this.props.isLoading ? "loading" : "loaded")
 
         const height =
@@ -78,13 +80,8 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
 
         return (
             <div className="menu-background enable-mouse">
-                <div className="menu" style={menuStyle}>
-                    <TextInputView
-                        overrideDefaultStyle={true}
-                        backgroundColor={null}
-                        foregroundColor={this.props.foregroundColor}
-                        onChange={evt => this._onChange(evt)}
-                    />
+                <MenuStyleWrapper className="menu">
+                    <TextInputView onChange={evt => this._onChange(evt)} />
                     <div className="items">
                         <div>
                             <AutoSizer disableHeight={true}>
@@ -101,7 +98,7 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
                             </AutoSizer>
                         </div>
                     </div>
-                    <div className={footerClassName} style={menuStyle}>
+                    <div className={footerClassName}>
                         <div className="loading-spinner">
                             <Icon
                                 name="circle-o-notch"
@@ -110,7 +107,7 @@ export class MenuView extends React.PureComponent<IMenuProps, {}> {
                             />
                         </div>
                     </div>
-                </div>
+                </MenuStyleWrapper>
             </div>
         )
     }
@@ -128,8 +125,6 @@ const NullProps: any = {
     selectedIndex: 0,
     filterText: "",
     items: EmptyArray,
-    backgroundColor: "black",
-    foregroundColor: "white",
     onSelect: noop,
     isLoading: true,
     rowHeight: 0,
@@ -148,8 +143,6 @@ const mapStateToProps = (
             selectedIndex: popupMenu.selectedIndex,
             filterText: popupMenu.filter,
             items: popupMenu.filteredOptions,
-            backgroundColor: popupMenu.backgroundColor,
-            foregroundColor: popupMenu.foregroundColor,
             onSelect: popupMenu.onSelectItem,
             isLoading: popupMenu.isLoading,
             rowHeight: state.configuration.rowHeight,

--- a/browser/src/Services/Sneak.tsx
+++ b/browser/src/Services/Sneak.tsx
@@ -156,8 +156,6 @@ export class SneakView extends React.PureComponent<ISneakViewProps, ISneakViewSt
                         onChange={evt => {
                             this.setState({ filterText: evt.currentTarget.value })
                         }}
-                        backgroundColor={"black"}
-                        foregroundColor={"white"}
                     />
                 </div>
                 {sneaks}

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -1,7 +1,4 @@
 import * as React from "react"
-import { connect } from "react-redux"
-
-import * as State from "./../Shell/ShellState"
 
 import { focusManager } from "./../../Services/FocusManager"
 
@@ -10,16 +7,10 @@ export interface ITextInputViewProps {
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void
 
     defaultValue?: string
-
-    backgroundColor: string
-    foregroundColor: string
-
-    overrideDefaultStyle?: boolean
 }
 
 // TODO: Is there a better value for this?
 const WordRegex = /[$_a-zA-Z0-9]/i
-const EmptyStyle: React.CSSProperties = {}
 
 /**
  * TextInputView is a lightweight input control, that implements some
@@ -35,17 +26,8 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
     }
 
     public render(): JSX.Element {
-        const containerStyle: React.CSSProperties = this.props.overrideDefaultStyle
-            ? EmptyStyle
-            : {
-                  padding: "4px",
-                  border: "1px solid " + this.props.foregroundColor,
-              }
-
         const inputStyle: React.CSSProperties = {
             outline: "none",
-            color: this.props.foregroundColor,
-            backgroundColor: this.props.backgroundColor,
             border: "0px",
             transform: "translateY(0px)",
         }
@@ -53,7 +35,7 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
         const defaultValue = this.props.defaultValue || ""
 
         return (
-            <div style={containerStyle}>
+            <div className="input-container">
                 <input
                     type="text"
                     style={inputStyle}
@@ -121,11 +103,3 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
         }
     }
 }
-
-const mapStateToProps = (state: State.IState, originalProps?: Partial<ITextInputViewProps>) => ({
-    ...originalProps,
-    backgroundColor: state.colors["editor.background"],
-    foregroundColor: state.colors["editor.foreground"],
-})
-
-export const TextInput = connect(mapStateToProps)(TextInputView)


### PR DESCRIPTION
The `TextInputView` takes in some props for `foregroundColor`/`backgroundColor` (this was before we had `styled-components` with theming) - it's a bit awkward now, especially in integrating it with the sidebar/search - so I'm pulling it out and refactoring the places that leveraged it, and replacing it with `styled-components` + theming.