### PR TITLE
UX: Sidebar - fix gap at top of screen

### DIFF
--- a/browser/src/Services/Sidebar/SidebarView.tsx
+++ b/browser/src/Services/Sidebar/SidebarView.tsx
@@ -95,7 +95,7 @@ const SidebarWrapper = withProps<ISidebarWrapperProps>(styled.div)`
     border-top: ${props =>
         props.isActive
             ? "2px solid " + props.theme["highlight.mode.normal.background"]
-            : "2px solid transparent"};
+            : "2px solid " + props.theme["editor.background"]};
 
     color: ${props => props.theme["sidebar.foreground"]};
     width: ${props => props.width};


### PR DESCRIPTION
There is a 2-pixel gap at the top of the screen, which is especially noticeable when the titlebar is visible in Mac:
![image](https://user-images.githubusercontent.com/13532591/35694850-7ae5a7e8-0737-11e8-8166-3336e64a1ed2.png)

This fills in that gap, so that it looks better in the case where the highlight is not on the sidebar.

(There are a few other issues in that screenshot, like the poor overflow experience in the explorer - will address that in a separate change)
