### PR TITLE
Bugfix/window number error removing bufferbar highlight

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -305,7 +305,8 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         this._windowManager.onWindowStateChanged.subscribe(tabPageState => {
-            const inactiveIds = tabPageState.inactiveWindows.map(w => w.windowNumber)
+            const filteredTabState = tabPageState.inactiveWindows.filter(w => !!w)
+            const inactiveIds = filteredTabState.map(w => w.windowNumber)
 
             this._actions.setActiveVimTabPage(tabPageState.tabId, [
                 tabPageState.activeWindow.windowNumber,
@@ -327,10 +328,8 @@ export class NeovimEditor extends Editor implements IEditor {
                 )
             }
 
-            tabPageState.inactiveWindows.map(w => {
-                if (w) {
-                    this._actions.setInactiveWindowState(w.windowNumber, w.dimensions)
-                }
+            filteredTabState.map(w => {
+                this._actions.setInactiveWindowState(w.windowNumber, w.dimensions)
             })
         })
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -313,20 +313,24 @@ export class NeovimEditor extends Editor implements IEditor {
             ])
 
             const { activeWindow } = tabPageState
-            this._actions.setWindowState(
-                activeWindow.windowNumber,
-                activeWindow.bufferId,
-                activeWindow.bufferFullPath,
-                activeWindow.column,
-                activeWindow.line,
-                activeWindow.bottomBufferLine,
-                activeWindow.topBufferLine,
-                activeWindow.dimensions,
-                activeWindow.bufferToScreen,
-            )
+            if (activeWindow) {
+                this._actions.setWindowState(
+                    activeWindow.windowNumber,
+                    activeWindow.bufferId,
+                    activeWindow.bufferFullPath,
+                    activeWindow.column,
+                    activeWindow.line,
+                    activeWindow.bottomBufferLine,
+                    activeWindow.topBufferLine,
+                    activeWindow.dimensions,
+                    activeWindow.bufferToScreen,
+                )
+            }
 
             tabPageState.inactiveWindows.map(w => {
-                this._actions.setInactiveWindowState(w.windowNumber, w.dimensions)
+                if (w) {
+                    this._actions.setInactiveWindowState(w.windowNumber, w.dimensions)
+                }
             })
         })
 

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -46,6 +46,8 @@ export interface INeovimSurfaceProps {
 
 export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> {
     public componentDidCatch(e: Error) {
+        // TODO Add an Error Page to inform user of how to proceed e.g. file bug report
+        // also pass error detais so user can file those
         // tslint:disable-next-line
         console.warn(`Error mounting the Neovim editor because`, e)
     }

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -45,6 +45,11 @@ export interface INeovimSurfaceProps {
 }
 
 export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, {}> {
+    public componentDidCatch(e: Error) {
+        // tslint:disable-next-line
+        console.warn(`Error mounting the Neovim editor because`, e)
+    }
+
     public render(): JSX.Element {
         return (
             <div className="container vertical full">


### PR DESCRIPTION
Noted recently that an error with the `windowNumber` subscription which happens consistently on startup which seems to take down the buffer bar selection, so it is no longer clear which buffer is selected. 

<img width="827" alt="screen shot 2018-02-01 at 19 51 10" src="https://user-images.githubusercontent.com/22454918/35700004-a5a21e60-0789-11e8-89f3-0d9d00fa3e6b.png">

I couldn't figure why the error might be happening but I added if block to the actions in the handler to prevent the error being thrown