### PR TITLE
Refactoring: Push some common commit / cancel handling into the TextInputView

### DIFF
--- a/browser/src/Editor/NeovimEditor/Rename.tsx
+++ b/browser/src/Editor/NeovimEditor/Rename.tsx
@@ -52,6 +52,7 @@ export class Rename {
         this._toolTipsProvider.showToolTip(
             _renameToolTipName,
             <RenameView
+                onCancel={() => this.cancelRename()}
                 onComplete={newValue => this._onRenameClosed(newValue)}
                 tokenName={activeToken.tokenName}
             />,

--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -63,8 +63,6 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     }
 
     input.bind("<f2>", "editor.rename", () => isNormalMode())
-    input.bind("<esc>", "editor.rename.cancel")
-    input.bind("<enter>", "editor.rename.commit")
 
     input.bind("<f3>", "language.format")
     input.bind(["<f12>"], "language.gotoDefinition", () => isNormalMode() && !menu.isMenuOpen())

--- a/browser/src/Services/FocusManager.ts
+++ b/browser/src/Services/FocusManager.ts
@@ -10,7 +10,7 @@ class FocusManager {
     public pushFocus(element: HTMLElement) {
         this._focusElementStack = [element, ...this._focusElementStack]
 
-        element.focus()
+        window.setTimeout(() => this.enforceFocus(), 0)
     }
 
     public popFocus(element: HTMLElement) {

--- a/browser/src/Services/Language/RenameView.tsx
+++ b/browser/src/Services/Language/RenameView.tsx
@@ -13,6 +13,7 @@ import { TextInputView } from "./../../UI/components/LightweightText"
 export interface IRenameViewProps {
     tokenName: string
     onComplete: (val: string) => void
+    onCancel: () => void
 }
 
 const ToolTipWrapper = styled.div`

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -46,7 +46,6 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
                     onFocus={evt => evt.currentTarget.select()}
                     ref={elem => {
                         this._element = elem
-                        window["derp"] = elem
                     }}
                 />
             </div>
@@ -71,7 +70,9 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
     }
 
     private _cancel(): void {
-        this.props.onCancel && this.props.onCancel()
+        if (this.props.onCancel) {
+            this.props.onCancel()
+        }
     }
 
     private _onKeyDown(keyboardEvent: React.KeyboardEvent<HTMLInputElement>): void {

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import { focusManager } from "./../../Services/FocusManager"
 
 export interface ITextInputViewProps {
+    onCancel?: () => void
     onComplete?: (result: string) => void
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void
 
@@ -35,7 +36,7 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
         const defaultValue = this.props.defaultValue || ""
 
         return (
-            <div className="input-container">
+            <div className="input-container enable-mouse">
                 <input
                     type="text"
                     style={inputStyle}
@@ -43,7 +44,10 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
                     onKeyDown={evt => this._onKeyDown(evt)}
                     onChange={evt => this._onChange(evt)}
                     onFocus={evt => evt.currentTarget.select()}
-                    ref={elem => (this._element = elem)}
+                    ref={elem => {
+                        this._element = elem
+                        window["derp"] = elem
+                    }}
                 />
             </div>
         )
@@ -66,9 +70,22 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
         }
     }
 
+    private _cancel(): void {
+        this.props.onCancel && this.props.onCancel()
+    }
+
     private _onKeyDown(keyboardEvent: React.KeyboardEvent<HTMLInputElement>): void {
+        if (keyboardEvent.keyCode === 27) {
+            this._cancel()
+            return
+        }
+
         if (this._element && keyboardEvent.ctrlKey) {
             switch (keyboardEvent.key) {
+                case "[":
+                case "c":
+                    this._cancel()
+                    break
                 case "u": {
                     this._element.value = ""
                     break


### PR DESCRIPTION
Each component that uses `<TextInputView />` so far has to do some of its own management around when to close and commit. This moves pieces of it to shared logic, and refactors the `<RenameView />` to leverage it (the other components that use it - sneak and menu - still work as they do today).

This will be used in the search UX, so that it doesn't have to implement its own cancel / commit commands and logic, and can leverage the shared core.