### PR TITLE
Bug fix: Regression in space/enter keys

### DIFF
--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -117,7 +117,13 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
             this._activeBinding = getInstance().bindToMenu()
 
             commandManager.registerCommand(
-                new CallbackCommand("select", null, null, () => this._select()),
+                new CallbackCommand(
+                    "select",
+                    null,
+                    null,
+                    () => this._select(),
+                    () => this.props.active,
+                ),
             )
 
             this._activeBinding.onCursorMoved.subscribe(newValue => {


### PR DESCRIPTION
__Issue:__ When navigating to the sidebar and then back to an editor, the `<space>` and `<enter>` keys no longer work.

__Defect:__ The `<VimNavigator />` component hooks a command for `select`, but doesn't unregister it - so it stays active even in other cases. The default binding for `select` is `<space>` and `<enter>`, so those get swallowed.

__Fix:__ There is a timing issue with unregistering (when switching panes, you can get a race condition where the new `<VimNavigator />` registers _before_ the old `<VimNavigator />` unregisters, so it just gets removed). A simple fix at the moment is to add a filter, such that this command is only active if the `<VimNavigator />` is active.