### PR TITLE
Fix #1396 - Navigation Quirks

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -687,6 +687,9 @@ export class NeovimEditor extends Editor implements IEditor {
         const startOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
             transport: this._configuration.getValue("experimental.neovim.transport"),
+            neovimPath: this._configuration.getValue("debug.neovimPath"),
+            loadInitVim: this._configuration.getValue("oni.loadInitVim"),
+            useDefaultConfig: this._configuration.getValue("oni.useDefaultConfig"),
         }
 
         await this._neovimInstance.start(startOptions)

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -22,11 +22,13 @@ export type MsgPackTransport = "stdio" | "pipe"
 export interface INeovimStartOptions {
     runtimePaths?: string[]
     transport?: MsgPackTransport
+    disableInitVim?: boolean
 }
 
 const DefaultStartOptions: INeovimStartOptions = {
     runtimePaths: [],
     transport: "stdio",
+    disableInitVim: false,
 }
 
 const getSessionFromProcess = async (
@@ -91,7 +93,7 @@ export const startNeovim = async (
         nvimProcessPath = neovimPath
     }
 
-    Log.info("[NeovimProcessSpawnwer::startNeovim] Neovim process path: " + nvimProcessPath)
+    Log.info("[NeovimProcessSpawner::startNeovim] Neovim process path: " + nvimProcessPath)
 
     const joinedRuntimePaths = runtimePaths.map(p => remapPathToUnpackedAsar(p)).join(",")
 
@@ -103,6 +105,13 @@ export const startNeovim = async (
 
     if (typeof loadInitVimConfigOption === "string") {
         initVimArg = ["-u", loadInitVimConfigOption]
+    }
+
+    if (options.disableInitVim) {
+        Log.info(
+            "[NeovimProcessSpawner::startNeovim] disableInitVim set to 'true', so not loading init.vim",
+        )
+        initVimArg = ["-u", noopInitVimPath]
     }
 
     const argsToPass = initVimArg.concat([

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -154,6 +154,7 @@ class SharedNeovimInstance implements SharedNeovimInstance {
     public async start(): Promise<void> {
         const startOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
+            disableInitVim: true,
         }
 
         this._initPromise = this._neovimInstance.start(startOptions)

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -155,7 +155,7 @@ class SharedNeovimInstance implements SharedNeovimInstance {
         const startOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
             loadInitVim: false,
-            useDefaultConfig: false,
+            useDefaultConfig: true,
         }
 
         this._initPromise = this._neovimInstance.start(startOptions)

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -154,7 +154,8 @@ class SharedNeovimInstance implements SharedNeovimInstance {
     public async start(): Promise<void> {
         const startOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
-            disableInitVim: true,
+            loadInitVim: false,
+            useDefaultConfig: false,
         }
 
         this._initPromise = this._neovimInstance.start(startOptions)


### PR DESCRIPTION
This change hopefully addresses #1396 (and the navigation part of #1413 ), by disabling the `init.vim` loading of our `SharedNeovimInstance`. For the UI that depends on it, it's mostly canonical vim navigation (`h`, `j`, `k`, `l`, `gg`, `G`, etc), so hopefully that will be sufficient. Worst case, we could specify an alternate config later to use for those specific pieces of UI.

Instead of the `NeovimProcessSpawner` needing to check the configuration for the options, we've pushed that upwards. This lets the `SharedNeovimInstance` override the `loadInitVim` and `useDefaultConfig` options, and force them to `false`. 

This should minimize conflicts in those pieces of UI, but we may need more work down the road in terms of extending or customizing the mappings for these components.
