### PR TITLE
Fix #1426 - Handle 'enter' directly in the 'TextInputView'

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -126,8 +126,6 @@ export class NeovimEditorCommands {
             return !this._menuManager.isMenuOpen()
         }
 
-        const isRenameActive = () => this._rename.isRenameActive()
-
         const commands = [
             new CallbackCommand(
                 "contextMenu.select",
@@ -201,20 +199,6 @@ export class NeovimEditorCommands {
 
             new CallbackCommand("editor.rename", "Rename", "Rename an item", () =>
                 this._rename.startRename(),
-            ),
-            new CallbackCommand(
-                "editor.rename.commit",
-                null,
-                null,
-                () => this._rename.commitRename(),
-                isRenameActive,
-            ),
-            new CallbackCommand(
-                "editor.rename.cancel",
-                null,
-                null,
-                () => this._rename.cancelRename(),
-                isRenameActive,
             ),
 
             new CallbackCommand("editor.quickInfo.show", null, null, () =>

--- a/browser/src/Editor/NeovimEditor/Rename.tsx
+++ b/browser/src/Editor/NeovimEditor/Rename.tsx
@@ -18,7 +18,6 @@ import { IToolTipsProvider } from "./ToolTipsProvider"
 const _renameToolTipName = "rename-tool-tip"
 export class Rename {
     private _isRenameActive: boolean
-    private _isRenameCommitted: boolean
 
     constructor(
         private _editor: Oni.Editor,
@@ -26,10 +25,6 @@ export class Rename {
         private _toolTipsProvider: IToolTipsProvider,
         private _workspace: Workspace,
     ) {}
-
-    public isRenameActive(): boolean {
-        return this._isRenameActive
-    }
 
     public async startRename(): Promise<void> {
         if (this._isRenameActive) {
@@ -53,7 +48,7 @@ export class Rename {
             _renameToolTipName,
             <RenameView
                 onCancel={() => this.cancelRename()}
-                onComplete={newValue => this._onRenameClosed(newValue)}
+                onComplete={newValue => this.commitRename(newValue)}
                 tokenName={activeToken.tokenName}
             />,
             {
@@ -64,25 +59,14 @@ export class Rename {
         )
     }
 
-    public commitRename(): void {
+    public commitRename(newValue: string): void {
         Log.verbose("[RENAME] Committing rename")
-        this._isRenameCommitted = true
-        this._isRenameActive = false
+        this.doRename(newValue)
         this.closeToolTip()
     }
 
     public cancelRename(): void {
         Log.verbose("[RENAME] Cancelling")
-        this._isRenameCommitted = false
-        this.closeToolTip()
-    }
-
-    public _onRenameClosed(newValue: string): void {
-        Log.verbose("[RENAME] _onRenameClosed")
-        if (this._isRenameCommitted) {
-            this._isRenameCommitted = false
-            this.doRename(newValue)
-        }
         this.closeToolTip()
     }
 

--- a/browser/src/UI/components/LightweightText.tsx
+++ b/browser/src/UI/components/LightweightText.tsx
@@ -54,10 +54,6 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
 
     public componentWillUnmount(): void {
         if (this._element) {
-            if (this.props.onComplete) {
-                this.props.onComplete(this._element.value)
-            }
-
             focusManager.popFocus(this._element)
             this._element = null
         }
@@ -78,6 +74,13 @@ export class TextInputView extends React.PureComponent<ITextInputViewProps, {}> 
     private _onKeyDown(keyboardEvent: React.KeyboardEvent<HTMLInputElement>): void {
         if (keyboardEvent.keyCode === 27) {
             this._cancel()
+            return
+        }
+
+        if (keyboardEvent.keyCode === 13) {
+            if (this.props.onComplete) {
+                this.props.onComplete(this._element.value)
+            }
             return
         }
 


### PR DESCRIPTION
Because of the changes to push more input management to `TextInputView`, the enter key broke on Rename, since the `enter` key wasn't baked completely. This adds enter key management to `TextInputView`, which is also needed for the text inputs in the sidebar.

Also tested the inputs in the quick open / command palette, which still worked after this change.

Fixes #1426 . A side effect of this is we can remove some of the state management and additional commands for the rename keys. The keybindings for `rename.commit` and `rename.cancel` have already been removed, and it seems like a common set of bindings that keeps getting reused between features.

If we find that users do want to rebind this commit/cancel keys, we can perhaps make a more universal command like `commit` and `cancel` that could apply across the various features (sidebar textbox, rename, menu, etc).