### PR TITLE
Fix #1409: Switch sneak mode binding to `Control+G`

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -106,7 +106,6 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     input.bind("<delete>", "explorer.delete")
 
     // TODO: Scope 's' to just the local window
-    input.bind("s", "sneak.show", () => isNormalMode() && !menu.isMenuOpen())
-    input.bind("S", "sneak.show", () => isNormalMode() && !menu.isMenuOpen())
+    input.bind("<c-g>", "sneak.show", () => isNormalMode() && !menu.isMenuOpen())
     input.bind(["<esc>", "<c-c>"], "sneak.hide")
 }


### PR DESCRIPTION
__Issue:__ The sneak mode binding (`s` and `S`) was overly aggressive and caused conflicts in a variety of situations - terminal buffers, fzf, typing in text inputs, etc.

__Fix:__ Use a more conservative binding to start (`<C-g>`)