### PR TITLE
feature/keep selected tab in view

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -116,46 +116,59 @@ export interface ITabPropsWithClick extends ITabProps {
     maxWidth: string
 }
 
-export const Tab = (props: ITabPropsWithClick) => {
-    const cssClasses = classNames("tab", {
-        selected: props.isSelected,
-        "not-selected": !props.isSelected,
-        "is-dirty": props.isDirty,
-        "not-dirty": !props.isDirty,
-    })
-
-    const style = {
-        backgroundColor: props.backgroundColor,
-        color: props.foregroundColor,
-        maxWidth: props.maxWidth,
-        height: props.height,
-        borderTop: "2px solid " + props.highlightColor,
+export class Tab extends React.Component<ITabPropsWithClick> {
+    private _tab: HTMLDivElement
+    public componentWillReceiveProps(next: ITabPropsWithClick) {
+        if (next.isSelected && this._tab) {
+            this._tab.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" })
+        }
     }
+    public render() {
+        const cssClasses = classNames("tab", {
+            selected: this.props.isSelected,
+            "not-selected": !this.props.isSelected,
+            "is-dirty": this.props.isDirty,
+            "not-dirty": !this.props.isDirty,
+        })
 
-    return (
-        <Sneakable callback={() => props.onClickName()}>
-            <div className={cssClasses} title={props.description} style={style}>
-                <div className="corner" onClick={props.onClickName}>
-                    <FileIcon
-                        fileName={props.iconFileName}
-                        isLarge={true}
-                        additionalClassNames={"file-icon-appear-animation"}
-                    />
-                </div>
-                <div className="name" onClick={props.onClickName}>
-                    <span className="name-inner">{props.name}</span>
-                </div>
-                <div className="corner enable-hover" onClick={props.onClickClose}>
-                    <div className="icon-container x-icon-container">
-                        <Icon name="times" />
+        const style = {
+            backgroundColor: this.props.backgroundColor,
+            color: this.props.foregroundColor,
+            maxWidth: this.props.maxWidth,
+            height: this.props.height,
+            borderTop: "2px solid " + this.props.highlightColor,
+        }
+
+        return (
+            <Sneakable callback={() => this.props.onClickName()}>
+                <div
+                    ref={(e: HTMLDivElement) => (this._tab = e)}
+                    className={cssClasses}
+                    title={this.props.description}
+                    style={style}
+                >
+                    <div className="corner" onClick={this.props.onClickName}>
+                        <FileIcon
+                            fileName={this.props.iconFileName}
+                            isLarge={true}
+                            additionalClassNames={"file-icon-appear-animation"}
+                        />
                     </div>
-                    <div className="icon-container circle-icon-container">
-                        <div className="circle" />
+                    <div className="name" onClick={this.props.onClickName}>
+                        <span className="name-inner">{this.props.name}</span>
+                    </div>
+                    <div className="corner enable-hover" onClick={this.props.onClickClose}>
+                        <div className="icon-container x-icon-container">
+                            <Icon name="times" />
+                        </div>
+                        <div className="icon-container circle-icon-container">
+                            <div className="circle" />
+                        </div>
                     </div>
                 </div>
-            </div>
-        </Sneakable>
-    )
+            </Sneakable>
+        )
+    }
 }
 
 const getTabName = (name: string): string => {


### PR DESCRIPTION
This PR adds functionality to keep the selected tab in view in the tab/buffer bar so if the bar is overflowing the selecting a buffer will bring the selected buffer into view that way the user isn't looking for a `selected` buffer somewhere off screen