### PR TITLE
Command Palette: Two small bug fixes

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -213,14 +213,14 @@ export class NeovimEditorCommands {
             ),
             new CallbackCommand(
                 "oni.config.openConfigJs",
-                "Edit Oni Config",
+                "Configuration: Edit Oni Config",
                 "Edit configuration file ('config.js') for Oni",
                 () => openDefaultConfig(),
             ),
 
             new CallbackCommand(
                 "oni.config.openInitVim",
-                "Edit Neovim Config",
+                "Configuration: Edit Neovim Config",
                 "Edit configuration file ('init.vim') for Neovim",
                 () => this._neovimInstance.openInitVim(),
             ),

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -222,12 +222,15 @@ export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
             className += " selected"
         }
 
-        const icon =
-            this.props.icon && typeof this.props.icon === "string" ? (
-                <Icon name={this.props.icon} />
-            ) : (
-                this.props.icon
-            )
+        let iconToUse: any = <Icon name={"default"} />
+
+        if (this.props.icon) {
+            if (typeof this.props.icon === "string") {
+                iconToUse = <Icon name={this.props.icon} />
+            } else {
+                iconToUse = this.props.icon
+            }
+        }
         return (
             <MenuItemWrapper
                 isSelected={this.props.isSelected}
@@ -235,7 +238,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
                 onClick={() => this.props.onClick()}
                 style={{ height: this.props.height + "px" }}
             >
-                {icon}
+                {iconToUse}
                 <HighlightTextByIndex
                     className="label"
                     text={this.props.label}


### PR DESCRIPTION
- Add a bit of padding in the case where there is no icon specified (in the command palette)
- Add a `Configuration: ` prefix for the edit configuration options