### PR TITLE
Refactoring: Migrate window management state to redux store

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimInput.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimInput.tsx
@@ -25,6 +25,7 @@ export interface INeovimInputProps {
     onImeEnd: () => void
     onKeyDown?: (key: string) => void
 
+    startActive?: boolean
     typingPrediction: TypingPredictionManager
 }
 
@@ -46,6 +47,7 @@ export class NeovimInput extends React.PureComponent<INeovimInputProps, {}> {
         return (
             <div ref={elem => (this._mouseElement = elem)} className="stack enable-mouse">
                 <KeyboardInput
+                    startActive={this.props.startActive}
                     onActivate={this.props.onActivate}
                     typingPrediction={this.props.typingPrediction}
                     onBounceStart={this.props.onBounceStart}

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -97,6 +97,7 @@ class NeovimSurface extends React.Component<INeovimSurfaceProps> {
                         <CursorLine lineType={"column"} />
                     </div>
                     <NeovimInput
+                        startActive={true}
                         onActivate={this.props.onActivate}
                         typingPrediction={this.props.typingPrediction}
                         neovimInstance={this.props.neovimInstance}

--- a/browser/src/Input/KeyboardInput.tsx
+++ b/browser/src/Input/KeyboardInput.tsx
@@ -44,7 +44,9 @@ interface IKeyboardInputViewState {
 }
 
 export interface IKeyboardInputProps {
+    startActive?: boolean
     onActivate: IEvent<void>
+
     onKeyDown?: (key: string) => void
     onImeStart?: () => void
     onImeEnd?: () => void
@@ -88,6 +90,10 @@ export class KeyboardInputView extends React.PureComponent<
                 focusManager.setFocus(this._keyboardElement)
             })
             this._disposables.push(d1)
+        }
+
+        if (this.props.startActive && this._keyboardElement) {
+            focusManager.setFocus(this._keyboardElement)
         }
     }
 

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -71,6 +71,10 @@ export class CanvasRenderer implements INeovimRenderer {
     }
 
     public redrawAll(screenInfo: IScreen): void {
+        if (!this._editorElement) {
+            return
+        }
+
         const cellsToUpdate: IPosition[] = []
 
         this._setContext()
@@ -96,6 +100,10 @@ export class CanvasRenderer implements INeovimRenderer {
     }
 
     public draw(screenInfo: IScreen): void {
+        if (!this._editorElement) {
+            return
+        }
+
         const cellsToUpdate: IPosition[] = []
         for (let x = 0; x < screenInfo.width; x++) {
             for (let y = 0; y < screenInfo.height; y++) {

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -17,9 +17,8 @@ export const activate = (configuration: Configuration, workspace: Workspace) => 
     _sidebarManager = new SidebarManager()
 
     if (configuration.getValue("sidebar.enabled")) {
-        const leftDock = windowManager.getDock("left")
-        leftDock.addSplit(new SidebarSplit(_sidebarManager))
-        leftDock.addSplit(new SidebarContentSplit(_sidebarManager))
+        windowManager.createSplit("left", new SidebarSplit(_sidebarManager))
+        windowManager.createSplit("left", new SidebarContentSplit(_sidebarManager))
 
         _sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
     }

--- a/browser/src/Services/WindowManager/LinearSplitProvider.ts
+++ b/browser/src/Services/WindowManager/LinearSplitProvider.ts
@@ -5,10 +5,9 @@
  * a tree-based hierarchy of horizontal and vertical splits
  */
 
-import * as Oni from "oni-api"
-
 import {
     Direction,
+    IAugmentedSplitInfo,
     IWindowSplitProvider,
     SingleSplitProvider,
     SplitDirection,
@@ -20,11 +19,11 @@ export class LinearSplitProvider implements IWindowSplitProvider {
 
     constructor(private _direction: SplitDirection) {}
 
-    public contains(split: Oni.IWindowSplit): boolean {
+    public contains(split: IAugmentedSplitInfo): boolean {
         return this._getProviderForSplit(split) != null
     }
 
-    public close(split: Oni.IWindowSplit): boolean {
+    public close(split: IAugmentedSplitInfo): boolean {
         const containingSplit = this._getProviderForSplit(split)
 
         if (!containingSplit) {
@@ -43,9 +42,9 @@ export class LinearSplitProvider implements IWindowSplitProvider {
     }
 
     public split(
-        split: Oni.IWindowSplit,
+        split: IAugmentedSplitInfo,
         direction: SplitDirection,
-        referenceSplit?: Oni.IWindowSplit,
+        referenceSplit?: IAugmentedSplitInfo,
     ): boolean {
         // If there is no reference split, we can just tack this split on
         if (!referenceSplit) {
@@ -78,7 +77,7 @@ export class LinearSplitProvider implements IWindowSplitProvider {
         return true
     }
 
-    public move(split: Oni.IWindowSplit, direction: Direction): Oni.IWindowSplit {
+    public move(split: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
         if (!split) {
             if (this._direction === "horizontal") {
                 const index = direction === "left" ? this._splitProviders.length - 1 : 0
@@ -127,7 +126,7 @@ export class LinearSplitProvider implements IWindowSplitProvider {
         return this._splitProviders[newIndex].move(null, direction)
     }
 
-    public getState(): SplitOrLeaf<Oni.IWindowSplit> {
+    public getState(): SplitOrLeaf<IAugmentedSplitInfo> {
         return {
             type: "Split",
             direction: this._direction,
@@ -150,7 +149,7 @@ export class LinearSplitProvider implements IWindowSplitProvider {
         }
     }
 
-    private _getProviderForSplit(split: Oni.IWindowSplit): IWindowSplitProvider {
+    private _getProviderForSplit(split: IAugmentedSplitInfo): IWindowSplitProvider {
         const providers = this._splitProviders.filter(prov => prov.contains(split))
 
         return providers.length > 0 ? providers[0] : null

--- a/browser/src/Services/WindowManager/RelationalSplitNavigator.ts
+++ b/browser/src/Services/WindowManager/RelationalSplitNavigator.ts
@@ -5,9 +5,7 @@
  * navigation relationships between other split provdiers
  */
 
-import * as Oni from "oni-api"
-
-import { Direction, getInverseDirection, IWindowSplitNavigator } from "./index"
+import { Direction, getInverseDirection, IAugmentedSplitInfo, IWindowSplitNavigator } from "./index"
 
 export interface WindowSplitRelationship {
     from: IWindowSplitNavigator
@@ -41,11 +39,11 @@ export class RelationalSplitNavigator implements IWindowSplitNavigator {
         this._addToProvidersIfNeeded(to)
     }
 
-    public contains(split: Oni.IWindowSplit): boolean {
+    public contains(split: IAugmentedSplitInfo): boolean {
         return this._getContainingSplit(split) !== null
     }
 
-    public move(split: Oni.IWindowSplit, direction: Direction): Oni.IWindowSplit {
+    public move(split: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
         // If there is no current split, that means we are entering
         if (split === null) {
             // Need to find the furthest split in the *reverse* direction.
@@ -98,7 +96,7 @@ export class RelationalSplitNavigator implements IWindowSplitNavigator {
         return this._getFurthestSplitInDirection(direction, currentRelationship.to)
     }
 
-    private _getContainingSplit(split: Oni.IWindowSplit): IWindowSplitNavigator {
+    private _getContainingSplit(split: IAugmentedSplitInfo): IWindowSplitNavigator {
         const providers = this._providers.filter(s => s.contains(split))
         return providers.length === 0 ? null : providers[0]
     }

--- a/browser/src/Services/WindowManager/SingleSplitProvider.ts
+++ b/browser/src/Services/WindowManager/SingleSplitProvider.ts
@@ -4,18 +4,22 @@
  * Split provider for a leaf node
  */
 
-import * as Oni from "oni-api"
-
-import { Direction, IWindowSplitProvider, SplitDirection, SplitOrLeaf } from "./index"
+import {
+    Direction,
+    IAugmentedSplitInfo,
+    IWindowSplitProvider,
+    SplitDirection,
+    SplitOrLeaf,
+} from "./index"
 
 export class SingleSplitProvider implements IWindowSplitProvider {
-    constructor(private _split: Oni.IWindowSplit) {}
+    constructor(private _split: IAugmentedSplitInfo) {}
 
-    public contains(split: Oni.IWindowSplit): boolean {
+    public contains(split: IAugmentedSplitInfo): boolean {
         return this._split === split
     }
 
-    public move(split: Oni.IWindowSplit, direction: Direction): Oni.IWindowSplit {
+    public move(split: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
         if (split === null) {
             return this._split
         } else {
@@ -23,15 +27,15 @@ export class SingleSplitProvider implements IWindowSplitProvider {
         }
     }
 
-    public split(split: Oni.IWindowSplit, direction: SplitDirection): boolean {
+    public split(split: IAugmentedSplitInfo, direction: SplitDirection): boolean {
         return false
     }
 
-    public close(split: Oni.IWindowSplit): boolean {
+    public close(split: IAugmentedSplitInfo): boolean {
         return false
     }
 
-    public getState(): SplitOrLeaf<Oni.IWindowSplit> {
+    public getState(): SplitOrLeaf<IAugmentedSplitInfo> {
         return {
             type: "Leaf",
             contents: this._split,

--- a/browser/src/Services/WindowManager/WindowDock.ts
+++ b/browser/src/Services/WindowManager/WindowDock.ts
@@ -2,48 +2,28 @@
  * WindowDock.ts
  */
 
-import { Event, IEvent } from "oni-types"
+import { Direction, IAugmentedSplitInfo, IWindowSplitNavigator } from "./index"
 
-import { Direction, IAugmentedSplitInfo, SplitDirection } from "./index"
+export type DockStateGetter = () => IAugmentedSplitInfo[]
 
-export interface IWindowDock {
-    splits: IAugmentedSplitInfo[]
+export class WindowDockNavigator implements IWindowSplitNavigator {
+    constructor(private _stateGetter: DockStateGetter) {}
 
-    onSplitsChanged: IEvent<void>
-
-    addSplit(split: IAugmentedSplitInfo): void
-    removeSplit(split: IAugmentedSplitInfo): void
-}
-
-export class WindowDock implements IWindowDock {
-    private _splits: IAugmentedSplitInfo[] = []
-    private _onSplitsChangedEvent: Event<void> = new Event<void>()
-
-    public get splits(): IAugmentedSplitInfo[] {
-        return this._splits
+    contains(split: IAugmentedSplitInfo): boolean {
+        const splits = this._stateGetter()
+        return splits.indexOf(split) >= 0
     }
 
-    public get onSplitsChanged(): IEvent<void> {
-        return this._onSplitsChangedEvent
-    }
+    move(startSplit: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
+        const splits = this._stateGetter()
 
-    public contains(split: IAugmentedSplitInfo): boolean {
-        return this._splits.indexOf(split) >= 0
-    }
-
-    public split(startSplit: IAugmentedSplitInfo, splitDirection: SplitDirection): boolean {
-        this.addSplit(startSplit)
-        return true
-    }
-
-    public move(startSplit: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
-        const currentIndex = this._splits.indexOf(startSplit)
+        const currentIndex = splits.indexOf(startSplit)
 
         if (currentIndex === -1) {
             if (direction === "left") {
-                return this._splits[this._splits.length - 1]
+                return splits[splits.length - 1]
             } else if (direction === "right") {
-                return this._splits[0]
+                return splits[0]
             } else {
                 return null
             }
@@ -52,25 +32,10 @@ export class WindowDock implements IWindowDock {
         // TODO: Generalize this - this is baked for a 'left dock' case right now
         const newIndex = direction === "left" ? currentIndex - 1 : currentIndex + 1
 
-        if (newIndex >= 0 && newIndex < this._splits.length) {
-            return this._splits[newIndex]
+        if (newIndex >= 0 && newIndex < splits.length) {
+            return splits[newIndex]
         } else {
             return null
         }
-    }
-
-    public addSplit(split: IAugmentedSplitInfo): void {
-        this._splits = [...this._splits, split]
-        this._onSplitsChangedEvent.dispatch()
-    }
-
-    public close(split: IAugmentedSplitInfo): boolean {
-        this.removeSplit(split)
-        return true
-    }
-
-    public removeSplit(split: IAugmentedSplitInfo): void {
-        this._splits = this._splits.filter(s => s !== split)
-        this._onSplitsChangedEvent.dispatch()
     }
 }

--- a/browser/src/Services/WindowManager/WindowDock.ts
+++ b/browser/src/Services/WindowManager/WindowDock.ts
@@ -9,12 +9,12 @@ export type DockStateGetter = () => IAugmentedSplitInfo[]
 export class WindowDockNavigator implements IWindowSplitNavigator {
     constructor(private _stateGetter: DockStateGetter) {}
 
-    contains(split: IAugmentedSplitInfo): boolean {
+    public contains(split: IAugmentedSplitInfo): boolean {
         const splits = this._stateGetter()
         return splits.indexOf(split) >= 0
     }
 
-    move(startSplit: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
+    public move(startSplit: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
         const splits = this._stateGetter()
 
         const currentIndex = splits.indexOf(startSplit)

--- a/browser/src/Services/WindowManager/WindowDock.ts
+++ b/browser/src/Services/WindowManager/WindowDock.ts
@@ -2,25 +2,24 @@
  * WindowDock.ts
  */
 
-import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 
-import { Direction, SplitDirection } from "./index"
+import { Direction, IAugmentedSplitInfo, SplitDirection } from "./index"
 
 export interface IWindowDock {
-    splits: Oni.IWindowSplit[]
+    splits: IAugmentedSplitInfo[]
 
     onSplitsChanged: IEvent<void>
 
-    addSplit(split: Oni.IWindowSplit): void
-    removeSplit(split: Oni.IWindowSplit): void
+    addSplit(split: IAugmentedSplitInfo): void
+    removeSplit(split: IAugmentedSplitInfo): void
 }
 
 export class WindowDock implements IWindowDock {
-    private _splits: Oni.IWindowSplit[] = []
+    private _splits: IAugmentedSplitInfo[] = []
     private _onSplitsChangedEvent: Event<void> = new Event<void>()
 
-    public get splits(): Oni.IWindowSplit[] {
+    public get splits(): IAugmentedSplitInfo[] {
         return this._splits
     }
 
@@ -28,16 +27,16 @@ export class WindowDock implements IWindowDock {
         return this._onSplitsChangedEvent
     }
 
-    public contains(split: Oni.IWindowSplit): boolean {
+    public contains(split: IAugmentedSplitInfo): boolean {
         return this._splits.indexOf(split) >= 0
     }
 
-    public split(startSplit: Oni.IWindowSplit, splitDirection: SplitDirection): boolean {
+    public split(startSplit: IAugmentedSplitInfo, splitDirection: SplitDirection): boolean {
         this.addSplit(startSplit)
         return true
     }
 
-    public move(startSplit: Oni.IWindowSplit, direction: Direction): Oni.IWindowSplit {
+    public move(startSplit: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo {
         const currentIndex = this._splits.indexOf(startSplit)
 
         if (currentIndex === -1) {
@@ -60,17 +59,17 @@ export class WindowDock implements IWindowDock {
         }
     }
 
-    public addSplit(split: Oni.IWindowSplit): void {
+    public addSplit(split: IAugmentedSplitInfo): void {
         this._splits = [...this._splits, split]
         this._onSplitsChangedEvent.dispatch()
     }
 
-    public close(split: Oni.IWindowSplit): boolean {
+    public close(split: IAugmentedSplitInfo): boolean {
         this.removeSplit(split)
         return true
     }
 
-    public removeSplit(split: Oni.IWindowSplit): void {
+    public removeSplit(split: IAugmentedSplitInfo): void {
         this._splits = this._splits.filter(s => s !== split)
         this._onSplitsChangedEvent.dispatch()
     }

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -17,6 +17,75 @@ import { RelationalSplitNavigator } from "./RelationalSplitNavigator"
 import { WindowDock } from "./WindowDock"
 import { ISplitInfo } from "./WindowState"
 
+import { Store, Reducer } from "redux"
+import { createStore as createReduxStore } from "./../../Redux"
+
+export interface IAugmentedSplitInfo extends Oni.IWindowSplit {
+    // Potential API methods
+    enter?(): void
+    leave?(): void
+
+    // Internal bookkeeping
+    id: string
+}
+
+type WindowActions =
+    | {
+          type: "SET_DOCK_SPLITS"
+          dock: Direction
+          splits: IAugmentedSplitInfo[]
+      }
+    | {
+          type: "SET_PRIMARY_SPLITS"
+          splits: ISplitInfo<IAugmentedSplitInfo>
+      }
+    | {
+          type: "SET_FOCUSED_SPLIT"
+          splitId: string
+      }
+    | {
+          type: "SHOW_SPLIT"
+          splitId: string
+      }
+    | {
+          type: "HIDE_SPLIT"
+          splitId: string
+      }
+
+export type DockWindows = { [key: string]: IAugmentedSplitInfo[] }
+
+export interface WindowState {
+    docks: DockWindows
+
+    primarySplit: ISplitInfo<IAugmentedSplitInfo>
+
+    focusedSplitId: string
+    hiddenSplits: string[]
+}
+
+export const DefaultWindowState: WindowState = {
+    docks: {
+        left: [],
+        right: [],
+        up: [],
+        down: [],
+    },
+    primarySplit: null,
+    focusedSplitId: null,
+    hiddenSplits: [],
+}
+
+export const reducer: Reducer<WindowState> = (
+    state: WindowState = DefaultWindowState,
+    action: WindowActions,
+) => {
+    return state
+}
+
+export const createStore = (): Store<WindowState> => {
+    return createReduxStore("WindowManager", reducer, DefaultWindowState, [])
+}
+
 export class WindowManager {
     private _activeSplit: any
 

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -16,7 +16,7 @@ import { Event, IEvent } from "oni-types"
 import { Direction, SplitDirection } from "./index"
 import { LinearSplitProvider } from "./LinearSplitProvider"
 import { RelationalSplitNavigator } from "./RelationalSplitNavigator"
-import { WindowDock } from "./WindowDock"
+import { WindowDockNavigator } from "./WindowDock"
 
 import { createStore, IAugmentedSplitInfo, ISplitInfo, WindowState } from "./WindowManagerStore"
 
@@ -61,7 +61,7 @@ export class WindowManager {
 
     private _onUnhandledMoveEvent = new Event<Direction>()
 
-    private _leftDock: WindowDock = null
+    private _leftDock: WindowDockNavigator = null
     private _primarySplit: LinearSplitProvider
     private _rootNavigator: RelationalSplitNavigator
 
@@ -96,11 +96,10 @@ export class WindowManager {
     constructor() {
         this._rootNavigator = new RelationalSplitNavigator()
 
-        this._leftDock = new WindowDock()
+        this._store = createStore()
+        this._leftDock = new WindowDockNavigator(() => this._store.getState().docks["left"])
         this._primarySplit = new LinearSplitProvider("horizontal")
         this._rootNavigator.setRelationship(this._leftDock, this._primarySplit, "right")
-
-        this._store = createStore()
     }
 
     // public split(
@@ -184,20 +183,6 @@ export class WindowManager {
 
     public moveDown(): void {
         this.move("down")
-    }
-
-    public getDock(direction: Direction): WindowDock {
-        if (direction === "left") {
-            return this._leftDock
-        } else {
-            // TODO
-            return null
-        }
-    }
-
-    // TODO: Deprecate
-    public showDock(direction: SplitDirection, split: Oni.IWindowSplit) {
-        // TODO
     }
 
     public close(split: any) {

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -35,6 +35,8 @@ export class AugmentedWindow implements IAugmentedSplitInfo {
         return this._id
     }
 
+    constructor(private _id: string, private _innerSplit: Oni.IWindowSplit | any) {}
+
     public render(): JSX.Element {
         return this._innerSplit.render()
     }
@@ -50,8 +52,6 @@ export class AugmentedWindow implements IAugmentedSplitInfo {
             this._innerSplit.leave()
         }
     }
-
-    constructor(private _id: string, private _innerSplit: Oni.IWindowSplit | any) {}
 }
 
 export class WindowManager {
@@ -97,7 +97,7 @@ export class WindowManager {
         this._rootNavigator = new RelationalSplitNavigator()
 
         this._store = createStore()
-        this._leftDock = new WindowDockNavigator(() => this._store.getState().docks["left"])
+        this._leftDock = new WindowDockNavigator(() => this._store.getState().docks.left)
         this._primarySplit = new LinearSplitProvider("horizontal")
         this._rootNavigator.setRelationship(this._leftDock, this._primarySplit, "right")
     }

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -18,10 +18,46 @@ import { LinearSplitProvider } from "./LinearSplitProvider"
 import { RelationalSplitNavigator } from "./RelationalSplitNavigator"
 import { WindowDock } from "./WindowDock"
 
-import { createStore, ISplitInfo, WindowState } from "./WindowManagerStore"
+import { createStore, IAugmentedSplitInfo, ISplitInfo, WindowState } from "./WindowManagerStore"
+
+export interface IWindowSplitHandle {
+    id: string
+
+    // Later:
+    // show()
+    // hide()
+    // focus()
+    // setSize()
+}
+
+export class AugmentedWindow implements IAugmentedSplitInfo {
+    public get id(): string {
+        return this._id
+    }
+
+    public render(): JSX.Element {
+        return this._innerSplit.render()
+    }
+
+    public enter(): void {
+        if (this._innerSplit.enter) {
+            this._innerSplit.enter()
+        }
+    }
+
+    public leave(): void {
+        if (this._innerSplit.leave) {
+            this._innerSplit.leave()
+        }
+    }
+
+    constructor(private _id: string, private _innerSplit: Oni.IWindowSplit | any) {}
+}
 
 export class WindowManager {
     private _activeSplit: any
+
+    private _lastId: number = 0
 
     private _onUnhandledMoveEvent = new Event<Direction>()
 
@@ -67,20 +103,61 @@ export class WindowManager {
         this._store = createStore()
     }
 
-    public split(
-        direction: SplitDirection,
+    // public split(
+    //     direction: SplitDirection,
+    //     newSplit: Oni.IWindowSplit,
+    //     referenceSplit?: Oni.IWindowSplit,
+    // ) {
+
+    //     this._primarySplit.split(augmentedWindow, direction, referenceSplit)
+    //     const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
+
+    //     this._store.dispatch({
+    //         type: "SET_PRIMARY_SPLITS",
+    //         splits: newState,
+    //     })
+
+    //     this._focusNewSplit(newSplit)
+    // }
+
+    public createSplit(
+        splitLocation: Direction | SplitDirection,
         newSplit: Oni.IWindowSplit,
-        referenceSplit?: Oni.IWindowSplit,
-    ) {
-        this._primarySplit.split(newSplit, direction, referenceSplit)
-        const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
+        referenceSplit?: any,
+    ): IWindowSplitHandle {
+        const nextId = this._lastId++
+        const windowId = "oni.window." + nextId.toString()
 
-        this._store.dispatch({
-            type: "SET_PRIMARY_SPLITS",
-            splits: newState,
-        })
+        const augmentedWindow = new AugmentedWindow(windowId, newSplit)
 
-        this._focusNewSplit(newSplit)
+        switch (splitLocation) {
+            case "right":
+            case "up":
+            case "down":
+            case "left": {
+                this._store.dispatch({
+                    type: "ADD_DOCK_SPLIT",
+                    dock: splitLocation,
+                    split: augmentedWindow,
+                })
+                break
+            }
+            case "horizontal":
+            case "vertical":
+                this._primarySplit.split(augmentedWindow, splitLocation, referenceSplit)
+                const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
+
+                this._store.dispatch({
+                    type: "SET_PRIMARY_SPLITS",
+                    splits: newState,
+                })
+
+                this._focusNewSplit(augmentedWindow)
+        }
+
+        return {
+            id: windowId,
+        }
     }
 
     public move(direction: Direction): void {
@@ -123,7 +200,7 @@ export class WindowManager {
         // TODO
     }
 
-    public close(split: Oni.IWindowSplit) {
+    public close(split: any) {
         this._primarySplit.close(split)
 
         const state = this._primarySplit.getState()
@@ -141,6 +218,11 @@ export class WindowManager {
         if (this._activeSplit && this._activeSplit.leave) {
             this._activeSplit.leave()
         }
+
+        this._store.dispatch({
+            type: "SET_FOCUSED_SPLIT",
+            splitId: null,
+        })
 
         this._activeSplit = newSplit
 

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -219,17 +219,16 @@ export class WindowManager {
             this._activeSplit.leave()
         }
 
-        this._store.dispatch({
-            type: "SET_FOCUSED_SPLIT",
-            splitId: newSplit.id,
-        })
-
         this._activeSplit = newSplit
 
         if (newSplit && newSplit.enter) {
             newSplit.enter()
         }
 
+        this._store.dispatch({
+            type: "SET_FOCUSED_SPLIT",
+            splitId: newSplit.id,
+        })
         // this._onActiveSplitChangedEvent.dispatch(this._activeSplit)
     }
 }

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -23,8 +23,6 @@ import { createStore, ISplitInfo, WindowState } from "./WindowManagerStore"
 export class WindowManager {
     private _activeSplit: any
 
-    private _onActiveSplitChangedEvent = new Event<Oni.IWindowSplit>()
-    private _onSplitChanged = new Event<ISplitInfo<Oni.IWindowSplit>>()
     private _onUnhandledMoveEvent = new Event<Direction>()
 
     private _leftDock: WindowDock = null
@@ -32,14 +30,6 @@ export class WindowManager {
     private _rootNavigator: RelationalSplitNavigator
 
     private _store: Store<WindowState>
-
-    public get onActiveSplitChanged(): IEvent<Oni.IWindowSplit> {
-        return this._onActiveSplitChangedEvent
-    }
-
-    public get onSplitChanged(): IEvent<ISplitInfo<Oni.IWindowSplit>> {
-        return this._onSplitChanged
-    }
 
     public get onUnhandledMove(): IEvent<Direction> {
         return this._onUnhandledMoveEvent
@@ -85,7 +75,11 @@ export class WindowManager {
         this._primarySplit.split(newSplit, direction, referenceSplit)
         const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
 
-        this._onSplitChanged.dispatch(newState)
+        this._store.dispatch({
+            type: "SET_PRIMARY_SPLITS",
+            splits: newState,
+        })
+
         this._focusNewSplit(newSplit)
     }
 
@@ -131,7 +125,12 @@ export class WindowManager {
 
     public close(split: Oni.IWindowSplit) {
         this._primarySplit.close(split)
-        this._onSplitChanged.dispatch(this.splitRoot)
+
+        const state = this._primarySplit.getState()
+        this._store.dispatch({
+            type: "SET_PRIMARY_SPLITS",
+            splits: state,
+        })
     }
 
     public focusSplit(split: Oni.IWindowSplit): void {
@@ -149,6 +148,6 @@ export class WindowManager {
             newSplit.enter()
         }
 
-        this._onActiveSplitChangedEvent.dispatch(this._activeSplit)
+        // this._onActiveSplitChangedEvent.dispatch(this._activeSplit)
     }
 }

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -221,7 +221,7 @@ export class WindowManager {
 
         this._store.dispatch({
             type: "SET_FOCUSED_SPLIT",
-            splitId: null,
+            splitId: newSplit.id,
         })
 
         this._activeSplit = newSplit

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -1,0 +1,91 @@
+/**
+ * WindowManagerStore.ts
+ *
+ * Redux store for managing window state
+ */
+
+import * as Oni from "oni-api"
+
+import { Store, Reducer } from "redux"
+import { createStore as createReduxStore } from "./../../Redux"
+
+import { Direction, ISplitInfo, SplitDirection } from "./index"
+
+export interface IAugmentedSplitInfo extends Oni.IWindowSplit {
+    // Potential API methods
+    enter?(): void
+    leave?(): void
+
+    // Internal bookkeeping
+    id: string
+}
+
+export type SplitOrLeaf<T> = ISplitInfo<T> | ISplitLeaf<T>
+
+export interface ISplitInfo<T> {
+    type: "Split"
+    splits: Array<SplitOrLeaf<T>>
+    direction: SplitDirection
+}
+
+export interface ISplitLeaf<T> {
+    type: "Leaf"
+    contents: T
+}
+
+type WindowActions =
+    | {
+          type: "SET_DOCK_SPLITS"
+          dock: Direction
+          splits: IAugmentedSplitInfo[]
+      }
+    | {
+          type: "SET_PRIMARY_SPLITS"
+          splits: ISplitInfo<IAugmentedSplitInfo>
+      }
+    | {
+          type: "SET_FOCUSED_SPLIT"
+          splitId: string
+      }
+    | {
+          type: "SHOW_SPLIT"
+          splitId: string
+      }
+    | {
+          type: "HIDE_SPLIT"
+          splitId: string
+      }
+
+export type DockWindows = { [key: string]: IAugmentedSplitInfo[] }
+
+export interface WindowState {
+    docks: DockWindows
+
+    primarySplit: ISplitInfo<IAugmentedSplitInfo>
+
+    focusedSplitId: string
+    hiddenSplits: string[]
+}
+
+export const DefaultWindowState: WindowState = {
+    docks: {
+        left: [],
+        right: [],
+        up: [],
+        down: [],
+    },
+    primarySplit: null,
+    focusedSplitId: null,
+    hiddenSplits: [],
+}
+
+export const reducer: Reducer<WindowState> = (
+    state: WindowState = DefaultWindowState,
+    action: WindowActions,
+) => {
+    return state
+}
+
+export const createStore = (): Store<WindowState> => {
+    return createReduxStore("WindowManager", reducer, DefaultWindowState, [])
+}

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -83,7 +83,15 @@ export const reducer: Reducer<WindowState> = (
     state: WindowState = DefaultWindowState,
     action: WindowActions,
 ) => {
-    return state
+    switch (action.type) {
+        case "SET_PRIMARY_SPLITS":
+            return {
+                ...state,
+                primarySplit: action.splits,
+            }
+        default:
+            return state
+    }
 }
 
 export const createStore = (): Store<WindowState> => {

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -35,9 +35,9 @@ export interface ISplitLeaf<T> {
 
 type WindowActions =
     | {
-          type: "SET_DOCK_SPLITS"
+          type: "ADD_DOCK_SPLIT"
           dock: Direction
-          splits: IAugmentedSplitInfo[]
+          split: IAugmentedSplitInfo
       }
     | {
           type: "SET_PRIMARY_SPLITS"
@@ -58,6 +58,13 @@ type WindowActions =
 
 export type DockWindows = { [key: string]: IAugmentedSplitInfo[] }
 
+export const DefaultDocksState: DockWindows = {
+    left: [],
+    right: [],
+    up: [],
+    down: [],
+}
+
 export interface WindowState {
     docks: DockWindows
 
@@ -68,12 +75,7 @@ export interface WindowState {
 }
 
 export const DefaultWindowState: WindowState = {
-    docks: {
-        left: [],
-        right: [],
-        up: [],
-        down: [],
-    },
+    docks: DefaultDocksState,
     primarySplit: null,
     focusedSplitId: null,
     hiddenSplits: [],
@@ -88,6 +90,24 @@ export const reducer: Reducer<WindowState> = (
             return {
                 ...state,
                 primarySplit: action.splits,
+            }
+        default:
+            return {
+                ...state,
+                docks: docksReducer(state.docks, action),
+            }
+    }
+}
+
+export const docksReducer: Reducer<DockWindows> = (
+    state: DockWindows = DefaultDocksState,
+    action: WindowActions,
+) => {
+    switch (action.type) {
+        case "ADD_DOCK_SPLIT":
+            return {
+                ...state,
+                [action.dock]: [...state[action.dock], action.split],
             }
         default:
             return state

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -6,18 +6,18 @@
 
 import * as Oni from "oni-api"
 
-import { Store, Reducer } from "redux"
+import { Reducer, Store } from "redux"
 import { createStore as createReduxStore } from "./../../Redux"
 
 import { Direction, ISplitInfo, SplitDirection } from "./index"
 
 export interface IAugmentedSplitInfo extends Oni.IWindowSplit {
+    // Internal bookkeeping
+    id: string
+
     // Potential API methods
     enter?(): void
     leave?(): void
-
-    // Internal bookkeeping
-    id: string
 }
 
 export type SplitOrLeaf<T> = ISplitInfo<T> | ISplitLeaf<T>
@@ -56,7 +56,9 @@ type WindowActions =
           splitId: string
       }
 
-export type DockWindows = { [key: string]: IAugmentedSplitInfo[] }
+export interface DockWindows {
+    [key: string]: IAugmentedSplitInfo[]
+}
 
 export const DefaultDocksState: DockWindows = {
     left: [],

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -91,6 +91,11 @@ export const reducer: Reducer<WindowState> = (
                 ...state,
                 primarySplit: action.splits,
             }
+        case "SET_FOCUSED_SPLIT":
+            return {
+                ...state,
+                focusedSplitId: action.splitId,
+            }
         default:
             return {
                 ...state,

--- a/browser/src/Services/WindowManager/WindowState.ts
+++ b/browser/src/Services/WindowManager/WindowState.ts
@@ -5,34 +5,3 @@
  *  - Applying a split
  *  - Closing a split
  */
-
-import { Direction, SplitDirection } from "./index"
-
-export type SplitOrLeaf<T> = ISplitInfo<T> | ISplitLeaf<T>
-
-export interface ISplitInfo<T> {
-    type: "Split"
-    splits: Array<SplitOrLeaf<T>>
-    direction: SplitDirection
-}
-
-export interface ISplitLeaf<T> {
-    type: "Leaf"
-    contents: T
-}
-
-export const getFurthestSplitInDirection = <T>(
-    root: SplitOrLeaf<T>,
-    direction: Direction,
-): ISplitLeaf<T> => {
-    if (!root) {
-        return null
-    }
-
-    switch (root.type) {
-        case "Leaf":
-            return root
-        case "Split":
-            return getFurthestSplitInDirection(root.splits[0], direction)
-    }
-}

--- a/browser/src/Services/WindowManager/WindowState.ts
+++ b/browser/src/Services/WindowManager/WindowState.ts
@@ -1,7 +1,0 @@
-/**
- * WindowSplit.ts
- *
- * Handles managing split state transitions, like:
- *  - Applying a split
- *  - Closing a split
- */

--- a/browser/src/Services/WindowManager/index.ts
+++ b/browser/src/Services/WindowManager/index.ts
@@ -15,7 +15,7 @@ export * from "./RelationalSplitNavigator"
 export * from "./SingleSplitProvider"
 export * from "./WindowDock"
 export * from "./WindowManager"
-export * from "./WindowState"
+export * from "./WindowManagerStore"
 
 // TODO: Possible API types?
 export type Direction = "up" | "down" | "left" | "right"
@@ -36,9 +36,8 @@ export const getInverseDirection = (direction: Direction): Direction => {
     }
 }
 
-import { SplitOrLeaf } from "./WindowState"
-
 import { WindowManager } from "./WindowManager"
+import { SplitOrLeaf } from "./WindowManagerStore"
 
 /**
  * Interface for something that can navigate between window splits

--- a/browser/src/Services/WindowManager/index.ts
+++ b/browser/src/Services/WindowManager/index.ts
@@ -8,8 +8,6 @@
  * to the active editor, and managing transitions between editors.
  */
 
-import * as Oni from "oni-api"
-
 export * from "./LinearSplitProvider"
 export * from "./RelationalSplitNavigator"
 export * from "./SingleSplitProvider"
@@ -37,14 +35,14 @@ export const getInverseDirection = (direction: Direction): Direction => {
 }
 
 import { WindowManager } from "./WindowManager"
-import { SplitOrLeaf } from "./WindowManagerStore"
+import { IAugmentedSplitInfo, SplitOrLeaf } from "./WindowManagerStore"
 
 /**
  * Interface for something that can navigate between window splits
  */
 export interface IWindowSplitNavigator {
-    contains(split: Oni.IWindowSplit): boolean
-    move(startSplit: Oni.IWindowSplit, direction: Direction): Oni.IWindowSplit
+    contains(split: IAugmentedSplitInfo): boolean
+    move(startSplit: IAugmentedSplitInfo, direction: Direction): IAugmentedSplitInfo
 }
 
 /**
@@ -56,12 +54,12 @@ export interface IWindowSplitNavigator {
  */
 export interface IWindowSplitProvider extends IWindowSplitNavigator {
     split(
-        newSplit: Oni.IWindowSplit,
+        newSplit: IAugmentedSplitInfo,
         direction: SplitDirection,
-        referenceSplit?: Oni.IWindowSplit,
+        referenceSplit?: IAugmentedSplitInfo,
     ): boolean
-    close(split: Oni.IWindowSplit): boolean
-    getState(): SplitOrLeaf<Oni.IWindowSplit>
+    close(split: IAugmentedSplitInfo): boolean
+    getState(): SplitOrLeaf<IAugmentedSplitInfo>
 }
 
 export const windowManager = new WindowManager()

--- a/browser/src/UI/Shell/ShellView.tsx
+++ b/browser/src/UI/Shell/ShellView.tsx
@@ -4,6 +4,8 @@
 
 import * as React from "react"
 
+import { Provider } from "react-redux"
+
 import * as Platform from "./../../Platform"
 
 import { getKeyEventToVimKey } from "./../../Input/Keyboard"
@@ -47,7 +49,9 @@ export class ShellView extends React.PureComponent<IShellViewComponentProps, {}>
                             </div>
                             <div className="container full">
                                 <div className="stack">
-                                    <WindowSplits windowManager={this.props.windowManager} />
+                                    <Provider store={this.props.windowManager.store}>
+                                        <WindowSplits />
+                                    </Provider>
                                 </div>
                                 <Overlays />
                             </div>

--- a/browser/src/UI/Shell/ShellView.tsx
+++ b/browser/src/UI/Shell/ShellView.tsx
@@ -50,7 +50,7 @@ export class ShellView extends React.PureComponent<IShellViewComponentProps, {}>
                             <div className="container full">
                                 <div className="stack">
                                     <Provider store={this.props.windowManager.store}>
-                                        <WindowSplits />
+                                        <WindowSplits windowManager={this.props.windowManager} />
                                     </Provider>
                                 </div>
                                 <Overlays />

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -6,25 +6,21 @@
 
 import * as React from "react"
 
-import * as Oni from "oni-api"
+import { connect } from "react-redux"
 
 import { WindowSplitHost } from "./WindowSplitHost"
 
-import { ISplitInfo, WindowManager } from "./../../Services/WindowManager"
+import { ISplitInfo, IAugmentedSplitInfo, WindowState } from "./../../Services/WindowManager"
 
 export interface IWindowSplitsProps {
-    windowManager: WindowManager
-}
-
-export interface IWindowSplitsState {
-    activeSplit: Oni.IWindowSplit
-    splitRoot: ISplitInfo<Oni.IWindowSplit>
-    leftDock: Oni.IWindowSplit[]
+    activeSplitId: string
+    splitRoot: ISplitInfo<IAugmentedSplitInfo>
+    leftDock: IAugmentedSplitInfo[]
 }
 
 export interface IDockProps {
-    activeSplit: Oni.IWindowSplit
-    splits: Oni.IWindowSplit[]
+    activeSplitId: string
+    splits: IAugmentedSplitInfo[]
 }
 
 export class Dock extends React.PureComponent<IDockProps, {}> {
@@ -36,7 +32,7 @@ export class Dock extends React.PureComponent<IDockProps, {}> {
                         key={i}
                         containerClassName="split"
                         split={s}
-                        isFocused={this.props.activeSplit === s}
+                        isFocused={this.props.activeSplitId === s.id}
                     />
                     <div className="split-spacer vertical" />
                 </div>
@@ -47,39 +43,9 @@ export class Dock extends React.PureComponent<IDockProps, {}> {
     }
 }
 
-export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindowSplitsState> {
-    constructor(props: IWindowSplitsProps) {
-        super(props)
-
-        this.state = {
-            activeSplit: props.windowManager.activeSplit,
-            splitRoot: props.windowManager.splitRoot,
-            leftDock: [...props.windowManager.getDock("left").splits],
-        }
-    }
-
-    public componentDidMount(): void {
-        this.props.windowManager.onSplitChanged.subscribe(newSplit => {
-            this.setState({
-                splitRoot: newSplit,
-            })
-        })
-
-        this.props.windowManager.getDock("left").onSplitsChanged.subscribe(() => {
-            this.setState({
-                leftDock: [...this.props.windowManager.getDock("left").splits],
-            })
-        })
-
-        this.props.windowManager.onActiveSplitChanged.subscribe(newSplit => {
-            this.setState({
-                activeSplit: newSplit,
-            })
-        })
-    }
-
+export class WindowSplitsView extends React.PureComponent<IWindowSplitsProps, {}> {
     public render() {
-        if (!this.state.splitRoot) {
+        if (!this.props.splitRoot) {
             return null
         }
 
@@ -90,11 +56,11 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
             height: "100%",
         }
 
-        const editors = this.state.splitRoot.splits.map((splitNode, i) => {
+        const editors = this.props.splitRoot.splits.map((splitNode, i) => {
             if (splitNode.type === "Split") {
                 return null
             } else {
-                const split: Oni.IWindowSplit = splitNode.contents
+                const split: IAugmentedSplitInfo = splitNode.contents
 
                 if (!split) {
                     return (
@@ -108,7 +74,7 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
                             containerClassName={"editor"}
                             key={i}
                             split={split}
-                            isFocused={split === this.state.activeSplit}
+                            isFocused={split.id === this.props.activeSplitId}
                         />
                     )
                 }
@@ -116,14 +82,23 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
         })
 
         // const spacer = this.state.leftDock.length > 0 ? <div className="split-spacer vertical" /> : null
-
         return (
             <div style={containerStyle}>
                 <div className="container horizontal full">
-                    <Dock splits={this.state.leftDock} activeSplit={this.state.activeSplit} />
+                    <Dock splits={this.props.leftDock} activeSplitId={this.props.activeSplitId} />
                     {editors}
                 </div>
             </div>
         )
     }
 }
+
+const mapStateToProps = (state: WindowState): IWindowSplitsProps => {
+    return {
+        activeSplitId: state.focusedSplitId,
+        leftDock: state.docks["left"],
+        splitRoot: state.primarySplit,
+    }
+}
+
+export const WindowSplits = connect(mapStateToProps)(WindowSplitsView)

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -10,14 +10,23 @@ import { connect } from "react-redux"
 
 import { WindowSplitHost } from "./WindowSplitHost"
 
-import { IAugmentedSplitInfo, ISplitInfo, WindowState } from "./../../Services/WindowManager"
+import {
+    IAugmentedSplitInfo,
+    ISplitInfo,
+    WindowManager,
+    WindowState,
+} from "./../../Services/WindowManager"
 
 import { noop } from "./../../Utility"
 
-export interface IWindowSplitsProps {
+export interface IWindowSplitsProps extends IWindowSplitsContainerProps {
     activeSplitId: string
     splitRoot: ISplitInfo<IAugmentedSplitInfo>
     leftDock: IAugmentedSplitInfo[]
+}
+
+export interface IWindowSplitsContainerProps {
+    windowManager: WindowManager
 }
 
 export interface IDockProps {
@@ -79,7 +88,7 @@ export class WindowSplitsView extends React.PureComponent<IWindowSplitsProps, {}
                             split={split}
                             isFocused={split.id === this.props.activeSplitId}
                             onClick={() => {
-                                this.props.windowManager.focusSplit(split)
+                                this.props.windowManager.focusSplit(split.id)
                             }}
                         />
                     )
@@ -87,7 +96,6 @@ export class WindowSplitsView extends React.PureComponent<IWindowSplitsProps, {}
             }
         })
 
-        // const spacer = this.state.leftDock.length > 0 ? <div className="split-spacer vertical" /> : null
         return (
             <div style={containerStyle}>
                 <div className="container horizontal full">
@@ -99,8 +107,12 @@ export class WindowSplitsView extends React.PureComponent<IWindowSplitsProps, {}
     }
 }
 
-const mapStateToProps = (state: WindowState): IWindowSplitsProps => {
+const mapStateToProps = (
+    state: WindowState,
+    containerProps: IWindowSplitsContainerProps,
+): IWindowSplitsProps => {
     return {
+        ...containerProps,
         activeSplitId: state.focusedSplitId,
         leftDock: state.docks.left,
         splitRoot: state.primarySplit,

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -10,7 +10,7 @@ import { connect } from "react-redux"
 
 import { WindowSplitHost } from "./WindowSplitHost"
 
-import { ISplitInfo, IAugmentedSplitInfo, WindowState } from "./../../Services/WindowManager"
+import { IAugmentedSplitInfo, ISplitInfo, WindowState } from "./../../Services/WindowManager"
 
 export interface IWindowSplitsProps {
     activeSplitId: string
@@ -96,7 +96,7 @@ export class WindowSplitsView extends React.PureComponent<IWindowSplitsProps, {}
 const mapStateToProps = (state: WindowState): IWindowSplitsProps => {
     return {
         activeSplitId: state.focusedSplitId,
-        leftDock: state.docks["left"],
+        leftDock: state.docks.left,
         splitRoot: state.primarySplit,
     }
 }

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -49,7 +49,7 @@ export const startEditors = async (
         workspace,
     )
     editorManager.setActiveEditor(editor)
-    windowManager.split("horizontal", editor)
+    windowManager.createSplit("horizontal", editor)
 
     await editor.init(args)
 }

--- a/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
+++ b/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
@@ -7,6 +7,10 @@ import * as assert from "assert"
 import { LinearSplitProvider } from "./../../../src/Services/WindowManager"
 
 export class MockWindowSplit {
+    public get id(): string {
+        return "mock.window"
+    }
+
     public render(): JSX.Element {
         return null
     }

--- a/browser/test/Services/WindowManager/RelationalSplitNavigatorTests.ts.ts
+++ b/browser/test/Services/WindowManager/RelationalSplitNavigatorTests.ts.ts
@@ -10,6 +10,10 @@ import {
 } from "./../../../src/Services/WindowManager"
 
 export class MockWindowSplit {
+    public get id(): string {
+        return "mock.window"
+    }
+
     public render(): JSX.Element {
         return null
     }

--- a/extensions/oni-plugin-markdown-preview/src/index.tsx
+++ b/extensions/oni-plugin-markdown-preview/src/index.tsx
@@ -168,6 +168,7 @@ class MarkdownPreview extends React.PureComponent<IMarkdownPreviewProps, IMarkdo
 
 class MarkdownPreviewEditor implements Oni.IWindowSplit {
     private _open: boolean = false
+    private _split: any
 
     constructor(private _oni: Oni.Plugin.Api) {
         this._oni.editors.activeEditor.onBufferEnter.subscribe(args => this.onBufferEnter(args))
@@ -184,14 +185,15 @@ class MarkdownPreviewEditor implements Oni.IWindowSplit {
     public open(): void {
         if (!this._open) {
             this._open = true
-            this._oni.windows.split(1, this)
+            // TODO: Update API
+            this._split = (this._oni.windows as any).createSplit("vertical", this)
         }
     }
 
     public close(): void {
         if (this._open) {
             this._open = false
-            this._oni.windows.close(this)
+            this._split.close()
         }
     }
 

--- a/extensions/oni-plugin-markdown-preview/src/index.tsx
+++ b/extensions/oni-plugin-markdown-preview/src/index.tsx
@@ -168,7 +168,7 @@ class MarkdownPreview extends React.PureComponent<IMarkdownPreviewProps, IMarkdo
 
 class MarkdownPreviewEditor implements Oni.IWindowSplit {
     private _open: boolean = false
-    private _split: any
+    private _split: Oni.WindowSplitHandle
 
     constructor(private _oni: Oni.Plugin.Api) {
         this._oni.editors.activeEditor.onBufferEnter.subscribe(args => this.onBufferEnter(args))
@@ -186,7 +186,7 @@ class MarkdownPreviewEditor implements Oni.IWindowSplit {
         if (!this._open) {
             this._open = true
             // TODO: Update API
-            this._split = (this._oni.windows as any).createSplit("vertical", this)
+            this._split = this._oni.windows.createSplit("vertical", this)
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
         "minimist": "1.2.0",
         "msgpack-lite": "0.1.26",
         "ocaml-language-server": "^1.0.21",
-        "oni-api": "^0.0.26",
+        "oni-api": "^0.0.30",
         "oni-neovim-binaries": "0.1.0",
         "oni-ripgrep": "0.0.3",
         "oni-types": "0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,9 +4502,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@^0.0.26:
-  version "0.0.26"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.26.tgz#07a23e6d12a61eed9bfecab0d0514ad9d785a210"
+oni-api@^0.0.30:
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.30.tgz#8bf54d15131f8f1cb5a72552d0383248a4622508"
 
 oni-neovim-binaries@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This is prepatory work for adding an API for WindowManager to explicitly control state about the splits. The goal is to have an API like `var split = Oni.windows.createSplit("horizontal", mySplit)`. 

From there, I should be able to do stuff like:
```
split.show()
split.hide()
split.setSize(...)
split.close()
```

The API is similiar to what we've had for menus, overlays, and statusbars, so I hope that it is a natural extension.

Using a redux store will make it easier leverage the state and hook up rendering to it. There are some pieces to untangle in terms of who owns what state between `WindowManager`, `WindowDock`, etc, but this is a step forward in implementing that functionality.

I'll need to rationalize this with the existing `addSplit` method to make sure I'm not breaking current functionality (the markdown preview uses this, so I'll test it prior to bringing this in completely).