### PR TITLE
Sidebar - Search: Remove filter for now

### DIFF
--- a/browser/src/Services/Search/index.tsx
+++ b/browser/src/Services/Search/index.tsx
@@ -134,7 +134,7 @@ export class SearchPaneView extends React.PureComponent<
             isActive: false,
             activeTextbox: null,
             searchQuery: "Type to search...",
-            fileFilter: "*.*",
+            fileFilter: null,
         }
     }
 
@@ -174,7 +174,7 @@ export class SearchPaneView extends React.PureComponent<
         return (
             <VimNavigator
                 active={this.state.isActive && !this.state.activeTextbox}
-                ids={["textbox.query", "textbox.filter"]}
+                ids={["textbox.query" /*, "textbox.filter"*/]}
                 onSelected={(selectedId: string) => {
                     this._onSelected(selectedId)
                 }}
@@ -190,7 +190,7 @@ export class SearchPaneView extends React.PureComponent<
                                 isFocused={selectedId === "textbox.query"}
                                 isActive={this.state.activeTextbox === "textbox.query"}
                             />
-                            <Label>Filter</Label>
+                            {/*<Label>Filter</Label>
                             <SearchTextBox
                                 val={this.state.fileFilter}
                                 onChangeText={val => this._onChangeFilesFilter(val)}
@@ -198,7 +198,7 @@ export class SearchPaneView extends React.PureComponent<
                                 onDismiss={() => this._clearActiveTextbox()}
                                 isFocused={selectedId === "textbox.filter"}
                                 isActive={this.state.activeTextbox === "textbox.filter"}
-                            />
+                            />*/}
                         </div>
                     )
                 }}
@@ -206,13 +206,13 @@ export class SearchPaneView extends React.PureComponent<
         )
     }
 
-    private _onChangeFilesFilter(val: string): void {
-        this.setState({
-            fileFilter: val,
-        })
+    // private _onChangeFilesFilter(val: string): void {
+    //     this.setState({
+    //         fileFilter: val,
+    //     })
 
-        this._startSearch()
-    }
+    //     this._startSearch()
+    // }
 
     private _onChangeSearchQuery(val: string): void {
         this.setState({


### PR DESCRIPTION
__Issue:__ The file filter functionality doesn't behave correctly cross-platform, so I'll remove it for now. If this feature ends up being useful, we can look at bringing it back (along with other search options, like case-matching, etc).

For now, we'll keep the search as an 'mvp' and have the basic search-while-typing functionality.