### PR TITLE
Sidebar - Plugins: Disable by default

### DIFF
--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -8,6 +8,7 @@ import * as React from "react"
 
 import { Event, IDisposable, IEvent } from "oni-types"
 
+import { Configuration } from "./../Services/Configuration"
 import { SidebarManager, SidebarPane } from "./../Services/Sidebar"
 
 import { SidebarContainerView, SidebarItemView } from "./../UI/components/SidebarItemView"
@@ -160,7 +161,13 @@ export class PluginsSidebarPaneView extends React.PureComponent<
     }
 }
 
-export const activate = (pluginManager: PluginManager, sidebarManager: SidebarManager) => {
-    const pane = new PluginsSidebarPane(pluginManager)
-    sidebarManager.add("plug", pane)
+export const activate = (
+    configuration: Configuration,
+    pluginManager: PluginManager,
+    sidebarManager: SidebarManager,
+) => {
+    if (configuration.getValue("sidebar.plugins.enabled")) {
+        const pane = new PluginsSidebarPane(pluginManager)
+        sidebarManager.add("plug", pane)
+    }
 }

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -257,6 +257,7 @@ const BaseConfiguration: IConfigurationValues = {
     "sidebar.width": "50px",
 
     "sidebar.marks.enabled": true,
+    "sidebar.plugins.enabled": false,
 
     "statusbar.enabled": true,
     "statusbar.fontSize": "0.9em",

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -205,6 +205,7 @@ export interface IConfigurationValues {
     "sidebar.width": string
 
     "sidebar.marks.enabled": boolean
+    "sidebar.plugins.enabled": boolean
 
     "statusbar.enabled": boolean
     "statusbar.fontSize": string

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -217,7 +217,7 @@ const start = async (args: string[]): Promise<void> => {
     Bookmarks.activate(configuration, editorManager, Sidebar.getInstance())
 
     const PluginsSidebarPane = await import("./Plugins/PluginSidebarPane")
-    PluginsSidebarPane.activate(pluginManager, sidebarManager)
+    PluginsSidebarPane.activate(configuration, pluginManager, sidebarManager)
 
     Performance.endMeasure("Oni.Start.Activate")
 


### PR DESCRIPTION
I'll disable the plugins on the sidebar by default, since it isn't too useful at the moment. It'll be a great starting point for something like #186 , though!

To see what we have today, you can still set `sidebar.plugins.enabled`.

It just lists the plugins discovered via Oni's built-in runtime path manager, but later we could add a discovery, installation, and plugin configuration experiences.