### PR TITLE
Fix 1407: Definition underline doesn't always update correctly

### DIFF
--- a/browser/src/Services/Language/LanguageStore.ts
+++ b/browser/src/Services/Language/LanguageStore.ts
@@ -244,6 +244,8 @@ export const queryForDefinitionEpic = (
 ): Epic<LanguageAction, ILanguageState> => (action$, store) =>
     action$
         .ofType("CURSOR_MOVED")
+        .debounceTime(configuration.getValue("editor.quickInfo.delay"))
+        .filter(() => store.getState().mode === "normal")
         .filter(
             () =>
                 store.getState().mode === "normal" &&


### PR DESCRIPTION
__Issue:__ This appears to be a regression from #1314 - originally, the hover query and definition query were grouped together, but this bug started reproducing after that change.

__Defect:__ There is a race condition - in `LanguageEditorIntegration`, we assume that the definition will be reset and then a new one produced, but because of the store throttling, and how quick the definition query is in some cases, that isn't always true (and the position won't be updated).

__Fix:__ The ideal fix would be to address the race condition in `LanguageEditorIntegration`, but if we bring the delay back it should work in general. Without the delay, and with the fix, the go-to definition is actually a bit jarring because of the variable delay between it and hover, so restoring the previous functionality (using the same _delay_) seems like a reasonable solution for now.