### PR TITLE
Fix #1436 - Automation: Use empty config if no configuration is specified

### DIFF
--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -49,8 +49,6 @@ const getConfigPath = (settings: any, rootPath: string) => {
 // Helper method to write a config to a temporary folder
 // Returns the path to the serialized config
 const serializeConfig = (configValues: { [key: string]: any }): string => {
-    log("Config: " + JSON.stringify(configValues))
-
     const stringifiedConfig = Object.keys(configValues).map(
         key => `"${key}": ${configValues[key]},`,
     )

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -49,6 +49,8 @@ const getConfigPath = (settings: any, rootPath: string) => {
 // Helper method to write a config to a temporary folder
 // Returns the path to the serialized config
 const serializeConfig = (configValues: { [key: string]: any }): string => {
+    log("Config: " + JSON.stringify(configValues))
+
     const stringifiedConfig = Object.keys(configValues).map(
         key => `"${key}": ${configValues[key]},`,
     )
@@ -77,13 +79,13 @@ const logWithTimeStamp = (message: string) => {
 
 export const runInProcTest = (rootPath: string, testName: string, timeout: number = 5000) => {
     describe(testName, () => {
-        const testCase = loadTest(rootPath, testName)
-
+        let testCase: ITestCase
         let oni: Oni
 
         beforeEach(async () => {
             logWithTimeStamp("BEFORE EACH: " + testName)
 
+            testCase = loadTest(rootPath, testName)
             const startOptions = {
                 configurationPath: testCase.configPath,
             }

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -32,14 +32,17 @@ const loadTest = (rootPath: string, testName: string): ITestCase => {
 import * as os from "os"
 
 const getConfigPath = (settings: any, rootPath: string) => {
-    if (!settings) {
-        return ""
-    } else if (settings.configPath) {
+    settings = settings || {}
+
+    if (settings.configPath) {
         return normalizePath(path.join(rootPath, settings.configPath))
     } else if (settings.config) {
         return normalizePath(serializeConfig(settings.config))
     } else {
-        return ""
+        // Fix #1436 - if no config is specified, we'll just use
+        // the empty config, so that the user's config doesn't
+        // impact the test results.
+        return normalizePath(serializeConfig({}))
     }
 }
 


### PR DESCRIPTION
__Issue:__ When running automation locally, if no configuration is specified for a test, the user's config is picked up - and in some cases this can cause problems. An example is having `textMateHighlighting` enabled with the `LargeFileTest` - there is a bug there that will cause a failure, but it's an existing issue not related to the developer's changes.

__Defect:__ If no config is specified, we fall back to the user's config instead of an empty config

__Fix:__ Use an empty config if no configuration was specified