### PR TITLE
Fix #1473: Run integration tests against local electron on developer machines

### DIFF
--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -8,12 +8,13 @@ const log = (msg: string) => {
 }
 
 const isCiBuild = () => {
-    const isCiBuild =
-        process.env["ONI_AUTOMATION_USE_DIST_BUILD"] ||
-        process.env["CONTINUOUS_INTEGRATION"] /* set by travis */ ||
-        process.env["APPVEYOR"] /* set by appveyor */
-    log("isCiBuild: " + isCiBuild)
-    return isCiBuild
+    const ciBuild = !!(
+        process.env.ONI_AUTOMATION_USE_DIST_BUILD ||
+        process.env.CONTINUOUS_INTEGRATION /* set by travis */ ||
+        process.env.APPVEYOR
+    ) /* set by appveyor */
+    log("isCiBuild: " + ciBuild)
+    return ciBuild
 }
 
 const getExecutablePathOnCiMachine = () => {
@@ -57,8 +58,9 @@ const getExecutablePathLocally = () => {
 }
 
 const getArgsForCiMachine = () => []
-const getArgsForLocalExecution = () =>
-    path.join(__dirname, "..", "..", "..", "lib", "main", "src", "main.js")
+const getArgsForLocalExecution = () => [
+    path.join(__dirname, "..", "..", "..", "lib", "main", "src", "main.js"),
+]
 
 export interface OniStartOptions {
     configurationPath?: string


### PR DESCRIPTION
__Issue:__ One pain point with debugging the CiTests is that they run against the packaged build, and its a long iteration loop. It definitely makes sense for them to run against packaged builds on the Ci machines, but locally, it's much easier if they run against the already setup electron.

__Fix:__ Use environment variables to gate whether we should launch from the local install or packaged install. On CI machines, we should use the dist build, but on local machines, we use the local electron. This can be overridden locally by setting the `ONI_AUTOMATION_USE_DIST_BUILD` environment variable.