### PR TITLE
Bugfix: Completion intermittently stops working

### DIFF
--- a/browser/src/Services/Completion/CompletionProviders.ts
+++ b/browser/src/Services/Completion/CompletionProviders.ts
@@ -64,7 +64,7 @@ export class CompletionProviders implements ICompletionsRequestor {
         filePath: string,
         completionItem: ICompletionInfoWithProvider,
     ): Promise<types.CompletionItem> {
-        if (completionItem.__provider) {
+        if (completionItem && completionItem.__provider) {
             const prov = this._getProviderById(completionItem.__provider)
 
             if (prov && prov.getCompletionDetails) {


### PR DESCRIPTION
__Issue:__ In some cases, the completion details provider can return null.

__Defect:__ We don't handle that case; we always assume a completion detail was returned.

__Fix:__ Protect against the case of a null `completionItem`