### PR TITLE
Fix regression in react/redux devtools

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -11,7 +11,7 @@ import { makeSingleInstance } from "./ProcessLifecycle"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
 
-const isDevelopment = process.env.NODE_ENV === "development" || process.env.ONI_WEBPACK_LOAD
+const isDevelopment = process.env.NODE_ENV === "development" || process.env.ONI_WEBPACK_LOAD === "1"
 const isDebug = process.argv.filter(arg => arg.indexOf("--debug") >= 0).length > 0
 
 interface IWindowState {

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -11,7 +11,7 @@ import { makeSingleInstance } from "./ProcessLifecycle"
 
 global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
 
-const isDevelopment = process.env.NODE_ENV === "development"
+const isDevelopment = process.env.NODE_ENV === "development" || process.env.ONI_WEBPACK_LOAD
 const isDebug = process.argv.filter(arg => arg.indexOf("--debug") >= 0).length > 0
 
 interface IWindowState {

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
         "css-loader": "0.28.4",
         "electron": "^1.8.2-beta.5",
         "electron-builder": "19.46.4",
-        "electron-devtools-installer": "2.2.1",
+        "electron-devtools-installer": "^2.2.3",
         "electron-mocha": "5.0.0",
         "electron-rebuild": "1.6.0",
         "extract-zip": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,9 +2100,9 @@ electron-chromedriver@~1.6.0:
     electron-download "^3.1.0"
     extract-zip "^1.6.0"
 
-electron-devtools-installer@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.1.tgz#0beb73ccbf65cbc4d09e706cebda638f839b8c55"
+electron-devtools-installer@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.3.tgz#58b9a4ec507377bc46e091cd43714188e0c369be"
   dependencies:
     "7zip" "0.0.6"
     cross-unzip "0.0.2"


### PR DESCRIPTION
Noticed that recently the react/redux devtools disappeared. Turns out there were two issues:
- The environment variable we use with `npm run start` changed, to minimize conflict. That should also be factored into the `isDevelopment` check in `main.ts`
- The `electron-devtools-installer` version we were using didn't support beta versions of electron. Updated to a new version that has a fix for beta versions.