### PR TITLE
Window Manager: Clicking on windows should focus window

### DIFF
--- a/browser/src/UI/components/WindowSplitHost.tsx
+++ b/browser/src/UI/components/WindowSplitHost.tsx
@@ -12,6 +12,7 @@ export interface IWindowSplitHostProps {
     split: Oni.IWindowSplit
     containerClassName: string
     isFocused: boolean
+    onClick: (evt: React.MouseEvent<HTMLElement>) => void
 }
 
 /**
@@ -22,7 +23,10 @@ export class WindowSplitHost extends React.PureComponent<IWindowSplitHostProps, 
         const className =
             this.props.containerClassName + (this.props.isFocused ? " focus" : " not-focused")
         return (
-            <div className="container vertical full">
+            <div
+                className="container vertical full"
+                onClick={evt => (!this.props.isFocused ? this.props.onClick(evt) : null)}
+            >
                 <div className={className}>{this.props.split.render()}</div>
             </div>
         )

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -37,6 +37,7 @@ export class Dock extends React.PureComponent<IDockProps, {}> {
                         containerClassName="split"
                         split={s}
                         isFocused={this.props.activeSplit === s}
+                        onClick={() => {}}
                     />
                     <div className="split-spacer vertical" />
                 </div>
@@ -109,6 +110,9 @@ export class WindowSplits extends React.PureComponent<IWindowSplitsProps, IWindo
                             key={i}
                             split={split}
                             isFocused={split === this.state.activeSplit}
+                            onClick={() => {
+                                this.props.windowManager.focusSplit(split)
+                            }}
                         />
                     )
                 }

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -12,6 +12,8 @@ import { WindowSplitHost } from "./WindowSplitHost"
 
 import { ISplitInfo, WindowManager } from "./../../Services/WindowManager"
 
+import { noop } from "./../../Utility"
+
 export interface IWindowSplitsProps {
     windowManager: WindowManager
 }
@@ -37,7 +39,7 @@ export class Dock extends React.PureComponent<IDockProps, {}> {
                         containerClassName="split"
                         split={s}
                         isFocused={this.props.activeSplit === s}
-                        onClick={() => {}}
+                        onClick={noop}
                     />
                     <div className="split-spacer vertical" />
                 </div>

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -29,6 +29,7 @@ export function nodeRequire(moduleName: string): any {
 }
 
 export const EmptyArray: any[] = []
+export const noop = () => {} // tslint:disable-line
 
 export const normalizePath = (fileName: string) => fileName.split("\\").join("/")
 


### PR DESCRIPTION
Now that we have multiple 'Windows', and focus tracked between them, it's important for clicking to behave as expected.

For now, if someone clicks on an editor window, we'll focus that window. (That behavior isn't there today, and can be confusing if someone is using the mouse)