### PR TITLE
Sidebar - UX: Clean up animation so it doesn't execute every sidebar transition

### DIFF
--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -117,7 +117,7 @@ export const SidebarHeaderWrapper = withProps<ISidebarHeaderProps>(styled.div)`
 export class SidebarHeaderView extends React.PureComponent<ISidebarHeaderProps, {}> {
     public render(): JSX.Element {
         return (
-            <SidebarHeaderWrapper {...this.props}>
+            <SidebarHeaderWrapper {...this.props} key={this.props.headerName}>
                 <span>{this.props.headerName}</span>
             </SidebarHeaderWrapper>
         )
@@ -172,9 +172,11 @@ export class SidebarContentView extends React.PureComponent<
         const header = activeEntry && activeEntry.pane ? activeEntry.pane.title : null
 
         return (
-            <SidebarContentWrapper key={activeEntry.id}>
+            <SidebarContentWrapper>
                 <SidebarHeaderView hasFocus={this.state.active} headerName={header} />
-                <SidebarInnerPaneWrapper>{activeEntry.pane.render()}</SidebarInnerPaneWrapper>
+                <SidebarInnerPaneWrapper key={activeEntry.id}>
+                    {activeEntry.pane.render()}
+                </SidebarInnerPaneWrapper>
             </SidebarContentWrapper>
         )
     }


### PR DESCRIPTION
The entrance animation would play every time the sidebar changed. That's a bit excessive and over the top, so this change sets it up to only play on initial load.