### PR TITLE
Fix #1446: Explorer - add overflow handling to items

### DIFF
--- a/browser/src/Services/Explorer/Explorer.less
+++ b/browser/src/Services/Explorer/Explorer.less
@@ -37,6 +37,9 @@
 
             .name {
                 flex: 1 1 auto;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
             }
         }
     }


### PR DESCRIPTION
This prevents wrapping of items in the explorer menu, and truncates with ellipsis if the name goes outside the explorer UI.

We still need to get resize behavior (#1414), but this is similiar to how other editors handle it.