### PR TITLE
[ISSUE-1439]: Display a list of all failed tests at the bottom of the…

### DIFF
--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -5,7 +5,7 @@ import * as path from "path"
 
 import * as mkdirp from "mkdirp"
 
-import { Oni, runInProcTest } from "./common"
+import { IFailedTest, Oni, runInProcTest } from "./common"
 
 const LongTimeout = 5000
 
@@ -49,13 +49,33 @@ export interface ITestCase {
     configPath: string
 }
 
+const FGRED = "\x1b[31m"
+const FGWHITE = "\x1b[37m"
+const FGGREEN = "\x1b[32m"
+const FGYELLOW = "\x1b[33m"
+
 // tslint:disable-next-line only-arrow-functions
 describe("ci tests", function() {
     const tests = Platform.isWindows()
         ? [...CiTests, ...WindowsOnlyTests]
         : Platform.isMac() ? [...CiTests, ...OSXOnlyTests] : CiTests
 
+    const testFailures: IFailedTest[] = []
     CiTests.forEach(test => {
-        runInProcTest(path.join(__dirname, "ci"), test)
+        runInProcTest(path.join(__dirname, "ci"), test, 5000, testFailures)
+    })
+
+    // After all of the tests are completed display failures
+    after(() => {
+        if (testFailures.length > 0) {
+            console.log("\n", FGRED, "---- FAILED TESTS ----\n")
+            testFailures.forEach(failure => {
+                console.log(FGYELLOW, "  [FAILED]:", FGWHITE, failure.test)
+                console.log(FGWHITE, "     Expected:", FGGREEN, failure.expected)
+                console.log(FGWHITE, "     Actual:", FGRED, failure.actual)
+                console.log(FGWHITE, "     Path:", failure.path, "\n")
+            })
+            console.log("")
+        }
     })
 })

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -12,6 +12,13 @@ export interface ITestCase {
     configPath: string
 }
 
+export interface IFailedTest {
+    test: string
+    path: string
+    expected: any
+    actual: any
+}
+
 const normalizePath = p => p.split("\\").join("/")
 
 const loadTest = (rootPath: string, testName: string): ITestCase => {
@@ -75,7 +82,12 @@ const logWithTimeStamp = (message: string) => {
     console.log(`[${deltaInSeconds}] ${message}`)
 }
 
-export const runInProcTest = (rootPath: string, testName: string, timeout: number = 5000) => {
+export const runInProcTest = (
+    rootPath: string,
+    testName: string,
+    timeout: number = 5000,
+    failures: IFailedTest[] = null,
+) => {
     describe(testName, () => {
         let testCase: ITestCase
         let oni: Oni
@@ -139,6 +151,16 @@ export const runInProcTest = (rootPath: string, testName: string, timeout: numbe
             console.log("")
 
             const result = JSON.parse(resultText)
+            if (failures && !result.passed) {
+                const failedTest: IFailedTest = {
+                    test: testName,
+                    path: testCase.testPath,
+                    expected: result.exception.expected,
+                    actual: result.exception.actual,
+                }
+                failures.push(failedTest)
+            }
+
             assert.ok(result.passed)
         })
     })


### PR DESCRIPTION
… CITest output

This is what I've come up with:

![tests](https://user-images.githubusercontent.com/17413539/35959012-8637bcd2-0c58-11e8-812e-f8d0c81bfd3e.png)

Ideally, we would suppress the native output at the very bottom, but I wasn't sure how to go about doing that. I'm open to suggestions!