### PR TITLE
Build - Artifact Upload: Fix upload logic in to our s3 container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ $LOCALAPPDATA
 lib
 lib_test
 dist
+s3_dist
 
 ### https://raw.github.com/github/gitignore/2b3b1f428fb84dc4ba3ad2307ec44af3c5799848/Node.gitignore
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,12 @@ deploy:
       secret_access_key:
         secure: S4f/aczEABGAMKk2tmVSkoGx+T2TLPmz5z6x6RKaM+eDmAaVSAELlIj1eAz6Tu2lv3jz+cpyAIISZNC/phORsJWwzbSZHVycLrMG0N3fDTqKFxu1fl6L3b3exRe9SiKXug73ZvHfktzd/XfRcgZKop4qgrwGiM57m0ZuZb/j1LkgjytTuvNAUxXbA84I8LZs/NhY17XuXq+KPlGElIHy3UFoGqQ8pBnTypkIU5rQTsoeAxXLBE8JAFfz+nBGZ7dx6OMbQcKX5jKh/gR3vk+4aTgV8gNE2Zp24ErjSqF2zly/gP9nE2DpfR7jqpZVHnb/v+OEjRDS80tLhPo8Dbibzwt2ZZNADpYBjSGtphwAmq4DCvJ7ORExOB5+O3wmXKQGdItyBTS7sW44n6BTyv87WxWuCaSDQ9QaO9PrbJdN5YGEYeRxSTM7Mn0t72IILkfFCUeSg6fl6tFs9iWIj5zltbxH1GQsRpA8j1Idg4O+894KnQABtw/YKh6rrdeYS9y/100qAjtV6qYyiP2IdPqMWGuasOiz87q3CQ8Ejd7uhiTjAaINVqos+0k04Yf5+rT4MqkeXnYFzjXuXcqDlpq6yJIZv3aD+PMSlZi2WmTYnPJXQFndHo/x9FhEh90UF9WdO5S27ySRSo8XQT4DyL3ToPkqz8y0slNmaNqiqMouQAU=
       bucket: oni-builds
-      file:
-        - dist/*.dmg
-        - dist/*.zip
+      local-dir: s3_dist
       upload-dir: osx_builds
       acl: public_read
       region: us-west-2
       skip_cleanup: true
       on:
-        condition: $TRAVIS_OS_NAME = osx
         repo: onivim/oni
     - provider: releases
       api_key:

--- a/build/script/CopyPackedFilesForS3Upload.js
+++ b/build/script/CopyPackedFilesForS3Upload.js
@@ -1,0 +1,35 @@
+/**
+ * Helper script to copy the packaged files to an 's3' folder
+ * for upload to s3
+ */
+
+const path = require("path")
+const fs = require("fs")
+const mkdirp = require("mkdirp")
+
+const rootPath = path.join(__dirname, "..", "..")
+const distPath = path.join(rootPath, "dist")
+const s3_distPath = path.join(rootPath, "s3_dist")
+
+console.log(`Creating 's3_dist' folder at: ${s3_distPath}`)
+mkdirp.sync(s3_distPath)
+
+// Get all files in 'dist'..
+const filesAndFolder = fs.readdirSync(distPath)
+
+// And copy the files to `s3_dist`
+filesAndFolder.forEach(f => {
+    console.log("- Checking: " + f)
+
+    const fullPath = path.join(distPath, f)
+    const stat = fs.statSync(fullPath)
+
+    if (stat.isFile()) {
+        const destPath = path.join(s3_distPath, f)
+        console.log(`-- Copying ${fullPath} to ${destPath}`)
+        fs.copyFileSync(fullPath, destPath)
+        console.log(`-- Copy successful`)
+    }
+})
+
+console.log("CopyPackedFilesForS3Upload::Complete")

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -38,3 +38,5 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     # npm run ccov:test:browser
     # npm run ccov:report
 fi
+
+npm run copy-dist-to-s3

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "cd browser && tsc -p tsconfig.test.json",
         "copy-icons": "node build/CopyIcons.js",
+        "copy-dist-to-s3": "node build/script/CopyPackedFilesForS3Upload.js",
         "debug:test:unit:browser":
             "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
         "demo": "npm run build:test && mocha -t 30000 lib_test/test/Demo.js",


### PR DESCRIPTION
__Issue:__ The S3 deployment provider is uploading the entire Oni folder, including all node_modules - causing a timeout.

__Defect__:  The s3 deployment provider for Travis CI doesn't respect the `file` parameter - instead, it wants a `local_dir` to specify where to upload from. 

__Fix__: Copy the files over to a staging file and then upload from there.