### PR TITLE
Sidebar: Add toggle functionality

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -108,4 +108,6 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     // TODO: Scope 's' to just the local window
     input.bind("<c-g>", "sneak.show", () => isNormalMode() && !menu.isMenuOpen())
     input.bind(["<esc>", "<c-c>"], "sneak.hide")
+
+    input.bind("<s-c-b>", "sidebar.toggle", isNormalMode)
 }

--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -33,7 +33,7 @@ export class SidebarContentSplit {
         return entry && entry.pane ? entry.pane : null
     }
 
-    constructor(private _sidebarManager: SidebarManager = new SidebarManager()) {}
+    constructor(private _sidebarManager: SidebarManager) {}
 
     public enter(): void {
         const pane: any = this.activePane

--- a/browser/src/Services/Sidebar/SidebarSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarSplit.tsx
@@ -12,7 +12,7 @@ import { SidebarManager } from "./SidebarStore"
 import { Sidebar } from "./SidebarView"
 
 export class SidebarSplit {
-    constructor(private _sidebarManager: SidebarManager = new SidebarManager()) {}
+    constructor(private _sidebarManager: SidebarManager) {}
 
     public enter(): void {
         this._sidebarManager.setActiveEntry(this._sidebarManager.activeEntryId)

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -7,6 +7,10 @@
 import { Reducer, Store } from "redux"
 import { createStore as createReduxStore } from "./../../Redux"
 
+import { WindowManager, WindowSplitHandle } from "./../WindowManager"
+import { SidebarContentSplit } from "./SidebarContentSplit"
+import { SidebarSplit } from "./SidebarSplit"
+
 import * as Oni from "oni-api"
 
 export interface ISidebarState {
@@ -38,6 +42,9 @@ export interface SidebarPane extends Oni.IWindowSplit {
 export class SidebarManager {
     private _store: Store<ISidebarState>
 
+    private _iconSplit: WindowSplitHandle
+    private _contentSplit: WindowSplitHandle
+
     public get activeEntryId(): string {
         return this._store.getState().activeEntryId
     }
@@ -50,8 +57,11 @@ export class SidebarManager {
         return this._store
     }
 
-    constructor() {
+    constructor(private _windowManager: WindowManager) {
         this._store = createStore()
+
+        this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
+        this._contentSplit = this._windowManager.createSplit("left", new SidebarContentSplit(this))
     }
 
     public setActiveEntry(id: string): void {
@@ -60,6 +70,22 @@ export class SidebarManager {
                 type: "SET_ACTIVE_ID",
                 activeEntryId: id,
             })
+
+            if (!this._contentSplit.isVisible) {
+                this._contentSplit.show()
+            }
+        }
+    }
+
+    public toggleSidebarVisibility(): void {
+        if (this._contentSplit.isVisible) {
+            this._contentSplit.hide()
+
+            if (this._contentSplit.isFocused) {
+                this._iconSplit.focus()
+            }
+        } else {
+            this._contentSplit.show()
         }
     }
 

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -5,8 +5,6 @@ import { windowManager } from "./../../Services/WindowManager"
 import { Workspace } from "./../../Services/Workspace"
 
 import { ExplorerSplit } from "./../Explorer/ExplorerSplit"
-import { SidebarContentSplit } from "./SidebarContentSplit"
-import { SidebarSplit } from "./SidebarSplit"
 import { SidebarManager } from "./SidebarStore"
 
 let _sidebarManager: SidebarManager = null
@@ -14,13 +12,20 @@ let _sidebarManager: SidebarManager = null
 export * from "./SidebarStore"
 
 export const activate = (configuration: Configuration, workspace: Workspace) => {
-    _sidebarManager = new SidebarManager()
+    _sidebarManager = new SidebarManager(windowManager)
+    _sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
 
+    commandManager.registerCommand({
+        command: "sidebar.toggle",
+        name: "Sidebar: Toggle",
+        detail: "Show / hide the contents of the sidebar pane.",
+        execute: () => _sidebarManager.toggleSidebarVisibility(),
+    })
+
+    // TODO: Bring this back
     if (configuration.getValue("sidebar.enabled")) {
-        windowManager.createSplit("left", new SidebarSplit(_sidebarManager))
-        windowManager.createSplit("left", new SidebarContentSplit(_sidebarManager))
-
-        _sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
+        // windowManager.createSplit("left", new SidebarSplit(_sidebarManager))
+        // windowManager.createSplit("left", new SidebarContentSplit(_sidebarManager))
     }
 }
 

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -12,20 +12,16 @@ let _sidebarManager: SidebarManager = null
 export * from "./SidebarStore"
 
 export const activate = (configuration: Configuration, workspace: Workspace) => {
-    _sidebarManager = new SidebarManager(windowManager)
-    _sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
-
-    commandManager.registerCommand({
-        command: "sidebar.toggle",
-        name: "Sidebar: Toggle",
-        detail: "Show / hide the contents of the sidebar pane.",
-        execute: () => _sidebarManager.toggleSidebarVisibility(),
-    })
-
-    // TODO: Bring this back
     if (configuration.getValue("sidebar.enabled")) {
-        // windowManager.createSplit("left", new SidebarSplit(_sidebarManager))
-        // windowManager.createSplit("left", new SidebarContentSplit(_sidebarManager))
+        _sidebarManager = new SidebarManager(windowManager)
+        _sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
+
+        commandManager.registerCommand({
+            command: "sidebar.toggle",
+            name: "Sidebar: Toggle",
+            detail: "Show / hide the contents of the sidebar pane.",
+            execute: () => _sidebarManager.toggleSidebarVisibility(),
+        })
     }
 }
 

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -98,6 +98,19 @@ export const reducer: Reducer<WindowState> = (
                 ...state,
                 focusedSplitId: action.splitId,
             }
+        case "SHOW_SPLIT":
+            return {
+                ...state,
+                hiddenSplits: state.hiddenSplits.filter(s => s !== action.splitId),
+            }
+        case "HIDE_SPLIT":
+            return {
+                ...state,
+                hiddenSplits: [
+                    ...state.hiddenSplits.filter(s => s !== action.splitId),
+                    action.splitId,
+                ],
+            }
         default:
             return {
                 ...state,
@@ -119,6 +132,10 @@ export const docksReducer: Reducer<DockWindows> = (
         default:
             return state
     }
+}
+
+export const leftDockSelector = (state: WindowState) => {
+    return state.docks["left"].filter(s => state.hiddenSplits.indexOf(s.id) === -1)
 }
 
 export const createStore = (): Store<WindowState> => {

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -135,7 +135,7 @@ export const docksReducer: Reducer<DockWindows> = (
 }
 
 export const leftDockSelector = (state: WindowState) => {
-    return state.docks["left"].filter(s => state.hiddenSplits.indexOf(s.id) === -1)
+    return state.docks.left.filter(s => state.hiddenSplits.indexOf(s.id) === -1)
 }
 
 export const createStore = (): Store<WindowState> => {

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -13,6 +13,7 @@ import { WindowSplitHost } from "./WindowSplitHost"
 import {
     IAugmentedSplitInfo,
     ISplitInfo,
+    leftDockSelector,
     WindowManager,
     WindowState,
 } from "./../../Services/WindowManager"
@@ -114,7 +115,7 @@ const mapStateToProps = (
     return {
         ...containerProps,
         activeSplitId: state.focusedSplitId,
-        leftDock: state.docks.left,
+        leftDock: leftDockSelector(state),
         splitRoot: state.primarySplit,
     }
 }


### PR DESCRIPTION
This adds functionality to toggle the sidebar contents, exposing a command `sidebar.toggle`, which is by default bound to `Control+Shift+B`.

This leverages the new window split APIs introduced in #1449 