### PR TITLE
Menu: Bring back 'additionalComponent'

### DIFF
--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -251,6 +251,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
                     highlightIndices={this.props.detailHighlights}
                     highlightClassName={"highlight"}
                 />
+                {this.props.additionalComponent}
             </MenuItemWrapper>
         )
     }


### PR DESCRIPTION
It looks like the `additionalComponent` was removed during a merge resolution, so I'm bringing it back.

We're using it in the command palette to show keyboard shortcuts for commands:
![image](https://user-images.githubusercontent.com/13532591/35996887-9c5ceff4-0ccc-11e8-85bf-4582649c47d8.png)