### PR TITLE
Feature/Add inner name component to truncate long names

### DIFF
--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -77,7 +77,6 @@
     transition: opacity 0.25s;
 
     overflow: hidden;
-    text-overflow: ellipsis;
     user-select: none;
 
     .name {

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -16,6 +16,7 @@ import { addDefaultUnitIfNeeded } from "./../../Font"
 
 import { Sneakable } from "./../../UI/components/Sneakable"
 import { Icon } from "./../../UI/Icon"
+import { styled, withProps } from "./../components/common"
 
 import { FileIcon } from "./../../Services/FileIcon"
 
@@ -54,6 +55,13 @@ export interface ITabsProps {
     fontFamily: string
     fontSize: string
 }
+
+const InnerName = withProps<{ isLong?: boolean }>(styled.span)`
+    ${p => p.isLong && `width: 250px;`};
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+`
 
 export class Tabs extends React.PureComponent<ITabsProps, {}> {
     public render(): JSX.Element {
@@ -155,7 +163,9 @@ export class Tab extends React.Component<ITabPropsWithClick> {
                         />
                     </div>
                     <div className="name" onClick={this.props.onClickName}>
-                        <span className="name-inner">{this.props.name}</span>
+                        <InnerName isLong={this.props.name.length > 50}>
+                            {this.props.name}
+                        </InnerName>
                     </div>
                     <div className="corner enable-hover" onClick={this.props.onClickClose}>
                         <div className="icon-container x-icon-container">


### PR DESCRIPTION
This PR adds truncation to long file names rather than wrapping which leads to issues with padding, there seems to have been an attempt in the less to add text overflow etc, I've added a styled component to render the name as the explicit styles are needed on the component itself (which is why this wasnt already working) and also an explicit width is necessary for the text overflow to kick in but setting a static width forces all tabs to be at that width which is visually undesirable. This component renders a width *only* if a file name is longer than 50 chars and prevents wrapping of the text

output:

<img width="463" alt="screen shot 2018-02-09 at 13 18 47" src="https://user-images.githubusercontent.com/22454918/36029843-c18ddbf0-0d9c-11e8-837e-b3d927d02724.png">