### PR TITLE
Error Handling / Robustness: Show notification when there is an unhandled error / rejection

### DIFF
--- a/browser/src/Services/Notifications/NotificationsView.tsx
+++ b/browser/src/Services/Notifications/NotificationsView.tsx
@@ -61,7 +61,6 @@ const NotificationWrapper = styled.div`
     background-color: red;
     color: white;
     width: 20em;
-    height: 4em;
 
     margin: 1em;
 
@@ -112,12 +111,16 @@ const NotificationTitle = styled.div`
 
     font-weight: bold;
     font-size: 1.1em;
+
+    margin-top: 0.5em;
 `
 
 const NotificationDescription = styled.div`
     flex: 1 1 auto;
     overflow-y: auto;
-    overflow-x: none;
+    overflow-x: hidden;
+
+    margin: 1em 0em;
 
     font-size: 0.9em;
 `

--- a/browser/src/Services/Notifications/index.ts
+++ b/browser/src/Services/Notifications/index.ts
@@ -6,6 +6,8 @@ import { OverlayManager } from "./../Overlay"
 
 import { Notifications } from "./Notifications"
 
+export * from "./Notifications"
+
 let _notifications: Notifications = null
 
 export const activate = (overlayManager: OverlayManager): void => {

--- a/browser/src/Services/UnhandledErrorMonitor.ts
+++ b/browser/src/Services/UnhandledErrorMonitor.ts
@@ -1,0 +1,90 @@
+/**
+ * UnhandledErrorMonitor
+ *
+ * Helper module to listen to unhandled errors
+ */
+
+import { Event, IEvent } from "oni-types"
+
+import { Notifications } from "./Notifications"
+
+export class UnhandledErrorMonitor {
+    private _onUnhandledErrorEvent = new Event<Error>()
+    private _onUnhandledRejectionEvent = new Event<string>()
+
+    private _queuedErrors: Error[] = []
+    private _queuedRejections: string[] = []
+    private _started: boolean = false
+
+    public get onUnhandledError(): IEvent<Error> {
+        return this._onUnhandledErrorEvent
+    }
+
+    public get onUnhandledRejection(): IEvent<string> {
+        return this._onUnhandledRejectionEvent
+    }
+
+    constructor() {
+        window.addEventListener("unhandledrejection", (evt: any) => {
+            if (!this._started) {
+                this._queuedRejections.push(evt.reason)
+            }
+
+            this._onUnhandledRejectionEvent.dispatch(evt.reason)
+        })
+
+        window.addEventListener("error", (evt: any) => {
+            if (!this._started) {
+                this._queuedErrors.push(evt.error)
+            }
+
+            this._onUnhandledErrorEvent.dispatch(evt.error)
+        })
+    }
+
+    public start(): void {
+        this._started = true
+
+        this._queuedRejections.forEach(rejection =>
+            this._onUnhandledRejectionEvent.dispatch(rejection),
+        )
+        this._queuedErrors.forEach(err => this._onUnhandledErrorEvent.dispatch(err))
+
+        this._queuedErrors = []
+        this._queuedRejections = []
+    }
+}
+
+let _unhandledErrorMonitor: UnhandledErrorMonitor = null
+
+export const activate = () => {
+    if (!_unhandledErrorMonitor) {
+        _unhandledErrorMonitor = new UnhandledErrorMonitor()
+    }
+}
+
+import { remote } from "electron"
+
+export const start = (notifications: Notifications) => {
+    const showError = (title: string, errorText: string) => {
+        const notification = notifications.createItem()
+
+        notification.onClick.subscribe(() => {
+            remote.getCurrentWebContents().openDevTools()
+        })
+
+        notification.setLevel("error")
+        notification.setContents(title, errorText)
+        notification.show()
+    }
+
+    _unhandledErrorMonitor.onUnhandledError.subscribe(val => {
+        const errorText = val ? val.toString() : "Open the debugger for more details."
+        showError("Unhandled Exception", errorText + "\nPlease report this error.")
+    })
+
+    _unhandledErrorMonitor.onUnhandledRejection.subscribe(val => {
+        const errorText: string = val ? val.toString() : "Open the debugger for more details."
+        showError("Unhandled Rejection", errorText + "\nPlease report this error.")
+    })
+}

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -16,6 +16,9 @@ import { IConfigurationValues } from "./Services/Configuration/IConfigurationVal
 const start = async (args: string[]): Promise<void> => {
     Performance.startMeasure("Oni.Start")
 
+    const UnhandledErrorMonitor = await import("./Services/UnhandledErrorMonitor")
+    UnhandledErrorMonitor.activate()
+
     const Shell = await import("./UI/Shell")
     Shell.activate()
 
@@ -131,6 +134,8 @@ const start = async (args: string[]): Promise<void> => {
 
     const Notifications = await notificationsPromise
     Notifications.activate(overlayManager)
+
+    UnhandledErrorMonitor.start(Notifications.getInstance())
 
     const Tasks = await taksPromise
     Tasks.activate(menuManager)


### PR DESCRIPTION
This implements one of the changes I mentioned in #1488 to 'fail fast' and show the user an error when it happens. The notification, on click, opens the debugger.

This puts errors 'front and center':
![image](https://user-images.githubusercontent.com/13532591/36054394-0274d052-0dab-11e8-913b-0f605797b227.png)

So that we 'fail fast' and can make them immediately actionable, instead of hitting downstream issues.

These sorts of changes can cause some pain _initially_, but the goal is that we tackle the issues, build up our safety net w/ automation, and end up with more robust tool in the long run.