### PR TITLE
Bugfix/add package json to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package.json
+vim/core/oni-plugin-typescript/package.json

--- a/vim/core/oni-plugin-typescript/package.json
+++ b/vim/core/oni-plugin-typescript/package.json
@@ -10,7 +10,10 @@
         "test": "npm install && tsc -p tsconfig.test.json && mocha --recursive ./lib_test/test"
     },
     "oni": {
-        "supportedFileTypes": ["javascript", "typescript"]
+        "supportedFileTypes": [
+            "javascript",
+            "typescript"
+        ]
     },
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
Not sure what the best solution would be to this but since `npm/yarn` insist on formatting the packages .json this constantly leaves changed files post push or commit, which occasionally have to be stashed to change branches etc. or muddy the water in terms of knowing what i've actually meaningfully changed. A solution to get round this is to add new package.json files to a `prettierignore` that way there isn't a competition (ps not sure if some sort of glob would work, theres nothing in the docs about globbing)