### PR TITLE
Bugfix/on focus split error

### DIFF
--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -108,7 +108,9 @@ export class ExplorerSplit {
         switch (selectedItem.type) {
             case "file":
                 this._editorManager.activeEditor.openFile(selectedItem.filePath)
-                windowManager.focusSplit(this._editorManager.activeEditor as any)
+                // FIXME: the editor manager is not a windowSplit aka this
+                // Should be being called with an ID not an active editor
+                windowManager.focusSplit("oni.window.0")
                 return
             case "folder":
                 const isDirectoryExpanded = ExplorerSelectors.isPathExpanded(

--- a/browser/src/Services/Sidebar/SidebarPane/SidebarPane.tsx
+++ b/browser/src/Services/Sidebar/SidebarPane/SidebarPane.tsx
@@ -35,13 +35,13 @@ export class SidebarPane {
         )
     }
 
-    public enter(): void {
+    public async enter(): Promise<void> {
         this._menuBinding = getInstance().bindToMenu()
 
         const widgets = this._store.getState().widgets
         const ids = flatMap(widgets, w => w.ids)
 
-        this._menuBinding.setItems(ids)
+        await this._menuBinding.setItems(ids)
 
         this._menuBinding.onCursorMoved.subscribe((id: string) => {
             this._store.dispatch({

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -110,7 +110,7 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
         }
     }
 
-    private _updateBasedOnProps(props: IVimNavigatorProps) {
+    private async _updateBasedOnProps(props: IVimNavigatorProps) {
         if (props.active && !this._activeBinding) {
             Log.info("[VimNavigator::activating]")
             this._releaseBinding()
@@ -140,10 +140,10 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
                 }
             })
 
-            this._activeBinding.setItems(this.props.ids, this.state.selectedId)
+            await this._activeBinding.setItems(this.props.ids, this.state.selectedId)
             this._activateEvent.dispatch()
         } else if (props.active && this._activeBinding) {
-            this._activeBinding.setItems(this.props.ids, this.state.selectedId)
+            await this._activeBinding.setItems(this.props.ids, this.state.selectedId)
         } else if (!props.active && this._activeBinding) {
             this._releaseBinding()
         }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -347,7 +347,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         return this.callFunction("OniGetContext", [])
     }
 
-    public start(startOptions?: INeovimStartOptions): Promise<void> {
+    public async start(startOptions?: INeovimStartOptions): Promise<void> {
         Performance.startMeasure("NeovimInstance.Start")
         this._initPromise = startNeovim(startOptions).then(nv => {
             Log.info("NeovimInstance: Neovim started")

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -93,7 +93,7 @@ export class MenuBinding extends Binding implements IMenuBinding {
     }
 
     public async setItems(items: string[], activeId?: string): Promise<void> {
-        this._promiseQueue.enqueuePromise(async () => {
+        await this._promiseQueue.enqueuePromise(async () => {
             if (items === this._currentOptions && activeId === this._currentId) {
                 return
             }

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -132,7 +132,6 @@ export class MenuBinding extends Binding implements IMenuBinding {
 }
 
 class SharedNeovimInstance implements SharedNeovimInstance {
-    private _initPromise: Promise<void>
     private _neovimInstance: NeovimInstance
 
     public get isInitialized(): boolean {
@@ -158,10 +157,8 @@ class SharedNeovimInstance implements SharedNeovimInstance {
             useDefaultConfig: true,
         }
 
-        this._initPromise = this._neovimInstance.start(startOptions)
-
         Log.info("[SharedNeovimInstance::start] Starting...")
-        await this._initPromise
+        await this._neovimInstance.start(startOptions)
         Log.info("[SharedNeovimInstance::start] Started successfully!")
     }
 }

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -93,7 +93,7 @@ export class MenuBinding extends Binding implements IMenuBinding {
     }
 
     public async setItems(items: string[], activeId?: string): Promise<void> {
-        await this._promiseQueue.enqueuePromise(async () => {
+        this._promiseQueue.enqueuePromise(async () => {
             if (items === this._currentOptions && activeId === this._currentId) {
                 return
             }
@@ -103,6 +103,9 @@ export class MenuBinding extends Binding implements IMenuBinding {
             this._currentOptions = items
             this._currentId = activeId
 
+            if (!this.neovimInstance.isInitialized) {
+                return
+            }
             const currentWinId = await this.neovimInstance.request("nvim_get_current_win", [])
             const currentBufId = await this.neovimInstance.eval("bufnr('%')")
             const bufferLength = await this.neovimInstance.eval<number>("line('$')")


### PR DESCRIPTION
@bryphe thanks to the new error ux I was coerced 😆 (actually think it is a great idea 🍾 though I wish it would only inform of an error once not every single time it occurs, maybe we could cache/storing error messages and only show the new modal if the error hasn't already been seen before, plus it specifically address an issue I raised 🚀 #1488 )
into looking into this bug which kept occurring whilst using splits.

Seems that setting menu items in the `sharedNeovimInterface` is async so I've change the calls to reflect that. Another issue which the bug raised which I havent found a solution for is that in the file explorer on opening a file `windowManager.focus` is called but with the `Oni.Editor` rather than a windowSplit id which is what it expects, except as far as I can see it the Oni.Editor has no knowledge of which split it belongs to which I imagine is a sensible thing for me to add I just have no idea where or how they interrelate since each split has a `private` inner editor and the editor has no idea about splits

EDIT: My temporary fix/hack was to pass in what I noted manually was the right split id which quietens down the errors. PS: if you agree re storing the messages i'm happy to look into that the red banners are a great call to action but also undismissable, 

TODO:

- [x] As well as the above this is a note to self that there is still a missing await as an error still occurs on initial vim enter 🤔 