### PR TITLE
Stop waiting for Oni at end of install.

### DIFF
--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -33,7 +33,7 @@ Name: "addToRightClickMenu"; Description: "Add {{AppName}} to the right click me
 Name: "{group}\{{AppName}}"; Filename: "{app}\{{AppExecutableName}}"
 
 [Run]
-Filename: "{app}\{{AppName}}"; Flags: postinstall skipifsilent
+Filename: "{app}\{{AppName}}"; Flags: postinstall skipifsilent nowait
 
 [Code]
 function NeedsAddPath(Param: string): boolean;


### PR DESCRIPTION
Tiny change for a tiny bug.

At the end of installing on Windows, the option to run Oni causes the installer to wait and not close until Oni is closed.
This allows the installer to close as expected.

Only other thing I noticed is there is currently a difference between Windows + other platforms, where Windows is a registered editor for less file types than we have in the `package.json`. Should probably update `BuildSetupTemplate.js` now so that it generates the filetype list on the fly from the `package.json` list, so we don't have multiple versions of the truth.