### PR TITLE
Bug fix: Crash in 'handleInput' if buffer is not available

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -794,7 +794,7 @@ export class NeovimEditor extends Editor implements IEditor {
 
         // Check if any of the buffer layers can handle the input...
         const buf: IBuffer = this.activeBuffer as IBuffer
-        const result = buf.handleInput(key)
+        const result = buf && buf.handleInput(key)
 
         if (result) {
             return


### PR DESCRIPTION
__Issue:__ In some cases, we can get a crash in `handleInput` when we try and call `buffer.handleInput` from `NeovimEditor`.

__Defect:__ This code is intended to allow a buffer / buffer layer to get a chance at the input (this is used in the welcome menu, for example, to allow for keyboard navigation). However, it assumes there is always a valid buffer available, which isn't always the case - we don't get the buffer object until a buffer event comes through. 

__Fix:__ Null check `buf` before calling `handleInput` on it.