### PR TITLE
Notifications: Add configuration setting to enable / disable

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -250,6 +250,8 @@ const BaseConfiguration: IConfigurationValues = {
     "menu.rowHeight": 40,
     "menu.maxItemsToShow": 8,
 
+    "notifications.enabled": true,
+
     "recorder.copyScreenshotToClipboard": false,
     "recorder.outputPath": os.tmpdir(),
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -193,6 +193,8 @@ export interface IConfigurationValues {
     "menu.rowHeight": number
     "menu.maxItemsToShow": number
 
+    "notifications.enabled": boolean
+
     // Output path to save screenshots and recordings
     "recorder.outputPath": string
 

--- a/browser/src/Services/Notifications/Notifications.ts
+++ b/browser/src/Services/Notifications/Notifications.ts
@@ -23,7 +23,14 @@ export class Notifications {
 
         this._overlay = this._overlayManager.createItem()
         this._overlay.setContents(getView(this._store))
+    }
+
+    public enable(): void {
         this._overlay.show()
+    }
+
+    public disable(): void {
+        this._overlay.hide()
     }
 
     public createItem(): Notification {

--- a/browser/src/Services/Notifications/index.ts
+++ b/browser/src/Services/Notifications/index.ts
@@ -2,16 +2,33 @@
  * index.ts
  */
 
+import * as Log from "./../../Log"
+
 import { OverlayManager } from "./../Overlay"
 
+import { Configuration } from "./../Configuration"
 import { Notifications } from "./Notifications"
 
 export * from "./Notifications"
 
 let _notifications: Notifications = null
 
-export const activate = (overlayManager: OverlayManager): void => {
+export const activate = (configuration: Configuration, overlayManager: OverlayManager): void => {
     _notifications = new Notifications(overlayManager)
+
+    const updateFromConfiguration = () => {
+        const areNotificationsEnabled = configuration.getValue("notifications.enabled")
+        Log.info("[Notifications] Setting enabled: " + areNotificationsEnabled)
+        areNotificationsEnabled ? _notifications.enable() : _notifications.disable()
+    }
+
+    configuration.onConfigurationChanged.subscribe(val => {
+        if (typeof val["notifications.enabled"] === "boolean") {
+            updateFromConfiguration()
+        }
+    })
+
+    updateFromConfiguration()
 }
 
 export const getInstance = (): Notifications => {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -133,7 +133,7 @@ const start = async (args: string[]): Promise<void> => {
     const menuManager = Menu.getInstance()
 
     const Notifications = await notificationsPromise
-    Notifications.activate(overlayManager)
+    Notifications.activate(configuration, overlayManager)
 
     UnhandledErrorMonitor.start(Notifications.getInstance())
 

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -80,3 +80,9 @@ export const test = async (oni: any) => {
     await oni.automation.waitFor(() => lastAlertText !== null, 20000)
     console.log("Alert text (screenshot output path): " + lastAlertText)
 }
+
+export const settings = {
+    config: {
+        "notifications.enabled": false,
+    },
+}


### PR DESCRIPTION
The notifications should be on-by-default, but we should give the user the opportunity to opt-out, too. I also noticed they were popping up in our hero screenshot on our website!

![screenshot-darwin](https://user-images.githubusercontent.com/13532591/36065139-57d2a68c-0e4b-11e8-82cc-29f7252b837c.png)

Still need to track down that error separately...