### PR TITLE
Automation - Sidebar: Test case for toggling split

### DIFF
--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -172,7 +172,7 @@ export class SidebarContentView extends React.PureComponent<
         const header = activeEntry && activeEntry.pane ? activeEntry.pane.title : null
 
         return (
-            <SidebarContentWrapper>
+            <SidebarContentWrapper className="sidebar-content">
                 <SidebarHeaderView hasFocus={this.state.active} headerName={header} />
                 <SidebarInnerPaneWrapper key={activeEntry.id}>
                     {activeEntry.pane.render()}

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -24,6 +24,7 @@ const CiTests = [
     "QuickOpenTest",
     "StatusBar-Mode",
     "NoInstalledNeovim",
+    "Sidebar.ToggleSplitTest",
     "WindowManager.ErrorBoundary",
     "Workspace.ConfigurationTest",
 

--- a/test/ci/Sidebar.ToggleSplitTest.ts
+++ b/test/ci/Sidebar.ToggleSplitTest.ts
@@ -1,0 +1,29 @@
+/**
+ * Test script to validate sidebar split toggle behavior
+ */
+
+import * as assert from "assert"
+
+import * as Oni from "oni-api"
+
+const getSidebarSplit = () => {
+    return document.querySelectorAll(".sidebar-content")
+}
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    // Wait for sidebar split to appear
+    await oni.automation.waitFor(() => getSidebarSplit().length === 1)
+
+    // Validate sidebar is hidden
+    oni.commands.executeCommand("sidebar.toggle")
+    await oni.automation.waitFor(() => getSidebarSplit().length === 0)
+    assert.ok(true, "Sidebar was hidden.")
+
+    // Validate sidebar comes back
+    oni.commands.executeCommand("sidebar.toggle")
+    await oni.automation.waitFor(() => getSidebarSplit().length === 1)
+
+    assert.ok(true, "Sidebar came back.")
+}


### PR DESCRIPTION
This adds some automation coverage for the sidebar - validating toggling the split shows/hides the split pane.