### PR TITLE
[ISSUE-246]: Add --help option to command-line oni

### DIFF
--- a/cli/oni
+++ b/cli/oni
@@ -12,7 +12,17 @@ processOptions.env = Object.assign({}, process.env, { "LOCAL_ONI": 1 })
 
 var isWindows = os.platform() === "win32";
 
-var args = process.argv.slice(2);
+var argv = require("minimist")(process.argv.slice(2));
+var args = argv._;
+var version = require(path.join(__dirname, "..", "package.json")).version;
+
+if(argv.help || argv.h) {
+    process.stdout.write("ONI: Modern Modal Editing - powered by Neovim\n");
+    process.stdout.write(` version: ${version}\n`);
+    process.stdout.write("\nUsage:\n oni [FILE]\t\tEdit file\n");
+    process.stdout.write("\nhttps://github.com/onivim/oni\n")
+    process.exit(0);
+}
 args.unshift(path.resolve(path.join(__dirname, "..", "lib", "main", "src", "main.js")))
 
 // In Windows, directly call into the electron executable - otherwise we"ll end up with a floating node console

--- a/cli/oni
+++ b/cli/oni
@@ -12,17 +12,7 @@ processOptions.env = Object.assign({}, process.env, { "LOCAL_ONI": 1 })
 
 var isWindows = os.platform() === "win32";
 
-var argv = require("minimist")(process.argv.slice(2));
-var args = argv._;
-var version = require(path.join(__dirname, "..", "package.json")).version;
-
-if(argv.help || argv.h) {
-    process.stdout.write("ONI: Modern Modal Editing - powered by Neovim\n");
-    process.stdout.write(` version: ${version}\n`);
-    process.stdout.write("\nUsage:\n oni [FILE]\t\tEdit file\n");
-    process.stdout.write("\nhttps://github.com/onivim/oni\n")
-    process.exit(0);
-}
+var args = process.argv.slice(2);
 args.unshift(path.resolve(path.join(__dirname, "..", "lib", "main", "src", "main.js")))
 
 // In Windows, directly call into the electron executable - otherwise we"ll end up with a floating node console

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -1,3 +1,4 @@
+import * as minimist from "minimist"
 import * as path from "path"
 
 import { app, BrowserWindow, ipcMain, Menu } from "electron"
@@ -13,6 +14,17 @@ global["getLogs"] = Log.getAllLogs // tslint:disable-line no-string-literal
 
 const isDevelopment = process.env.NODE_ENV === "development" || process.env.ONI_WEBPACK_LOAD === "1"
 const isDebug = process.argv.filter(arg => arg.indexOf("--debug") >= 0).length > 0
+
+// We want to check for the 'help' flag before initializing electron
+const argv = minimist(process.argv.slice(1))
+const version = require(path.join(__dirname, "..", "..", "..", "package.json")).version // tslint:disable-line no-var-requires
+if (argv.help || argv.h) {
+    process.stdout.write("ONI: Modern Modal Editing - powered by Neovim\n")
+    process.stdout.write(` version: ${version}\n`)
+    process.stdout.write("\nUsage:\n oni [FILE]\t\tEdit file\n")
+    process.stdout.write("\nhttps://github.com/onivim/oni\n")
+    process.exit(0)
+}
 
 interface IWindowState {
     bounds?: {


### PR DESCRIPTION
> based on #246 

- Added `--help` (also `-h`) to command line initialization
sample output:

![args](https://user-images.githubusercontent.com/17413539/36066808-ac91beb4-0e65-11e8-9191-f872a9f96089.png)
