### PR TITLE
Bugfix/ Catch thrown error in tss parsing response

### DIFF
--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -81,7 +81,12 @@ export class TypeScriptServerHost extends events.EventEmitter {
 
         this._rl.on("line", msg => {
             if (msg.indexOf("{") === 0) {
-                this._parseResponse(msg)
+                try {
+                    this._parseResponse(msg)
+                } catch (e) {
+                    // tslint:disable-next-line
+                    console.warn(`Error parsing TSS response: ${e}`)
+                }
             }
         })
     }


### PR DESCRIPTION
When parsing a response from the `tss` if the response fails, we currently reject with an error which isn't handled at all, this error seems to crop up if you rename a file or open a new file (ts) I think the `tss` is probably correctly not able to deal with request since it maybe doesn't know what happened not sure if theres a better solution here but seems we should at least catch the error, not sure whether more need to be done here but I just log that that occured 🤷‍♂️ 