### PR TITLE
Automation: Improve robustness of process-kill strategy

### DIFF
--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -108,7 +108,14 @@ const ensureOniNotRunning = async () => {
 
         filteredProcesses.forEach(processInfo => {
             console.log("Attemping to kill pid: " + processInfo.pid)
-            process.kill(processInfo.pid)
+            // Sometimes, there can be a race condition here. For example,
+            // the process may have closed between when we queried above
+            // and when we try to kill it. So we'll wrap it in a try/catch.
+            try {
+                process.kill(processInfo.pid)
+            } catch (ex) {
+                console.warn(ex)
+            }
         })
         attempts++
     }


### PR DESCRIPTION
__Issue:__ Sometimes our call to `process.kill` crashes. On Linux, we sometimes see an exception value of `ESRCH` which means it couldn't find the process pid.

__Defect:__ There is a race condition - the process may have closed between querying for the process info and actually trying to `kill` it.

__Fix:__ There isn't a robust way to check for this, so we'll wrap in a `try...catch` and log the error. If the `process.kill` failed because it's already closed, that's fine. If the `process.kill` failed and wasn't able to close the process, we should follow the retry logic... 