### PR TITLE
Automation: Don't write log for passing tests

### DIFF
--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -176,14 +176,19 @@ export const runInProcTest = (
                 })
             }
 
-            const rendererLogs: any[] = await oni.client.getRenderProcessLogs()
-            console.log("")
-            console.log("---LOGS (Renderer): " + testName)
-            writeLogs(rendererLogs)
-            console.log("--- " + testName + " ---")
-
             console.log("Getting result...")
             const resultText = await oni.client.getText(".automated-test-result")
+            const result = JSON.parse(resultText)
+
+            if (!result || !result.passed) {
+                const rendererLogs: any[] = await oni.client.getRenderProcessLogs()
+                console.log("")
+                console.log("---LOGS (Renderer): " + testName)
+                writeLogs(rendererLogs)
+                console.log("--- " + testName + " ---")
+            } else {
+                console.log("-- LOGS: Skipped writing logs because the test passed.")
+            }
 
             console.log("")
             logWithTimeStamp("---RESULT: " + testName)
@@ -191,7 +196,6 @@ export const runInProcTest = (
             console.log("--- " + testName + " ---")
             console.log("")
 
-            const result = JSON.parse(resultText)
             if (failures && !result.passed) {
                 const failedTest: IFailedTest = {
                     test: testName,


### PR DESCRIPTION
Our test output is getting pretty huge. I think that we really only care about the logs if the test fails, so I added a condition to skip writing the log if the test passed.