### PR TITLE
Sidebar - Refactoring: Separate Explorer initialization

### DIFF
--- a/browser/src/Services/Explorer/index.tsx
+++ b/browser/src/Services/Explorer/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * Explorer/index.tsx
+ *
+ * Entry point for explorer-related features
+ */
+
+import { CommandManager } from "./../CommandManager"
+import { EditorManager } from "./../EditorManager"
+import { SidebarManager } from "./../Sidebar"
+import { Workspace } from "./../Workspace"
+
+import { ExplorerSplit } from "./ExplorerSplit"
+
+export const activate = (
+    commandManager: CommandManager,
+    editorManager: EditorManager,
+    sidebarManager: SidebarManager,
+    workspace: Workspace,
+) => {
+    sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
+}

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -1,10 +1,8 @@
 import { commandManager } from "./../../Services/CommandManager"
 import { Configuration } from "./../../Services/Configuration"
-import { editorManager } from "./../../Services/EditorManager"
 import { windowManager } from "./../../Services/WindowManager"
 import { Workspace } from "./../../Services/Workspace"
 
-import { ExplorerSplit } from "./../Explorer/ExplorerSplit"
 import { SidebarManager } from "./SidebarStore"
 
 let _sidebarManager: SidebarManager = null
@@ -14,7 +12,6 @@ export * from "./SidebarStore"
 export const activate = (configuration: Configuration, workspace: Workspace) => {
     if (configuration.getValue("sidebar.enabled")) {
         _sidebarManager = new SidebarManager(windowManager)
-        _sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
 
         commandManager.registerCommand({
             command: "sidebar.toggle",

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -189,8 +189,14 @@ const start = async (args: string[]): Promise<void> => {
 
     Performance.startMeasure("Oni.Start.Sidebar")
     const Sidebar = await sidebarPromise
+    const Explorer = await import("./Services/Explorer")
+    const Search = await import("./Services/Search")
+
     Sidebar.activate(configuration, workspace)
     const sidebarManager = Sidebar.getInstance()
+
+    Explorer.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
+    Search.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
     Performance.endMeasure("Oni.Start.Sidebar")
 
     const createLanguageClientsFromConfiguration =
@@ -219,12 +225,6 @@ const start = async (args: string[]): Promise<void> => {
 
     const Snippets = await snippetPromise
     Snippets.activate()
-
-    const Explorer = await import("./Services/Explorer")
-    Explorer.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
-
-    const Search = await import("./Services/Search")
-    Search.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
 
     const ThemePicker = await themePickerPromise
     ThemePicker.activate(configuration, menuManager, Themes.getThemeManagerInstance())

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -220,6 +220,9 @@ const start = async (args: string[]): Promise<void> => {
     const Snippets = await snippetPromise
     Snippets.activate()
 
+    const Explorer = await import("./Services/Explorer")
+    Explorer.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
+
     const Search = await import("./Services/Search")
     Search.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
 


### PR DESCRIPTION
Today the Explorer is initialized implicitly with the sidebar - this change splits it out so that it is initialized externally. This decouples the sidebar from having to know about any of the sidebar panes (and means that the sidebar doesn't need to care about `EditorManager` anymore)