### PR TITLE
UX: Add a simple spinner while a search query is in progress

### DIFF
--- a/browser/src/Services/Search/SearchPaneView.tsx
+++ b/browser/src/Services/Search/SearchPaneView.tsx
@@ -1,0 +1,184 @@
+/**
+ * Search/index.tsx
+ *
+ * Entry point for search-related features
+ */
+
+import * as React from "react"
+
+import { IDisposable, IEvent } from "oni-types"
+
+import { Workspace } from "./../Workspace"
+
+export * from "./SearchProvider"
+
+import { ISearchOptions } from "./SearchProvider"
+
+import { SearchTextBox } from "./SearchTextBox"
+import styled from "styled-components"
+
+import { SidebarEmptyPaneView } from "./../../UI/components/SidebarEmptyPaneView"
+import { VimNavigator } from "./../../UI/components/VimNavigator"
+
+const Label = styled.div`
+    margin: 8px;
+`
+
+export interface ISearchPaneViewProps {
+    workspace: Workspace
+    onEnter: IEvent<void>
+    onLeave: IEvent<void>
+    onFocus: IEvent<void>
+    focusImmediately?: boolean
+
+    onSearchOptionsChanged: (opts: ISearchOptions) => void
+}
+
+export interface ISearchPaneViewState {
+    activeWorkspace: string
+    isActive: boolean
+    activeTextbox: string
+
+    searchQuery: string
+    fileFilter: string
+}
+
+export class SearchPaneView extends React.PureComponent<
+    ISearchPaneViewProps,
+    ISearchPaneViewState
+> {
+    private _subscriptions: IDisposable[] = []
+
+    constructor(props: ISearchPaneViewProps) {
+        super(props)
+
+        this.state = {
+            activeWorkspace: this.props.workspace.activeWorkspace,
+            isActive: false,
+            activeTextbox: null,
+            searchQuery: "Search...",
+            fileFilter: null,
+        }
+    }
+
+    public componentDidMount(): void {
+        this._cleanExistingSubscriptions()
+
+        const s1 = this.props.onEnter.subscribe(() => this.setState({ isActive: true }))
+        const s2 = this.props.onLeave.subscribe(() => this.setState({ isActive: false }))
+        const s3 = this.props.workspace.onDirectoryChanged.subscribe((wd: string) =>
+            this.setState({ activeWorkspace: wd }),
+        )
+
+        const s4 = this.props.onFocus.subscribe(() =>
+            this.setState({ activeTextbox: "textbox.query" }),
+        )
+
+        this._subscriptions = [s1, s2, s3, s4]
+
+        if (this.props.focusImmediately) {
+            this.setState({
+                activeTextbox: "textbox.query",
+            })
+        }
+    }
+
+    public componentWillUnmount(): void {
+        this._cleanExistingSubscriptions()
+    }
+
+    private _cleanExistingSubscriptions(): void {
+        this._subscriptions.forEach(s => s.dispose())
+        this._subscriptions = []
+    }
+
+    public render(): JSX.Element {
+        if (!this.state.activeWorkspace) {
+            return (
+                <SidebarEmptyPaneView
+                    active={this.state.isActive}
+                    contentsText="Nothing to search, yet!"
+                    actionButtonText={"Open Folder"}
+                    onClickButton={() => this.props.workspace.openFolder()}
+                />
+            )
+        }
+
+        return (
+            <VimNavigator
+                active={this.state.isActive && !this.state.activeTextbox}
+                ids={["textbox.query" /*, "textbox.filter"*/]}
+                onSelected={(selectedId: string) => {
+                    this._onSelected(selectedId)
+                }}
+                render={(selectedId: string) => {
+                    return (
+                        <div>
+                            <Label>Query</Label>
+                            <SearchTextBox
+                                val={this.state.searchQuery}
+                                onChangeText={val => this._onChangeSearchQuery(val)}
+                                onCommit={() => this._clearActiveTextbox()}
+                                onDismiss={() => this._clearActiveTextbox()}
+                                isFocused={selectedId === "textbox.query"}
+                                isActive={this.state.activeTextbox === "textbox.query"}
+                                onClick={() => this._onSelected("textbox.query")}
+                            />
+                            {/*<Label>Filter</Label>
+                            <SearchTextBox
+                                val={this.state.fileFilter}
+                                onChangeText={val => this._onChangeFilesFilter(val)}
+                                onCommit={() => this._clearActiveTextbox()}
+                                onDismiss={() => this._clearActiveTextbox()}
+                                isFocused={selectedId === "textbox.filter"}
+                                isActive={this.state.activeTextbox === "textbox.filter"}
+                            />*/}
+                        </div>
+                    )
+                }}
+            />
+        )
+    }
+
+    // private _onChangeFilesFilter(val: string): void {
+    //     this.setState({
+    //         fileFilter: val,
+    //     })
+
+    //     this._startSearch()
+    // }
+
+    private _onChangeSearchQuery(val: string): void {
+        this.setState({
+            searchQuery: val,
+        })
+
+        this._startSearch()
+    }
+
+    // private _onCommit(): void {
+
+    // }
+
+    private _clearActiveTextbox(): void {
+        this.setState({ activeTextbox: null })
+    }
+
+    private _onSelected(selectedId: string): void {
+        if (selectedId === "button.search") {
+            this._startSearch()
+        } else if (selectedId === "textbox.query") {
+            this.setState({ activeTextbox: "textbox.query" })
+        } else if (selectedId === "textbox.filter") {
+            this.setState({ activeTextbox: "textbox.filter" })
+        }
+    }
+
+    private _startSearch(): void {
+        this.props.onSearchOptionsChanged({
+            searchQuery: this.state.searchQuery,
+            fileFilter: this.state.fileFilter,
+            workspace: this.props.workspace.activeWorkspace,
+        })
+    }
+}

--- a/browser/src/Services/Search/SearchPaneView.tsx
+++ b/browser/src/Services/Search/SearchPaneView.tsx
@@ -153,7 +153,7 @@ export class SearchPaneView extends React.PureComponent<
             searchQuery: val,
         })
 
-        this._startSearch()
+        this._startSearch(val)
     }
 
     // private _onCommit(): void {
@@ -165,18 +165,16 @@ export class SearchPaneView extends React.PureComponent<
     }
 
     private _onSelected(selectedId: string): void {
-        if (selectedId === "button.search") {
-            this._startSearch()
-        } else if (selectedId === "textbox.query") {
+        if (selectedId === "textbox.query") {
             this.setState({ activeTextbox: "textbox.query" })
         } else if (selectedId === "textbox.filter") {
             this.setState({ activeTextbox: "textbox.filter" })
         }
     }
 
-    private _startSearch(): void {
+    private _startSearch(val: string): void {
         this.props.onSearchOptionsChanged({
-            searchQuery: this.state.searchQuery,
+            searchQuery: val,
             fileFilter: this.state.fileFilter,
             workspace: this.props.workspace.activeWorkspace,
         })

--- a/browser/src/Services/Search/SearchResultsSpinnerView.tsx
+++ b/browser/src/Services/Search/SearchResultsSpinnerView.tsx
@@ -1,0 +1,90 @@
+/**
+ * Search/index.tsx
+ *
+ * Entry point for search-related features
+ */
+
+import * as React from "react"
+
+import { IDisposable, IEvent } from "oni-types"
+
+import styled, { keyframes } from "styled-components"
+
+import { withProps } from "./../../UI/components/common"
+import { Icon, IconSize } from "./../../UI/Icon"
+
+export interface ISearchResultSpinnerViewProps {
+    onSearchStarted: IEvent<void>
+    onSearchFinished: IEvent<void>
+}
+
+export interface ISearchResultSpinnerViewState {
+    isActive: boolean
+}
+
+const SpinnerWrapper = withProps<{ isActive: boolean }>(styled.div)`
+    opacity: ${props => (props.isActive ? "0.5" : "0")};
+    transition: opacity 0.5s ease-in;
+
+    width: 100%;
+    min-height: 5em;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    position: relative;
+`
+
+const RotateKeyFrames = keyframes`
+    0% { transform: rotateZ(0deg); }
+    100% { transform: rotateZ(360deg); }
+`
+
+const SpinnerRotator = styled.div`
+    animation: ${RotateKeyFrames} 0.5s linear infinite;
+    transform-origin: center;
+`
+
+export class SearchResultSpinnerView extends React.PureComponent<
+    ISearchResultSpinnerViewProps,
+    ISearchResultSpinnerViewState
+> {
+    private _subscriptions: IDisposable[] = []
+
+    constructor(props: ISearchResultSpinnerViewProps) {
+        super(props)
+
+        this.state = {
+            isActive: false,
+        }
+    }
+
+    public componentDidMount(): void {
+        this._cleanExistingSubscriptions()
+
+        const s1 = this.props.onSearchStarted.subscribe(() => this.setState({ isActive: true }))
+        const s2 = this.props.onSearchFinished.subscribe(() => this.setState({ isActive: false }))
+
+        this._subscriptions = [s1, s2]
+    }
+
+    public componentWillUnmount(): void {
+        this._cleanExistingSubscriptions()
+    }
+
+    private _cleanExistingSubscriptions(): void {
+        this._subscriptions.forEach(s => s.dispose())
+        this._subscriptions = []
+    }
+
+    public render(): JSX.Element {
+        return (
+            <SpinnerWrapper isActive={this.state.isActive}>
+                <SpinnerRotator>
+                    <Icon name={"circle-o-notch"} size={IconSize.ThreeX} />
+                </SpinnerRotator>
+            </SpinnerWrapper>
+        )
+    }
+}

--- a/browser/src/Services/Search/index.tsx
+++ b/browser/src/Services/Search/index.tsx
@@ -6,9 +6,9 @@
 
 import * as React from "react"
 
-import { Event, IDisposable, IEvent } from "oni-types"
-
 import { Subject } from "rxjs/Subject"
+
+import { Event, IEvent } from "oni-types"
 
 import { CommandManager } from "./../CommandManager"
 import { EditorManager } from "./../EditorManager"
@@ -18,14 +18,14 @@ import { Workspace } from "./../Workspace"
 export * from "./SearchProvider"
 
 import {
-    ISearchProvider,
     ISearchOptions,
+    ISearchProvider,
     ISearchQuery,
-    RipGrepSearchProvider,
     QuickFixSearchResultsViewer,
+    RipGrepSearchProvider,
 } from "./SearchProvider"
 
-import { SearchTextBox } from "./SearchTextBox"
+import { SearchPaneView } from "./SearchPaneView"
 
 export class SearchPane {
     private _onEnter = new Event<void>()
@@ -105,174 +105,6 @@ export class SearchPane {
         })
 
         this._currentQuery = query
-    }
-}
-
-import styled from "styled-components"
-
-import { SidebarEmptyPaneView } from "./../../UI/components/SidebarEmptyPaneView"
-import { VimNavigator } from "./../../UI/components/VimNavigator"
-
-const Label = styled.div`
-    margin: 8px;
-`
-
-export interface ISearchPaneViewProps {
-    workspace: Workspace
-    onEnter: IEvent<void>
-    onLeave: IEvent<void>
-    onFocus: IEvent<void>
-    focusImmediately?: boolean
-
-    onSearchOptionsChanged: (opts: ISearchOptions) => void
-}
-
-export interface ISearchPaneViewState {
-    activeWorkspace: string
-    isActive: boolean
-    activeTextbox: string
-
-    searchQuery: string
-    fileFilter: string
-}
-
-export class SearchPaneView extends React.PureComponent<
-    ISearchPaneViewProps,
-    ISearchPaneViewState
-> {
-    private _subscriptions: IDisposable[] = []
-
-    constructor(props: ISearchPaneViewProps) {
-        super(props)
-
-        this.state = {
-            activeWorkspace: this.props.workspace.activeWorkspace,
-            isActive: false,
-            activeTextbox: null,
-            searchQuery: "Search...",
-            fileFilter: null,
-        }
-    }
-
-    public componentDidMount(): void {
-        this._cleanExistingSubscriptions()
-
-        const s1 = this.props.onEnter.subscribe(() => this.setState({ isActive: true }))
-        const s2 = this.props.onLeave.subscribe(() => this.setState({ isActive: false }))
-        const s3 = this.props.workspace.onDirectoryChanged.subscribe((wd: string) =>
-            this.setState({ activeWorkspace: wd }),
-        )
-
-        const s4 = this.props.onFocus.subscribe(() =>
-            this.setState({ activeTextbox: "textbox.query" }),
-        )
-
-        this._subscriptions = [s1, s2, s3, s4]
-
-        if (this.props.focusImmediately) {
-            this.setState({
-                activeTextbox: "textbox.query",
-            })
-        }
-    }
-
-    public componentWillUnmount(): void {
-        this._cleanExistingSubscriptions()
-    }
-
-    private _cleanExistingSubscriptions(): void {
-        this._subscriptions.forEach(s => s.dispose())
-        this._subscriptions = []
-    }
-
-    public render(): JSX.Element {
-        if (!this.state.activeWorkspace) {
-            return (
-                <SidebarEmptyPaneView
-                    active={this.state.isActive}
-                    contentsText="Nothing to search, yet!"
-                    actionButtonText={"Open Folder"}
-                    onClickButton={() => this.props.workspace.openFolder()}
-                />
-            )
-        }
-
-        return (
-            <VimNavigator
-                active={this.state.isActive && !this.state.activeTextbox}
-                ids={["textbox.query" /*, "textbox.filter"*/]}
-                onSelected={(selectedId: string) => {
-                    this._onSelected(selectedId)
-                }}
-                render={(selectedId: string) => {
-                    return (
-                        <div>
-                            <Label>Query</Label>
-                            <SearchTextBox
-                                val={this.state.searchQuery}
-                                onChangeText={val => this._onChangeSearchQuery(val)}
-                                onCommit={() => this._clearActiveTextbox()}
-                                onDismiss={() => this._clearActiveTextbox()}
-                                isFocused={selectedId === "textbox.query"}
-                                isActive={this.state.activeTextbox === "textbox.query"}
-                                onClick={() => this._onSelected("textbox.query")}
-                            />
-                            {/*<Label>Filter</Label>
-                            <SearchTextBox
-                                val={this.state.fileFilter}
-                                onChangeText={val => this._onChangeFilesFilter(val)}
-                                onCommit={() => this._clearActiveTextbox()}
-                                onDismiss={() => this._clearActiveTextbox()}
-                                isFocused={selectedId === "textbox.filter"}
-                                isActive={this.state.activeTextbox === "textbox.filter"}
-                            />*/}
-                        </div>
-                    )
-                }}
-            />
-        )
-    }
-
-    // private _onChangeFilesFilter(val: string): void {
-    //     this.setState({
-    //         fileFilter: val,
-    //     })
-
-    //     this._startSearch()
-    // }
-
-    private _onChangeSearchQuery(val: string): void {
-        this.setState({
-            searchQuery: val,
-        })
-
-        this._startSearch()
-    }
-
-    // private _onCommit(): void {
-
-    // }
-
-    private _clearActiveTextbox(): void {
-        this.setState({ activeTextbox: null })
-    }
-
-    private _onSelected(selectedId: string): void {
-        if (selectedId === "button.search") {
-            this._startSearch()
-        } else if (selectedId === "textbox.query") {
-            this.setState({ activeTextbox: "textbox.query" })
-        } else if (selectedId === "textbox.filter") {
-            this.setState({ activeTextbox: "textbox.filter" })
-        }
-    }
-
-    private _startSearch(): void {
-        this.props.onSearchOptionsChanged({
-            searchQuery: this.state.searchQuery,
-            fileFilter: this.state.fileFilter,
-            workspace: this.props.workspace.activeWorkspace,
-        })
     }
 }
 


### PR DESCRIPTION
__Issue:__ There's no visual feedback while a search query is in progress, aside from the quickfix list filling up.

__Fix:__ Incorporate a small spinner.

I also noticed an issue with how we are sending the query results (they were always behind by one). I'm including that bug fix here too since the build queue is backed up.