### PR TITLE
Temporarily disable notifications for this next release

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -217,7 +217,9 @@ const BaseConfiguration: IConfigurationValues = {
     "menu.rowHeight": 40,
     "menu.maxItemsToShow": 8,
 
-    "notifications.enabled": true,
+    // TEMPORARY - Since notifications came late in the cycle for this release,
+    // temporarily disabling it so that we have a bit more time to stabilize.
+    "notifications.enabled": process.env.NODE_ENV !== "production",
 
     "recorder.copyScreenshotToClipboard": false,
     "recorder.outputPath": os.tmpdir(),


### PR DESCRIPTION
Although going against my principle of 'failing fast', I'm planning to _temporarily_ turn off the notifications for this release. The reason is that they came in late, and there are still cases where they are particularly noisy (for example, I noticed in the CSS / HTML LSP that it was popping up - definitely bugs we need to fix!)

This doesn't make the situation any worse than the previous release, where issues were already "swept under the rug", and in fact this release made big strides because we now validate there are no errors in our automation logs, and we fixed several previously ignored crashes like #1514, #1499, #1516 , which is awesome - these were issues that had definitely impacted the experience.

Once I branch for the next release , I'll revert this change and hopefully we can fix the remaining issues and get to a new level of robustness 👍 

