### PR TITLE
Bump package version from 0.2.22 -> 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "",
     "email": "bryphe@outlook.com",
     "homepage": "https://www.onivim.io",
-    "version": "0.2.22",
+    "version": "0.3.0",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
     "keywords": [
         "vim",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "email": "bryphe@outlook.com",
     "homepage": "https://www.onivim.io",
     "version": "0.2.22",
-    "description": "NeoVim front-end with IDE-style extensibility",
+    "description": "Code editor with a modern twist on modal editing - powered by neovim.",
     "keywords": [
         "vim",
         "neovim",


### PR DESCRIPTION
When I look at all the progress that came in this release, it's _crazy_ - we've started to deliver on a vision of breaking free of terminal, we have UI that is external to Vim but still navigable in the same way. Not only that, but the project as a whole is getting more mature in terms of stability, test coverage, etc. I think these are pretty good reasons to hit version `0.3.0`. Going from `0.2.21` to `0.2.22` doesn't seem to quite do it justice 😅 

We're making big strides and I'm excited about the next release. I'm going to tweak the roadmap shortly. Really appreciate all the help and contributions from everyone - we wouldn't be this far without all you've done! 👍 