### PR TITLE
Add commandline and wildmenu mode on by default

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -44,10 +44,10 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.fakeLag.neovimInput": null,
 
     "experimental.editor.textMateHighlighting.enabled": false,
-    "experimental.commandline.mode": false,
-    "experimental.commandline.icons": false,
+    "wildmenu.mode": true,
+    "commandline.mode": true,
+    "commandline.icons": true,
     "experimental.welcome.enabled": false,
-    "experimental.wildmenu.mode": false,
 
     "experimental.neovim.transport": "stdio",
     // TODO: Enable pipe transport for Windows

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -40,8 +40,9 @@ export interface IConfigurationValues {
     // The transport to use for Neovim
     // Valid values are "stdio" and "pipe"
     "experimental.neovim.transport": string
-    "experimental.commandline.mode": boolean
-    "experimental.commandline.icons": boolean
+    "wildmenu.mode": boolean
+    "commandline.mode": boolean
+    "commandline.icons": boolean
 
     "experimental.welcome.enabled": boolean
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -870,8 +870,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         shouldExtPopups: boolean,
     ) {
         if (major >= 0 && minor >= 2 && patch >= 1) {
-            const useExtCmdLine = this._configuration.getValue("experimental.commandline.mode")
-            const useExtWildMenu = this._configuration.getValue("experimental.wildmenu.mode")
+            const useExtCmdLine = this._configuration.getValue("commandline.mode")
+            const useExtWildMenu = this._configuration.getValue("wildmenu.mode")
             return {
                 rgb: true,
                 popupmenu_external: shouldExtPopups,


### PR DESCRIPTION
@bryphe thanks for turning these on by default, as a side note as part of my alleged enzyme PR I'm looking to add some tests for these and will look at adding some integration ones as well once I have the integration tests working locally