### PR TITLE
Bugfix: Reduce log noise

### DIFF
--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -813,6 +813,12 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 case "wildmenu_hide":
                     this._onWildMenuHideEvent.dispatch()
                     break
+                case "update_sp":
+                case "mode_info_set":
+                case "busy_start":
+                case "busy_stop":
+                    Log.verbose("Ignore command: " + command)
+                    break
                 default:
                     Log.warn("Unhandled command: " + command)
             }

--- a/extensions/oni-plugin-markdown-preview/package.json
+++ b/extensions/oni-plugin-markdown-preview/package.json
@@ -10,7 +10,9 @@
         "test": "tsc -p tsconfig.test.json && mocha --recursive ./lib_test/test"
     },
     "oni": {
-        "supportedFileTypes": ["markdown"],
+        "supportedFileTypes": [
+            "markdown"
+        ],
         "commands": {
             "markdown.preview": {
                 "name": "Markdown Preview",


### PR DESCRIPTION
- Reduce the severity of certain unused Neovim events to `verbose` (originally was `warning`)
- Prettify `oni-plugin-markdown-preview`'s `package.json`

Benefit: reduce clutter for a user that wants to view logs and report the actual error.