### PR TITLE
WIP: based on Issue-1562

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -52,6 +52,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<s-c-t>", "language.symbols.document")
         input.bind("<c-tab>", "buffer.toggle")
         input.bind("<s-c-f>", "search.searchAllFiles")
+        input.bind("<s-c-e>", "explorer.toggle")
 
         if (config.getValue("editor.clipboard.enabled")) {
             input.bind("<c-c>", "editor.clipboard.yank", isVisualMode)

--- a/browser/src/Services/Explorer/index.tsx
+++ b/browser/src/Services/Explorer/index.tsx
@@ -18,4 +18,16 @@ export const activate = (
     workspace: Workspace,
 ) => {
     sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
+
+    const toggleExplorer = () => {
+        sidebarManager.toggleVisibilityById("oni.sidebar.explorer")
+    }
+
+    commandManager.registerCommand({
+        command: "explorer.toggle",
+        name: "Explorer: Toggle Visiblity",
+        detail: "Toggles the explorer in the sidebar",
+        execute: toggleExplorer,
+        enabled: () => !!workspace.activeWorkspace,
+    })
 }

--- a/browser/src/Services/Search/index.tsx
+++ b/browser/src/Services/Search/index.tsx
@@ -136,7 +136,7 @@ export const activate = (
     sidebarManager.add("search", new SearchPane(editorManager, workspace, onFocusEvent))
 
     const searchAllFiles = () => {
-        sidebarManager.setActiveEntry("oni.sidebar.search")
+        sidebarManager.toggleVisibilityById("oni.sidebar.search")
 
         onFocusEvent.dispatch()
     }

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -60,13 +60,8 @@ export class SidebarManager {
     constructor(private _windowManager: WindowManager = null) {
         this._store = createStore()
 
-        if (_windowManager) {
-            this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
-            this._contentSplit = this._windowManager.createSplit(
-                "left",
-                new SidebarContentSplit(this),
-            )
-        }
+        this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
+        this._contentSplit = this._windowManager.createSplit("left", new SidebarContentSplit(this))
     }
 
     public setActiveEntry(id: string): void {
@@ -100,6 +95,26 @@ export class SidebarManager {
         }
     }
 
+    public toggleVisibilityById(id: string): void {
+        if (id) {
+            if (id !== this.activeEntryId) {
+                this._store.dispatch({
+                    type: "SET_ACTIVE_ID",
+                    activeEntryId: id,
+                })
+
+                this._contentSplit.show()
+            } else {
+                if (this._contentSplit.isVisible) {
+                    this._contentSplit.hide()
+                } else {
+                    // In some cases you can have an ACTIVE entry that is hidden
+                    this._contentSplit.show()
+                }
+            }
+        }
+    }
+
     public enter(): void {
         this._store.dispatch({ type: "ENTER" })
     }
@@ -118,6 +133,11 @@ export class SidebarManager {
             type: "ADD_ENTRY",
             entry,
         })
+    }
+
+    public hide(): void {
+        this._contentSplit.hide()
+        this._iconSplit.hide()
     }
 }
 

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -10,17 +10,16 @@ let _sidebarManager: SidebarManager = null
 export * from "./SidebarStore"
 
 export const activate = (configuration: Configuration, workspace: Workspace) => {
-    if (configuration.getValue("sidebar.enabled")) {
-        _sidebarManager = new SidebarManager(windowManager)
+    _sidebarManager = new SidebarManager(windowManager)
+    commandManager.registerCommand({
+        command: "sidebar.toggle",
+        name: "Sidebar: Toggle",
+        detail: "Show / hide the contents of the sidebar pane.",
+        execute: () => _sidebarManager.toggleSidebarVisibility(),
+    })
 
-        commandManager.registerCommand({
-            command: "sidebar.toggle",
-            name: "Sidebar: Toggle",
-            detail: "Show / hide the contents of the sidebar pane.",
-            execute: () => _sidebarManager.toggleSidebarVisibility(),
-        })
-    } else {
-        _sidebarManager = new SidebarManager()
+    if (!configuration.getValue("sidebar.enabled")) {
+        _sidebarManager.hide()
     }
 }
 


### PR DESCRIPTION
### Allow for Oni to behave as expected when `sidebar.enabled` is set to `false`

> Based on [Issue #1562](https://github.com/onivim/oni/issues/1562)

When `sidebar.enabled` equals  `false` (i.e. the sidebar is never given a WindowManager) hitting `<s-c-f>` would throw an error

- Added a new key binding `<s-c-e>` 

- Historically, the sidebar was never initialized if the configuration file disabled it. Now, when setting `sidebar.enabled` to `false` the sidebar is created normally, but hidden from the user
    - This prevents the previously documented error and still allows for search/explorer use with the appropriate key commands: `<s-c-f>` (File search), `<s-c-e>` (Explorer), and `<s-c-b>` (open sidebar to last used option)

- Removed error previously documented by @bryphe 

@bryphe @Akin909 This is still a work-in-progress, the one thing I can't seem to work through is opening the `Explorer`, focusing on it (your cursor is in it), and then keeping if focused while closing it. 

When you do this you find that the main editor window has lost focus and Oni seems to be unresponsive. By manually clicking in the main window everything "goes back to normal". Focus should be regained automatically when the sidebar is closed. This issue exists in the current code as far as I can tell (only with the `Explorer` sidebar, `Search` behaves correctly). Maybe you guys have a better solution to giving the main window its focus back?

As always, open to suggestions. Thanks!