### PR TITLE
Feature: Add folder/file naming if filename is duplicated

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -191,7 +191,7 @@ export class Tab extends React.Component<ITabPropsWithClick> {
     }
 }
 
-const getTabName = (name: string, isDuplicate?: boolean): string => {
+export const getTabName = (name: string, isDuplicate?: boolean): string => {
     if (!name) {
         return "[No Name]"
     }
@@ -249,7 +249,7 @@ export const checkTabBuffers = (buffersInTabs: number[], buffers: State.IBuffer[
     return tabBufs.some(buf => buf.modified)
 }
 
-const checkDuplicate = (current: string, names: string[]) =>
+export const checkDuplicate = (current: string, names: string[]) =>
     names.filter((name: string) => path.basename(name) === path.basename(current)).length > 1
 
 const getTabsFromBuffers = createSelector(

--- a/browser/test/Tabs/TabsTest.tsx
+++ b/browser/test/Tabs/TabsTest.tsx
@@ -18,7 +18,7 @@ describe("Tab bar utility function tests", () => {
         it("Should return a only a filename if there are no duplicates", () => {
             const testArray = ["/folder/index.js", "/folderTwo/apple.js"]
             const isDuplicate = checkDuplicate("index.js", testArray)
-            const name = getTabName("index.js", isDuplicate)
+            const name = getTabName("/folder/index.js", isDuplicate)
             assert.ok(name === "index.js")
         })
         it("Should return a folder and a filename if there are duplicates", () => {

--- a/browser/test/Tabs/TabsTest.tsx
+++ b/browser/test/Tabs/TabsTest.tsx
@@ -1,4 +1,5 @@
 import * as assert from "assert"
+import * as path from "path"
 import { checkDuplicate, getTabName } from "./../../src/UI/components/Tabs"
 
 describe("Tab bar utility function tests", () => {
@@ -15,17 +16,18 @@ describe("Tab bar utility function tests", () => {
         })
     })
     describe("Get tab name function should return a longer name if duplicates present", () => {
+        const sep = path.sep
         it("Should return a only a filename if there are no duplicates", () => {
-            const testArray = ["/folder/index.js", "/folderTwo/apple.js"]
+            const testArray = [`${sep}folder${sep}index.js`, `${sep}folderTwo${sep}apple.js`]
             const isDuplicate = checkDuplicate("index.js", testArray)
-            const name = getTabName("/folder/index.js", isDuplicate)
+            const name = getTabName(`${sep}folder${sep}index.js`, isDuplicate)
             assert.ok(name === "index.js")
         })
         it("Should return a folder and a filename if there are duplicates", () => {
-            const testArray = ["/folder/index.js", "/folderTwo/index.js"]
-            const isDuplicate = checkDuplicate("index.js", testArray)
-            const name = getTabName("/folder/index.js", isDuplicate)
-            assert.ok(name === "folder/index.js")
+            const testArray = [`${sep}folder${sep}index.js`, `${sep}folderTwo${sep}index.js`]
+            const isDuplicate = checkDuplicate(`index.js`, testArray)
+            const name = getTabName(`${sep}folder${sep}index.js`, isDuplicate)
+            assert.ok(name === `folder${sep}index.js`)
         })
     })
 })

--- a/browser/test/Tabs/index.ts
+++ b/browser/test/Tabs/index.ts
@@ -1,0 +1,31 @@
+import * as assert from "assert"
+import { checkDuplicate, getTabName } from "./../../src/UI/components/Tabs"
+
+describe("Tab bar utility function tests", () => {
+    describe("Array duplicates check", () => {
+        it("Should return a true if there is a duplicate in an array", () => {
+            const testArray = ["/folder/index.js", "/folderTwo/index.js"]
+            const isDuplicate = checkDuplicate("index.js", testArray)
+            assert.ok(isDuplicate)
+        })
+        it("Should return a false if there is not a duplicate in an array", () => {
+            const testArray = ["/folder/index.js", "/folderTwo/apple.js"]
+            const isDuplicate = checkDuplicate("index.js", testArray)
+            assert.ok(!isDuplicate)
+        })
+    })
+    describe("Get tab name function should return a longer name if duplicates present", () => {
+        it("Should return a only a filename if there are no duplicates", () => {
+            const testArray = ["/folder/index.js", "/folderTwo/apple.js"]
+            const isDuplicate = checkDuplicate("index.js", testArray)
+            const name = getTabName("index.js", isDuplicate)
+            assert.ok(name === "index.js")
+        })
+        it("Should return a folder and a filename if there are duplicates", () => {
+            const testArray = ["/folder/index.js", "/folderTwo/index.js"]
+            const isDuplicate = checkDuplicate("index.js", testArray)
+            const name = getTabName("/folder/index.js", isDuplicate)
+            assert.ok(name === "folder/index.js")
+        })
+    })
+})


### PR DESCRIPTION
This PR adds functionality to the tab bar to check if the buffer
path is duplicated and if so rather than showing `index.js`, next
tab `index.js`.

It now shows `thisFolder/index.js`, `thatFolder/index.js`