### PR TITLE
Fix tab creation issues some of the time.

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -453,13 +453,7 @@ export class NeovimEditor extends Editor implements IEditor {
             const response = await this._neovimInstance.request("nvim_call_atomic", [atomicCalls])
 
             tabs.map((tab: ITab, index: number) => {
-                const currentTabsBuffers = response[0][index]
-
-                if (currentTabsBuffers instanceof Array === false) {
-                    tab.buffersInTab = []
-                } else {
-                    tab.buffersInTab = response[0][index]
-                }
+                tab.buffersInTab = response[0][index] instanceof Array ? response[0][index] : []
             })
 
             this._actions.setTabs(currentTabId, tabs)

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -235,6 +235,10 @@ export const shouldShowFileIcon = (state: State.IState): boolean => {
 }
 
 export const checkTabBuffers = (buffersInTabs: number[], buffers: State.IBuffer[]): boolean => {
+    if (buffersInTabs instanceof Array === false || buffers instanceof Array === false) {
+        return false
+    }
+
     const tabBufs = buffers.filter(buf => buffersInTabs.find(tabBuf => tabBuf === buf.id))
 
     return tabBufs.some(buf => buf.modified)

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -235,10 +235,6 @@ export const shouldShowFileIcon = (state: State.IState): boolean => {
 }
 
 export const checkTabBuffers = (buffersInTabs: number[], buffers: State.IBuffer[]): boolean => {
-    if (buffersInTabs instanceof Array === false || buffers instanceof Array === false) {
-        return false
-    }
-
     const tabBufs = buffers.filter(buf => buffersInTabs.find(tabBuf => tabBuf === buf.id))
 
     return tabBufs.some(buf => buf.modified)
@@ -292,7 +288,7 @@ const getTabsFromVimTabs = createSelector(
         showFileIcon: boolean,
         allBuffers: State.IBuffer[],
     ) => {
-        return tabState.tabs.map((t: any, idx: number) => ({
+        return tabState.tabs.map((t: State.ITab, idx: number) => ({
             id: t.id,
             name: getIdPrefix((idx + 1).toString(), shouldShowId) + getTabName(t.name),
             highlightColor: t.id === tabState.selectedTabId ? color : "transparent",

--- a/browser/test/Editor/NeovimEditor/BufferStateTests.ts
+++ b/browser/test/Editor/NeovimEditor/BufferStateTests.ts
@@ -38,5 +38,14 @@ describe("BufferStateTests", () => {
 
             assert(!result, "Unmodified buffer correctly linked")
         })
+
+        it("Passing over empty arrays works correctly", () => {
+            const buffers = [] as any
+            const buffersInTabs = [] as number[]
+
+            const result = checkTabBuffers(buffersInTabs, buffers)
+
+            assert(!result, "No buffers correctly linked")
+        })
     })
 })


### PR DESCRIPTION
Check that input parameters are arrays.

I'm not fully sure how this issue came about, calling `:tabnew` and `:tabclose` a few times works, and then at some point it just breaks....

This at the very least fixes the issue here. If we've got no array for the tabs, the only real thing we can do is return false since there is no buffers to have been edited yet.

Edit: As a primarily non-TS dev, is there a different way of writing my function parameters? I assumed that defining it with `number[]` either only an array would be passed in, or that it would be treated like c style langs and find would just run over the first element and quit if a single val was passed, but that evidently hasn't been the case.