### PR TITLE
[WIP] #55 - Part 3- Snippet placeholder synchronization

### DIFF
--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -167,6 +167,13 @@ export class OniEditor implements IEditor {
         return this._neovimEditor.setSelection(range)
     }
 
+    public async blockInput(
+        inputFunction: (input: (inp: string) => Promise<void>) => Promise<void>,
+    ) {
+        const neovim = this._neovimEditor.neovim as any
+        return neovim.blockInput(inputFunction)
+    }
+
     public executeCommand(command: string): void {
         this._neovimEditor.executeCommand(command)
     }

--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -88,8 +88,12 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     input.bind(["<s-enter", "<C-s>"], "quickOpen.openFileHorizontal")
     input.bind("<C-t>", "quickOpen.openFileNewTab")
 
+    // Snippets
+    input.bind("<tab>", "snippet.nextPlaceholder")
+    input.bind("<s-tab>", "snippet.previousPlaceholder")
+
     // Completion
-    input.bind(["<enter>", "<tab>"], "contextMenu.select")
+    input.bind(["<enter>"], "contextMenu.select")
     input.bind(["<down>", "<C-n>"], "contextMenu.next")
     input.bind(["<up>", "<C-p>"], "contextMenu.previous")
     input.bind(

--- a/browser/src/Services/Snippets/OniSnippet.ts
+++ b/browser/src/Services/Snippets/OniSnippet.ts
@@ -87,7 +87,9 @@ export class OniSnippet {
             )
 
             placeholderToReplace.forEach(rep => {
-                snippet.replace(rep, snip.children)
+                const placeHolder = new Snippets.Placeholder(rep.index)
+                placeHolder.appendChild(snip)
+                snippet.replace(rep, [placeHolder])
             })
         })
 

--- a/browser/src/Services/Snippets/OniSnippet.ts
+++ b/browser/src/Services/Snippets/OniSnippet.ts
@@ -49,6 +49,10 @@ export class OniSnippet {
         this._placeholderValues[index] = newValue
     }
 
+    public getPlaceholderValue(index: number): string {
+        return this._placeholderValues[index] || null
+    }
+
     public getPlaceholders(): OniSnippetPlaceholder[] {
         const snippet = this._getSnippetWithFilledPlaceholders()
         const placeholders = snippet.placeholders

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -4,6 +4,7 @@
  * Manages snippet integration
  */
 
+import { CommandManager } from "./../CommandManager"
 import { editorManager, EditorManager } from "./../EditorManager"
 
 import { OniSnippet } from "./OniSnippet"
@@ -28,20 +29,42 @@ export class SnippetManager {
     }
 
     public nextPlaceholder(): void {
-        if (this._isSnippetActive()) {
+        if (this.isSnippetActive()) {
             this._activeSession.nextPlaceholder()
         }
     }
 
-    private _isSnippetActive(): boolean {
+    public previousPlaceholder(): void {
+        if (this.isSnippetActive()) {
+            this._activeSession.previousPlaceholder()
+        }
+    }
+
+    public isSnippetActive(): boolean {
         return !!this._activeSession
     }
 }
 
 let _snippetManager: SnippetManager
 
-export const activate = () => {
+export const activate = (commandManager: CommandManager) => {
     _snippetManager = new SnippetManager(editorManager)
+
+    commandManager.registerCommand({
+        command: "snippet.nextPlaceholder",
+        name: null,
+        detail: null,
+        enabled: () => _snippetManager.isSnippetActive(),
+        execute: () => _snippetManager.nextPlaceholder(),
+    })
+
+    commandManager.registerCommand({
+        command: "snippet.previousPlaceholder",
+        name: null,
+        detail: null,
+        enabled: () => _snippetManager.isSnippetActive(),
+        execute: () => _snippetManager.previousPlaceholder(),
+    })
 }
 
 export const getInstance = (): SnippetManager => {

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -8,8 +8,8 @@ import { IDisposable } from "oni-types"
 
 import * as Log from "./../../Log"
 
-import { Subject } from "rxjs/Subject"
 import "rxjs/add/operator/auditTime"
+import { Subject } from "rxjs/Subject"
 
 import { CommandManager } from "./../CommandManager"
 import { editorManager, EditorManager } from "./../EditorManager"

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -6,7 +6,7 @@
 
 import * as types from "vscode-languageserver-types"
 
-import { IEvent, Event } from "oni-types"
+import { Event, IEvent } from "oni-types"
 
 import * as Log from "./../../Log"
 

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -93,9 +93,6 @@ export class SnippetSession {
 
         await this._snippet.setPlaceholder(index, val)
         await this._updateSnippet()
-
-        //         const placeholders = this._snippet.getPlaceholders()
-        //         await this._highlightPlaceholder(placeholders[this._placeholderIndex])
     }
 
     // Helper method to query the value of the current placeholder,

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -166,6 +166,10 @@ export class SnippetSession {
     }
 
     private async _highlightPlaceholder(currentPlaceholder: OniSnippetPlaceholder): Promise<void> {
+        if (!currentPlaceholder) {
+            return
+        }
+
         const adjustedLine = currentPlaceholder.line + this._position.line
         const adjustedCharacter =
             currentPlaceholder.line === 0

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -282,7 +282,7 @@ const getTabsFromVimTabs = createSelector(
         BufferSelectors.getBufferMetadata,
     ],
     (
-        tabState: any,
+        tabState: State.ITabState,
         color: any,
         shouldShowId: boolean,
         showFileIcon: boolean,

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -225,7 +225,7 @@ const start = async (args: string[]): Promise<void> => {
     GlobalCommands.activate(commandManager, menuManager, tasks)
 
     const Snippets = await snippetPromise
-    Snippets.activate()
+    Snippets.activate(commandManager)
 
     const KeyDisplayer = await keyDisplayerPromise
     KeyDisplayer.activate(commandManager, inputManager, overlayManager)

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -131,6 +131,7 @@ export class MockStatusBar implements Oni.StatusBar {
 
 export class MockEditor extends Editor {
     private _activeBuffer: MockBuffer = null
+    private _currentSelection: types.Range = null
 
     public get activeBuffer(): Oni.Buffer {
         return this._activeBuffer as any
@@ -150,6 +151,14 @@ export class MockEditor extends Editor {
     public simulateBufferEnter(buffer: MockBuffer): void {
         this._activeBuffer = buffer
         this.notifyBufferEnter(buffer as any)
+    }
+
+    public async setSelection(range: types.Range): Promise<void> {
+        this._currentSelection = range
+    }
+
+    public async getSelection(): Promise<types.Range> {
+        return this._currentSelection
     }
 
     public setActiveBufferLine(line: number, lineContents: string): void {

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -10,7 +10,7 @@ import { SnippetSession } from "./../../../src/Services/Snippets/SnippetSession"
 
 import * as Mocks from "./../../Mocks"
 
-// tslint:disable-file no-invalid-template-strings
+// tslint:disable no-invalid-template-strings
 
 describe("SnippetSession", () => {
     let mockEditor: Mocks.MockEditor

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -10,6 +10,8 @@ import { SnippetSession } from "./../../../src/Services/Snippets/SnippetSession"
 
 import * as Mocks from "./../../Mocks"
 
+// tslint:disable-file no-invalid-template-strings
+
 describe("SnippetSession", () => {
     let mockEditor: Mocks.MockEditor
     let mockBuffer: Mocks.MockBuffer

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -98,5 +98,23 @@ describe("SnippetSession", () => {
         })
     })
 
-    describe("synchronizeUpdatedPlaceholders", () => {})
+    describe("synchronizeUpdatedPlaceholders", () => {
+        it("updates placeholders", async () => {
+            const snippet = new OniSnippet("${1:test} ${1} ${1}")
+            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            await snippetSession.start()
+
+            // Validate
+            const [currentLine] = await mockBuffer.getLines(0, 1)
+            assert.strictEqual(currentLine, "test test test")
+
+            // Simulate typing in first entry
+            await mockEditor.setActiveBufferLine(0, "test3 test test")
+
+            await snippetSession.synchronizeUpdatedPlaceholders()
+
+            const [synchronizedLine] = await mockBuffer.getLines(0, 1)
+            assert.strictEqual(synchronizedLine, "test3 test3 test3")
+        })
+    })
 })

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -3,6 +3,7 @@
  */
 
 import * as assert from "assert"
+import * as types from "vscode-languageserver-types"
 
 import { OniSnippet } from "./../../../src/Services/Snippets/OniSnippet"
 import { SnippetSession } from "./../../../src/Services/Snippets/SnippetSession"
@@ -61,4 +62,41 @@ describe("SnippetSession", () => {
         assert.strictEqual(firstLine, "somefoo")
         assert.strictEqual(secondLine, "barline")
     })
+
+    it("highlights first placeholder", async () => {
+        const snippet = new OniSnippet("${0:test}")
+        snippetSession = new SnippetSession(mockEditor as any, snippet)
+
+        mockBuffer.setLinesSync(["abc"])
+        mockBuffer.setCursorPosition(0, 1)
+
+        await snippetSession.start()
+
+        const selection = await mockEditor.getSelection()
+
+        const expectedRange = types.Range.create(0, 1, 0, 4)
+        assert.strictEqual(selection.start.line, expectedRange.start.line)
+        assert.strictEqual(selection.start.character, expectedRange.start.character)
+        assert.strictEqual(selection.end.character, expectedRange.end.character)
+    })
+
+    describe("next placeholder", () => {
+        it("highlights correct placeholder after calling nextPlaceholder", async () => {
+            const snippet = new OniSnippet("${0:test} ${1:test2}")
+            snippetSession = new SnippetSession(mockEditor as any, snippet)
+
+            await snippetSession.start()
+
+            await snippetSession.nextPlaceholder()
+
+            const selection = await mockEditor.getSelection()
+
+            const expectedRange = types.Range.create(0, 5, 0, 9)
+            assert.strictEqual(selection.start.line, expectedRange.start.line)
+            assert.strictEqual(selection.start.character, expectedRange.start.character)
+            assert.strictEqual(selection.end.character, expectedRange.end.character)
+        })
+    })
+
+    describe("synchronizeUpdatedPlaceholders", () => {})
 })


### PR DESCRIPTION
This change implements initial functionality for tabbing through placeholders, and updating mirrored placeholders based on buffer updates. From here, we can start integrating snippet providers (coming from plugins, configuration, etc) and actually start leveraging functionality.

