### PR TITLE
Build: Remove cache completely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ branches:
   only:
   - master
   - /^release.*/
-cache:
-    directories:
-        - node_modules/oni-neovim-binaries
-        - node_modules/oni-ripgrep
 matrix:
   include:
   - os: linux


### PR DESCRIPTION
Since OSX build is failing consistently for PRs, might as well try removing the cache again... I'm curious if we'll hit the rate-limit issues we did before. If so, we might have to try another strategy for caching the specific binaries we need for Oni (neovim and ripgrep)