### PR TITLE
Configuration: Use notification instead of alert for error reporting

### DIFF
--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -76,11 +76,6 @@ const start = async (args: string[]): Promise<void> => {
         }
     }
 
-    configuration.onConfigurationError.subscribe(err => {
-        // TODO: Better / nicer handling of error:
-        alert(err)
-    })
-
     configuration.start()
 
     configChange(configuration.getValues()) // initialize values
@@ -139,6 +134,14 @@ const start = async (args: string[]): Promise<void> => {
 
     const Notifications = await notificationsPromise
     Notifications.activate(configuration, overlayManager)
+
+    configuration.onConfigurationError.subscribe(err => {
+        const notifications = Notifications.getInstance()
+        const notification = notifications.createItem()
+        notification.setContents("Error Loading Configuration", err.toString())
+        notification.setLevel("error")
+        notification.show()
+    })
 
     UnhandledErrorMonitor.start(Notifications.getInstance())
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -140,6 +140,9 @@ const start = async (args: string[]): Promise<void> => {
         const notification = notifications.createItem()
         notification.setContents("Error Loading Configuration", err.toString())
         notification.setLevel("error")
+        notification.onClick.subscribe(() =>
+            commandManager.executeCommand("oni.config.openConfigJs"),
+        )
         notification.show()
     })
 


### PR DESCRIPTION
This change uses our notification framework for bubbling up configuration errors, as opposed to an alert. This is beneficial because the `alert` is modal and blocks all input, whereas the notification is _slightly_ less intrusive. Clicking the notification takes you to the configuration file.