### PR TITLE
Configuration - TypeScript configuration Part 1: Refactor edit configuration command

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -4,18 +4,14 @@
  * Contextual commands for NeovimEditor
  *
  */
-import * as fs from "fs"
 import * as os from "os"
-import * as path from "path"
 
 import { clipboard } from "electron"
 import * as Oni from "oni-api"
 
 import { NeovimInstance } from "./../../neovim"
 import { CallbackCommand, CommandManager } from "./../../Services/CommandManager"
-import { getUserConfigFilePath } from "./../../Services/Configuration"
 import { ContextMenuManager } from "./../../Services/ContextMenu"
-import { editorManager } from "./../../Services/EditorManager"
 import { findAllReferences, format, LanguageEditorIntegration } from "./../../Services/Language"
 import { MenuManager } from "./../../Services/Menu"
 import { QuickOpen } from "./../../Services/QuickOpen"
@@ -102,24 +98,6 @@ export class NeovimEditorCommands {
             await neovimInstance.command("set paste")
             await neovimInstance.input(sanitizedText)
             await neovimInstance.command("set nopaste")
-        }
-
-        const openDefaultConfig = async (): Promise<void> => {
-            const activeEditor = editorManager.activeEditor
-            const buf = await activeEditor.openFile(getUserConfigFilePath())
-            const lineCount = buf.lineCount
-
-            if (lineCount === 1) {
-                const defaultConfigJsPath = path.join(
-                    __dirname,
-                    "configuration",
-                    "config.default.js",
-                )
-                const defaultConfigLines = fs
-                    .readFileSync(defaultConfigJsPath, "utf8")
-                    .split(os.EOL)
-                await buf.setLines(0, defaultConfigLines.length, defaultConfigLines)
-            }
         }
 
         const shouldShowMenu = () => {
@@ -211,13 +189,6 @@ export class NeovimEditorCommands {
             new CallbackCommand("language.symbols.workspace", null, null, () =>
                 this._symbols.openWorkspaceSymbolsMenu(),
             ),
-            new CallbackCommand(
-                "oni.config.openConfigJs",
-                "Configuration: Edit Oni Config",
-                "Edit configuration file ('config.js') for Oni",
-                () => openDefaultConfig(),
-            ),
-
             new CallbackCommand(
                 "oni.config.openInitVim",
                 "Configuration: Edit Neovim Config",

--- a/browser/src/Services/Configuration/ConfigurationCommands.ts
+++ b/browser/src/Services/Configuration/ConfigurationCommands.ts
@@ -1,0 +1,33 @@
+/**
+ * ConfigurationCommands
+ */
+
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import { CommandManager } from "./../CommandManager"
+import { EditorManager } from "./../EditorManager"
+
+import { getUserConfigFilePath } from "./index"
+
+export const activate = (commandManager: CommandManager, editorManager: EditorManager) => {
+    const openDefaultConfig = async (): Promise<void> => {
+        const activeEditor = editorManager.activeEditor
+        const buf = await activeEditor.openFile(getUserConfigFilePath())
+        const lineCount = buf.lineCount
+
+        if (lineCount === 1) {
+            const defaultConfigJsPath = path.join(__dirname, "configuration", "config.default.js")
+            const defaultConfigLines = fs.readFileSync(defaultConfigJsPath, "utf8").split(os.EOL)
+            await buf.setLines(0, defaultConfigLines.length, defaultConfigLines)
+        }
+    }
+
+    commandManager.registerCommand({
+        command: "oni.config.openConfigJs",
+        name: "Configuration: Edit User Config",
+        detail: "Edit user configuration file for Oni",
+        execute: () => openDefaultConfig(),
+    })
+}

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -23,6 +23,7 @@ const start = async (args: string[]): Promise<void> => {
     Shell.activate()
 
     const configurationPromise = import("./Services/Configuration")
+    const configurationCommandsPromise = import("./Services/Configuration/ConfigurationCommands")
     const pluginManagerPromise = import("./Plugins/PluginManager")
     const themesPromise = import("./Services/Themes")
     const iconThemesPromise = import("./Services/IconThemes")
@@ -223,6 +224,9 @@ const start = async (args: string[]): Promise<void> => {
     const { inputManager } = await inputManagerPromise
 
     const autoClosingPairsPromise = import("./Services/AutoClosingPairs")
+
+    const ConfigurationCommands = await configurationCommandsPromise
+    ConfigurationCommands.activate(commandManager, editorManager)
 
     const AutoClosingPairs = await autoClosingPairsPromise
     AutoClosingPairs.activate(configuration, editorManager, inputManager, languageManager)


### PR DESCRIPTION
- Moves the 'edit configuration' command out of editor and into a `ConfigurationCommands` object. We'll start wiring up some more interesting functionality there.

My goal is to have the ability to leverage different configuration 'providers', with the first/default one being a `TypeScriptConfigurationProvider`. This will allow us to bring to bear the language support, along with the typing we get with the `oni-api` definitions, to hopefully make it easier to add more interesting functionality to the configuration.

This is orthogonal to #976 - ideally, in the TypeScriptConfigurationProvider, we could also toss in the full set of configuration options to help make it easier to get started configuring.