### PR TITLE
Feature: Template files + snippets

### DIFF
--- a/.oni/config.js
+++ b/.oni/config.js
@@ -18,6 +18,7 @@ module.exports = {
             sourceFolder: "browser/src",
             mappedFolder: "browser/test",
             mappedFileName: "${fileName}Tests.ts",
+            templateFilePath: ".oni/templates/UnitTestTemplate.ts",
         },
     ],
 }

--- a/.oni/config.js
+++ b/.oni/config.js
@@ -18,7 +18,7 @@ module.exports = {
             sourceFolder: "browser/src",
             mappedFolder: "browser/test",
             mappedFileName: "${fileName}Tests.ts",
-            templateFilePath: ".oni/templates/UnitTestTemplate.ts",
+            templateFilePath: ".oni/templates/UnitTestTemplate.ts.template",
         },
     ],
 }

--- a/.oni/templates/UnitTestTemplate.ts.template
+++ b/.oni/templates/UnitTestTemplate.ts.template
@@ -1,0 +1,12 @@
+/**
+ * ${0}.ts
+ */
+
+import * as assert from "assert"
+
+describe("${0}", () => {
+    it("${1:tests}", async () => {
+        ${2:assert.ok(false, "fail")}
+    })
+})
+

--- a/browser/src/Services/FileMappings.ts
+++ b/browser/src/Services/FileMappings.ts
@@ -12,13 +12,20 @@ export interface IFileMapping {
 
     mappedFolder: string
     mappedFileName: string
+
+    templateFilePath?: string
+}
+
+export interface IFileMappingResult {
+    fullPath: string
+    templateFileFullPath?: string
 }
 
 export const getMappedFile = (
     rootFolder: string,
     filePath: string,
     mappings: IFileMapping[],
-): string | null => {
+): IFileMappingResult | null => {
     const mappingsThatApply = mappings.filter(m => doesMappingMatchFile(rootFolder, filePath, m))
 
     if (mappingsThatApply.length === 0) {
@@ -27,7 +34,15 @@ export const getMappedFile = (
 
     const mapping = mappingsThatApply[0]
 
-    return getMappedFileFromMapping(rootFolder, filePath, mapping)
+    const fullPath = getMappedFileFromMapping(rootFolder, filePath, mapping)
+    const templateFileFullPath = mapping.templateFilePath
+        ? path.join(rootFolder, mapping.templateFilePath)
+        : null
+
+    return {
+        fullPath,
+        templateFileFullPath,
+    }
 }
 
 export const doesMappingMatchFile = (

--- a/browser/src/Services/Snippets/OniSnippet.ts
+++ b/browser/src/Services/Snippets/OniSnippet.ts
@@ -8,6 +8,7 @@
  */
 
 import * as Snippets from "vscode-snippet-parser/lib"
+import { normalizeNewLines } from "./../../Utility"
 
 export interface OniSnippetPlaceholder {
     index: number
@@ -42,8 +43,11 @@ export const getLineCharacterFromOffset = (
 export class OniSnippet {
     private _parser: Snippets.SnippetParser = new Snippets.SnippetParser()
     private _placeholderValues: { [index: number]: string } = {}
+    private _snippetString: string
 
-    constructor(private _snippetString: string) {}
+    constructor(snippet: string) {
+        this._snippetString = normalizeNewLines(snippet)
+    }
 
     public setPlaceholder(index: number, newValue: string): void {
         this._placeholderValues[index] = newValue

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -28,7 +28,6 @@ import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 import { convertTextDocumentEditsToFileMap } from "./../Language/Edits"
 
-import * as WorkspaceCommands from "./WorkspaceCommands"
 import { WorkspaceConfiguration } from "./WorkspaceConfiguration"
 
 const fsStat = promisify(stat)
@@ -195,8 +194,6 @@ export const activate = (configuration: Configuration, editorManager: EditorMana
     _workspace.onDirectoryChanged.subscribe(newDirectory => {
         configuration.setValues({ "workspace.defaultWorkspace": newDirectory }, true)
     })
-
-    WorkspaceCommands.activateCommands(configuration, editorManager, _workspace)
 }
 
 export const getInstance = (): Workspace => {

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -11,8 +11,8 @@ import * as mkdirp from "mkdirp"
 import { CallbackCommand, commandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
-import { SnippetManager } from "./../Snippets"
 import * as FileMappings from "./../FileMappings"
+import { SnippetManager } from "./../Snippets"
 
 import { Workspace } from "./Workspace"
 

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -11,6 +11,7 @@ import * as mkdirp from "mkdirp"
 import { CallbackCommand, commandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
+import { SnippetManager } from "./../Snippets"
 import * as FileMappings from "./../FileMappings"
 
 import { Workspace } from "./Workspace"
@@ -18,35 +19,48 @@ import { Workspace } from "./Workspace"
 export const activateCommands = (
     configuration: Configuration,
     editorManager: EditorManager,
+    snippetManager: SnippetManager,
     workspace: Workspace,
 ) => {
-    const openTestFileInSplit = () => {
-        const mappedFile = getTestFileMappedToCurrentFile()
+    const openTestFileInSplit = async () => {
+        const mappingResult = getTestFileMappedToCurrentFile()
+        const mappedFile = mappingResult.fullPath
+        const templateFile = mappingResult.templateFileFullPath
 
         if (mappedFile) {
+            let snippetToInsert: string = null
+
             if (!fs.existsSync(mappedFile)) {
                 // Ensure the folder exists for the mapped file
                 const containingFolder = path.dirname(mappedFile)
                 mkdirp.sync(containingFolder)
+
+                if (templateFile && fs.existsSync(templateFile)) {
+                    snippetToInsert = fs.readFileSync(templateFile).toString("utf8")
+                }
             }
 
-            editorManager.activeEditor.openFile(mappedFile)
+            await editorManager.activeEditor.openFile(mappedFile)
+
+            if (snippetToInsert) {
+                await snippetManager.insertSnippet(snippetToInsert)
+            }
         }
     }
 
     const hasExistingTestFile = () => {
         const mappedFile = getTestFileMappedToCurrentFile()
 
-        return fs.existsSync(mappedFile)
+        return mappedFile && fs.existsSync(mappedFile.fullPath)
     }
 
     const canCreateTestFile = () => {
         const mappedFile = getTestFileMappedToCurrentFile()
 
-        return !fs.existsSync(mappedFile)
+        return mappedFile && !fs.existsSync(mappedFile.fullPath)
     }
 
-    const getTestFileMappedToCurrentFile = (): string => {
+    const getTestFileMappedToCurrentFile = (): FileMappings.IFileMappingResult => {
         const mappings: FileMappings.IFileMapping[] = configuration.getValue(
             "workspace.testFileMappings",
         )
@@ -72,6 +86,7 @@ export const activateCommands = (
             currentBufferPath,
             mappings,
         )
+
         return mappedFile
     }
 

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -157,6 +157,10 @@ export const createCompletablePromise = <T>(): ICompletablePromise<T> => {
     }
 }
 
+export const normalizeNewLines = (str: string): string => {
+    return str.split("\r\n").join("\n")
+}
+
 /**
  * Helper function to ignore incoming values while a promise is waiting to complete
  * This is lossy, in that any input that comes in will be dropped while the promise

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -48,6 +48,7 @@ const start = async (args: string[]): Promise<void> => {
     const keyDisplayerPromise = import("./Services/KeyDisplayer")
     const taksPromise = import("./Services/Tasks")
     const workspacePromise = import("./Services/Workspace")
+    const workspaceCommandsPromise = import("./Services/Workspace/WorkspaceCommands")
 
     const themePickerPromise = import("./Services/Themes/ThemePicker")
     const cssPromise = import("./CSS")
@@ -232,6 +233,14 @@ const start = async (args: string[]): Promise<void> => {
 
     const Snippets = await snippetPromise
     Snippets.activate(commandManager)
+
+    const WorkspaceCommands = await workspaceCommandsPromise
+    WorkspaceCommands.activateCommands(
+        configuration,
+        editorManager,
+        Snippets.getInstance(),
+        workspace,
+    )
 
     const KeyDisplayer = await keyDisplayerPromise
     KeyDisplayer.activate(commandManager, inputManager, overlayManager)

--- a/browser/test/Services/FileMappingsTests.ts
+++ b/browser/test/Services/FileMappingsTests.ts
@@ -23,6 +23,27 @@ describe("FileMappings", () => {
     })
 
     describe("getMappedFile", () => {
+        it("returns null for template file if template file doesn't exist", () => {
+            const srcFile = path.join(srcPath, "source.ts")
+
+            const mapping: FileMappings.IFileMapping = {
+                sourceFolder: "browser/src",
+
+                mappedFolder: "browser/test",
+                mappedFileName: "${fileName}Test.ts", // tslint:disable-line
+            }
+
+            const mappedFile = FileMappings.getMappedFile(srcPath, srcFile, [mapping])
+
+            assert.strictEqual(
+                mappedFile.templateFileFullPath,
+                null,
+                "`templateFileFullPath` should be null since there is no tempalate file specified.",
+            )
+        })
+    })
+
+    describe("getMappedFileFromMapping", () => {
         it("returns simple mapping", () => {
             const srcFile = path.join(srcPath, "source.ts")
             const testFile = path.join(testPath, "sourceTest.ts")

--- a/browser/test/Services/FileMappingsTests.ts
+++ b/browser/test/Services/FileMappingsTests.ts
@@ -33,12 +33,32 @@ describe("FileMappings", () => {
                 mappedFileName: "${fileName}Test.ts", // tslint:disable-line
             }
 
-            const mappedFile = FileMappings.getMappedFile(srcPath, srcFile, [mapping])
+            const mappedFile = FileMappings.getMappedFile(rootPath, srcFile, [mapping])
 
             assert.strictEqual(
                 mappedFile.templateFileFullPath,
                 null,
-                "`templateFileFullPath` should be null since there is no tempalate file specified.",
+                "`templateFileFullPath` should be null since there is no template file specified.",
+            )
+        })
+
+        it("returns a template file if template file exists", () => {
+            const srcFile = path.join(srcPath, "source.ts")
+
+            const mapping: FileMappings.IFileMapping = {
+                sourceFolder: "browser/src",
+
+                mappedFolder: "browser/test",
+                mappedFileName: "${fileName}Test.ts", // tslint:disable-line
+
+                templateFilePath: "templates/template.ts",
+            }
+
+            const mappedFile = FileMappings.getMappedFile(rootPath, srcFile, [mapping])
+
+            assert.strictEqual(
+                mappedFile.templateFileFullPath,
+                path.join(rootPath, mapping.templateFilePath),
             )
         })
     })


### PR DESCRIPTION
This is the first usage of snippets outside of directly calling `Oni.snippets.insertSnippet(...)` from the console...

Oni has a feature that allows for creating a test file by specifying a mapping in the `workspace.testFileMappings` setting.

This adds an additional option - a template file to be used, and it is loaded as a snippet, so that it can have placeholders as tab stops. Still work left to do, but once the bugs are worked out, it'll be nice functionality to have - and it's a way to start exercising snippets while the completion provider and plugin loading is implemented.