### PR TITLE
Snippets: Add support in 'commitCompletion' for InsertTextFormat.Snippet

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -45,6 +45,7 @@ import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 import { editorManager } from "./../../Services/EditorManager"
 import { Errors } from "./../../Services/Errors"
 import { Overlay, OverlayManager } from "./../../Services/Overlay"
+import { SnippetManager } from "./../../Services/Snippets"
 import { TokenColors } from "./../../Services/TokenColors"
 
 import * as Shell from "./../../UI/Shell"
@@ -168,6 +169,7 @@ export class NeovimEditor extends Editor implements IEditor {
         private _menuManager: MenuManager,
         private _overlayManager: OverlayManager,
         private _pluginManager: PluginManager,
+        private _snippetManager: SnippetManager,
         private _tasks: Tasks,
         private _themeManager: ThemeManager,
         private _tokenColors: TokenColors,
@@ -527,6 +529,7 @@ export class NeovimEditor extends Editor implements IEditor {
             this._configuration,
             this._completionProviders,
             this._languageManager,
+            this._snippetManager,
         )
         this._completionMenu = new CompletionMenu(this._contextMenuManager.create())
 

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -28,6 +28,7 @@ import { LanguageManager } from "./../../Services/Language"
 import { MenuManager } from "./../../Services/Menu"
 import { OverlayManager } from "./../../Services/Overlay"
 
+import { SnippetManager } from "./../../Services/Snippets"
 import { ISyntaxHighlighter } from "./../../Services/SyntaxHighlighting"
 
 import { Tasks } from "./../../Services/Tasks"
@@ -110,6 +111,7 @@ export class OniEditor implements IEditor {
         private _menuManager: MenuManager,
         private _overlayManager: OverlayManager,
         private _pluginManager: PluginManager,
+        private _snippetManager: SnippetManager,
         private _tasks: Tasks,
         private _themeManager: ThemeManager,
         private _tokenColors: TokenColors,
@@ -124,6 +126,7 @@ export class OniEditor implements IEditor {
             this._menuManager,
             this._overlayManager,
             this._pluginManager,
+            this._snippetManager,
             this._tasks,
             this._themeManager,
             this._tokenColors,
@@ -172,6 +175,7 @@ export class OniEditor implements IEditor {
                     this._menuManager,
                     this._overlayManager,
                     this._pluginManager,
+                    this._snippetManager,
                     this._tasks,
                     this._themeManager,
                     this._tokenColors,

--- a/browser/src/Services/Completion/Completion.ts
+++ b/browser/src/Services/Completion/Completion.ts
@@ -8,6 +8,7 @@ import { Store, Unsubscribe } from "redux"
 import * as types from "vscode-languageserver-types"
 
 import { LanguageManager } from "./../Language"
+import { SnippetManager } from "./../Snippets"
 
 import { getFilteredCompletions } from "./CompletionSelectors"
 import { ICompletionsRequestor } from "./CompletionsRequestor"
@@ -17,7 +18,6 @@ import { ICompletionState } from "./CompletionState"
 import { createStore } from "./CompletionStore"
 
 import { Configuration } from "./../Configuration"
-import * as CompletionUtility from "./CompletionUtility"
 
 export interface ICompletionShowEventArgs {
     filteredCompletions: types.CompletionItem[]
@@ -67,6 +67,7 @@ export class Completion implements IDisposable {
         private _configuration: Configuration,
         private _completionsRequestor: ICompletionsRequestor,
         private _languageManager: LanguageManager,
+        private _snippetManager: SnippetManager,
     ) {
         this._completionsRequestor = this._completionsRequestor
         this._store = createStore(
@@ -74,6 +75,7 @@ export class Completion implements IDisposable {
             this._languageManager,
             this._configuration,
             this._completionsRequestor,
+            this._snippetManager,
         )
 
         const sub1 = this._editor.onBufferEnter.subscribe((buf: Oni.Buffer) => {
@@ -113,7 +115,7 @@ export class Completion implements IDisposable {
             type: "COMMIT_COMPLETION",
             meetLine: state.meetInfo.meetLine,
             meetPosition: state.meetInfo.meetPosition,
-            completionText: CompletionUtility.getInsertText(completionItem),
+            completion: completionItem,
         })
     }
 

--- a/browser/src/Services/Completion/CompletionSelectors.ts
+++ b/browser/src/Services/Completion/CompletionSelectors.ts
@@ -34,7 +34,8 @@ export const getFilteredCompletions = (state: ICompletionState): types.Completio
     if (
         state.meetInfo.meetLine === state.lastCompletionInfo.meetLine &&
         state.meetInfo.meetPosition === state.lastCompletionInfo.meetPosition &&
-        state.meetInfo.meetBase === state.lastCompletionInfo.completedText
+        state.meetInfo.meetBase ===
+            CompletionUtility.getInsertText(state.lastCompletionInfo.completion)
     ) {
         return EmptyCompletions
     }

--- a/browser/src/Services/Completion/CompletionState.ts
+++ b/browser/src/Services/Completion/CompletionState.ts
@@ -42,13 +42,13 @@ export const DefaultCompletionBufferInfo: ICompletionBufferInfo = {
 export interface ILastCompletionInfo {
     meetLine: number
     meetPosition: number
-    completedText: string
+    completion: types.CompletionItem
 }
 
 export const DefaultLastCompletionInfo: ILastCompletionInfo = {
     meetLine: -1,
     meetPosition: -1,
-    completedText: "",
+    completion: null,
 }
 
 export interface ICompletionResults {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -163,6 +163,9 @@ const start = async (args: string[]): Promise<void> => {
     const CSS = await cssPromise
     CSS.activate()
 
+    const Snippets = await snippetPromise
+    Snippets.activate(commandManager)
+
     Shell.Actions.setLoadingComplete()
 
     const Diagnostics = await diagnosticsPromise
@@ -182,6 +185,7 @@ const start = async (args: string[]): Promise<void> => {
             menuManager,
             overlayManager,
             pluginManager,
+            Snippets.getInstance(),
             tasks,
             Themes.getThemeManagerInstance(),
             TokenColors.getInstance(),
@@ -229,9 +233,6 @@ const start = async (args: string[]): Promise<void> => {
 
     const GlobalCommands = await globalCommandsPromise
     GlobalCommands.activate(commandManager, menuManager, tasks)
-
-    const Snippets = await snippetPromise
-    Snippets.activate(commandManager)
 
     const KeyDisplayer = await keyDisplayerPromise
     KeyDisplayer.activate(commandManager, inputManager, overlayManager)

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -15,6 +15,7 @@ import { IDiagnosticsDataSource } from "./Services/Diagnostics"
 import { LanguageManager } from "./Services/Language"
 import { MenuManager } from "./Services/Menu"
 import { OverlayManager } from "./Services/Overlay"
+import { SnippetManager } from "./Services/Snippets"
 import { Tasks } from "./Services/Tasks"
 import { ThemeManager } from "./Services/Themes"
 import { TokenColors } from "./Services/TokenColors"
@@ -31,6 +32,7 @@ export const startEditors = async (
     menuManager: MenuManager,
     overlayManager: OverlayManager,
     pluginManager: PluginManager,
+    snippetManager: SnippetManager,
     tasks: Tasks,
     themeManager: ThemeManager,
     tokenColors: TokenColors,
@@ -45,6 +47,7 @@ export const startEditors = async (
         menuManager,
         overlayManager,
         pluginManager,
+        snippetManager,
         tasks,
         themeManager,
         tokenColors,

--- a/browser/test/Services/Completion/CompletionTests.ts
+++ b/browser/test/Services/Completion/CompletionTests.ts
@@ -75,6 +75,7 @@ describe("Completion", () => {
             mockConfiguration as any,
             mockCompletionRequestor,
             mockLanguageManager as any,
+            null /* snippet manager */,
         )
     })
 

--- a/browser/test/Services/Completion/CompletionUtilityTests.ts
+++ b/browser/test/Services/Completion/CompletionUtilityTests.ts
@@ -46,7 +46,7 @@ describe("CompletionUtility", () => {
             mockBuffer.setCursorPosition(0, 9)
 
             const snippetCompletionItem = types.CompletionItem.create("completion_snippet")
-            snippetCompletionItem.insertText = "${0:foo} ${1:bar}"
+            snippetCompletionItem.insertText = "${0:foo} ${1:bar}" // tslint:disable-line
             snippetCompletionItem.insertTextFormat = types.InsertTextFormat.Snippet
 
             await CompletionUtility.commitCompletion(

--- a/browser/test/Services/Completion/CompletionUtilityTests.ts
+++ b/browser/test/Services/Completion/CompletionUtilityTests.ts
@@ -5,7 +5,28 @@ import * as CompletionUtility from "./../../../src/Services/Completion/Completio
 const DefaultCursorMatchRegEx = /[a-z]/i
 const DefaultTriggerCharacters = ["."]
 
+import { MockBuffer } from "./../../Mocks"
+
 describe("CompletionUtility", () => {
+    describe("commitCompletion", () => {
+        let mockBuffer: MockBuffer
+
+        beforeEach(() => {
+            mockBuffer = new MockBuffer()
+        })
+
+        it("handles basic completion", async () => {
+            mockBuffer.setLinesSync(["some comp sentence"])
+            mockBuffer.setCursorPosition(0, 9)
+
+            await CompletionUtility.commitCompletion(mockBuffer as any, 0, 5, "completion")
+
+            const [resultLine] = await mockBuffer.getLines(0, 1)
+
+            assert.strictEqual(resultLine, "some completion sentence")
+        })
+    })
+
     describe("getCompletionStart", () => {
         it("rewinds back to first character", () => {
             const bufferLine = "abc"

--- a/browser/test/Services/Completion/CompletionUtilityTests.ts
+++ b/browser/test/Services/Completion/CompletionUtilityTests.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert"
 
+import * as types from "vscode-languageserver-types"
+
 import * as CompletionUtility from "./../../../src/Services/Completion/CompletionUtility"
 
 const DefaultCursorMatchRegEx = /[a-z]/i
@@ -19,7 +21,10 @@ describe("CompletionUtility", () => {
             mockBuffer.setLinesSync(["some comp sentence"])
             mockBuffer.setCursorPosition(0, 9)
 
-            await CompletionUtility.commitCompletion(mockBuffer as any, 0, 5, "completion")
+            const simpleCompletionItem = types.CompletionItem.create("completion")
+            simpleCompletionItem.insertText = "completion"
+
+            await CompletionUtility.commitCompletion(mockBuffer as any, 0, 5, simpleCompletionItem)
 
             const [resultLine] = await mockBuffer.getLines(0, 1)
 


### PR DESCRIPTION
Today, our `commitCompletion` method (which is what actually inserts completion text) only handles inserting strings.  In order to support snippets, we need to expand this to actually take the `CompletionItem`, and from there, we can handle inserting a snippet if need be.

This `commitCompletion` method would be a natural place to add additional functionality - like for #1593 , implementing code actions.

