### PR TITLE
Build: Add explicit management for caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ branches:
   only:
   - master
   - /^release.*/
+cache:
+  directories:
+  - .oni_build_cache
 matrix:
   include:
   - os: linux
@@ -27,6 +30,7 @@ install:
 - npm install -g yarn
 - yarn install
 script:
+- npm run check-cached-binaries
 - ./build/script/travis-build.sh
 deploy:
     - provider: s3

--- a/build/script/CheckBinariesForBuild.js
+++ b/build/script/CheckBinariesForBuild.js
@@ -1,0 +1,66 @@
+/**
+ * Helper script to validate the binaries we need for Oni.
+ *
+ * Because github throttles unauthenticated requests to download,
+ * in some cases on the CI machines, we are unable to get the
+ */
+
+const path = require("path")
+const fs = require("fs")
+const mkdirp = require("mkdirp")
+const fsExtra = require("fs-extra")
+
+const rootPath = path.join(__dirname, "..", "..")
+const cachePath = path.join(rootPath, ".oni_build_cache")
+
+const modulesToCheck = ["oni-neovim-binaries", "oni-ripgrep"]
+
+const isAuthenticated = !!process.env["GITHUB_TOKEN"]
+
+const doBinFoldersExist = root => {
+    const fullPaths = modulesToCheck.map(m => path.join(root, "node_modules", m, "bin"))
+
+    let result = true
+
+    fullPaths.forEach(fp => {
+        console.log("- checking folder: " + fp)
+        result = result && doesFolderExist(fp)
+    })
+
+    return result
+}
+
+const copyFolders = (srcRoot, destRoot) => {
+    modulesToCheck.forEach(m => {
+        const srcDirectory = path.join(srcRoot, "node_modules", m)
+        const destDirectory = path.join(destRoot, "node_modules", m)
+        console.log(`- Copying from ${srcDirectory} to ${destDirectory}`)
+        fsExtra.copySync(srcDirectory, destDirectory)
+    })
+}
+
+const doesFolderExist = folder => {
+    return fs.existsSync(folder) && fs.statSync(folder).isDirectory()
+}
+
+console.log("Checking binaries for build...")
+console.log("- isAuthenticated: " + isAuthenticated)
+
+const foldersExist = doBinFoldersExist(rootPath)
+const cacheFoldersExist = doBinFoldersExist(cachePath)
+
+console.log("- doBinFoldersExist in root: " + foldersExist)
+console.log("- doBinFoldersExist in cache: " + cacheFoldersExist)
+
+if (isAuthenticated && doBinFoldersExist) {
+    console.log("- Copying files to cache")
+    copyFolders(rootPath, cachePath)
+    console.log("- Copy complete")
+} else if (!isAuthenticated && !doBinFoldersExist && cacheFoldersExist) {
+    console.log("- Copying files from cache")
+    copyFolders(cachePath, rootPath)
+    console.log("- Copy complete!")
+} else {
+    console.log("Binary folders do not exist, cancelling build")
+    process.exit(1)
+}

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         "build:test": "npm run build:test:unit && npm run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "cd browser && tsc -p tsconfig.test.json",
+        "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
         "copy-dist-to-s3": "node build/script/CopyPackedFilesForS3Upload.js",
         "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",


### PR DESCRIPTION
This adds some explicit management for working with our cached binaries.

In the case where we were able to successfully download the binaries, we'll copy them to `.oni_build_cache`. This should always be the case when `GITHUB_TOKEN` is provided (for non-pull-requets).

In the case where we were _not_ able to successfully download the binaries (which is expected when a `GITHUB_TOKEN` is not available), we'll copy them from the `.oni_build_cache` over the node_modules.

This also adds logging so we can see a bit more transparency in terms of what is in the cache and what we are copying - hopefully this can help make the OSX builds more robust for PRs.