### PR TITLE
Configuration: Introduce seam to allow custom edit strategies

### DIFF
--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -10,6 +10,7 @@ import * as Log from "./../../Log"
 import * as Performance from "./../../Performance"
 import { diff } from "./../../Utility"
 
+import { IConfigurationEditor, JavaScriptConfigurationEditor } from "./ConfigurationEditor"
 import { DefaultConfiguration } from "./DefaultConfiguration"
 import { checkDeprecatedSettings } from "./DeprecatedConfigurationValues"
 import { FileConfigurationProvider } from "./FileConfigurationProvider"
@@ -58,6 +59,13 @@ export class Configuration implements Oni.Configuration {
     private _fileToProvider: { [key: string]: IConfigurationProvider } = {}
     private _configProviderInfo = new Map<IConfigurationProvider, ConfigurationProviderInfo>()
 
+    private _configurationEditors: { [key: string]: IConfigurationEditor } = {}
+
+    public get editor(): IConfigurationEditor {
+        const val = this.getValue("configuration.editor")
+        return this._configurationEditors[val] || new JavaScriptConfigurationEditor()
+    }
+
     public get onConfigurationError(): IEvent<Error> {
         return this._onConfigurationErrorEvent
     }
@@ -79,6 +87,10 @@ export class Configuration implements Oni.Configuration {
         this.addConfigurationFile(UserConfiguration.getUserConfigFilePath())
 
         Performance.mark("Config.load.end")
+    }
+
+    public registerEditor(id: string, editor: IConfigurationEditor): void {
+        this._configurationEditors[id] = editor
     }
 
     public addConfigurationFile(filePath: string): void {

--- a/browser/src/Services/Configuration/ConfigurationCommands.ts
+++ b/browser/src/Services/Configuration/ConfigurationCommands.ts
@@ -9,25 +9,22 @@ import * as path from "path"
 import { CommandManager } from "./../CommandManager"
 import { EditorManager } from "./../EditorManager"
 
+import { Configuration } from "./Configuration"
+import { ConfigurationEditManager } from "./ConfigurationEditor"
+
 import { getUserConfigFilePath } from "./index"
 
-export const activate = (commandManager: CommandManager, editorManager: EditorManager) => {
-    const openDefaultConfig = async (): Promise<void> => {
-        const activeEditor = editorManager.activeEditor
-        const buf = await activeEditor.openFile(getUserConfigFilePath())
-        const lineCount = buf.lineCount
-
-        if (lineCount === 1) {
-            const defaultConfigJsPath = path.join(__dirname, "configuration", "config.default.js")
-            const defaultConfigLines = fs.readFileSync(defaultConfigJsPath, "utf8").split(os.EOL)
-            await buf.setLines(0, defaultConfigLines.length, defaultConfigLines)
-        }
-    }
+export const activate = (
+    commandManager: CommandManager,
+    configuration: Configuration,
+    editorManager: EditorManager,
+) => {
+    const configurationEditManager = new ConfigurationEditManager(configuration, editorManager)
 
     commandManager.registerCommand({
         command: "oni.config.openConfigJs",
         name: "Configuration: Edit User Config",
         detail: "Edit user configuration file for Oni",
-        execute: () => openDefaultConfig(),
+        execute: () => configurationEditManager.editConfiguration(getUserConfigFilePath()),
     })
 }

--- a/browser/src/Services/Configuration/ConfigurationCommands.ts
+++ b/browser/src/Services/Configuration/ConfigurationCommands.ts
@@ -2,10 +2,6 @@
  * ConfigurationCommands
  */
 
-import * as fs from "fs"
-import * as os from "os"
-import * as path from "path"
-
 import { CommandManager } from "./../CommandManager"
 import { EditorManager } from "./../EditorManager"
 

--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -2,9 +2,9 @@
  * ConfigurationEditor.ts
  */
 
-import * as os from "os"
 import * as fs from "fs"
 import * as Oni from "oni-api"
+import * as os from "os"
 
 import * as Log from "./../../Log"
 

--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -1,0 +1,73 @@
+/**
+ * ConfigurationEditor.ts
+ */
+
+import { EditorManager } from "./../EditorManager"
+
+import { Configuration } from "./Configuration"
+
+// For configuring Oni, JavaScript is the de-facto language, and the configuration
+// today will _always_ happen through `config.js`
+//
+// However, we want to support configuring in dialects of JS, like:
+// - TypeScript
+// - Reason
+// - ClojureScript
+// - CoffeeScript
+// - Script# (C#)
+// etc...
+//
+// Or even wasm languages!
+//
+// `IConfigurationEditor` provides an interface for this functionality.
+//
+// The expectation is that implementors of this will specify a separate file,
+// and implement functionality for compilng to JavaScript.
+export interface IConfigurationEditor {
+    // For configuration editors that use a different language
+    // (TypeScript, Reason, etc), this specifies the file
+    // that should be opened for editing.
+    getEditFile(configurationFilePath: string): Promise<string>
+
+    // When the edit file is saved, this is responsible for transpiling the contents
+    // to javascript.
+    transpileConfigurationToJavaScript(contents: string): Promise<string>
+}
+
+export class JavaScriptConfigurationEditor {
+    public async getEditFile(configurationFilePath: string): Promise<string> {
+        return configurationFilePath
+    }
+
+    public async transpileConfigurationToJavaScript(contents: string): Promise<string> {
+        return contents
+    }
+}
+
+export interface IConfigurationEditInfo {
+    editor: IConfigurationEditor
+    destinationConfigFilePath: string
+}
+
+export class ConfigurationEditManager {
+    private _fileToEditor: { [filePath: string]: IConfigurationEditInfo } = {}
+
+    constructor(private _configuration: Configuration, private _editorManager: EditorManager) {}
+
+    public async editConfiguration(configFile: string): Promise<void> {
+        const editor = this._configuration.editor
+        const editFile = await editor.getEditFile(configFile)
+
+        if (editFile) {
+            this._fileToEditor[editFile] = {
+                editor,
+                destinationConfigFilePath: configFile,
+            }
+        } else {
+            this._fileToEditor[configFile] = {
+                editor: new JavaScriptConfigurationEditor(),
+                destinationConfigFilePath: configFile,
+            }
+        }
+    }
+}

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -33,6 +33,7 @@ const BaseConfiguration: IConfigurationValues = {
     deactivate: noop,
 
     "autoUpdate.enabled": false,
+    "configuration.editor": "javascript",
 
     "debug.fixedSize": null,
     "debug.neovimPath": null,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -36,6 +36,8 @@ export interface IConfigurationValues {
 
     "editor.split.mode": string
 
+    "configuration.editor": string
+
     // - textMateHighlighting
     "experimental.editor.textMateHighlighting.enabled": boolean
 

--- a/browser/src/Services/Configuration/UserConfiguration.ts
+++ b/browser/src/Services/Configuration/UserConfiguration.ts
@@ -19,6 +19,12 @@ export const getUserConfigFilePath = (): string => {
 }
 
 export const getUserConfigFolderPath = (): string => {
+    const configFileFromEnv = process.env["ONI_CONFIG_FILE"] as string // tslint:disable-line
+
+    if (configFileFromEnv) {
+        return path.dirname(configFileFromEnv)
+    }
+
     return Platform.isWindows()
         ? path.join(Platform.getUserHome(), "oni")
         : path.join(Platform.getUserHome(), ".oni")

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -233,7 +233,7 @@ const start = async (args: string[]): Promise<void> => {
     const autoClosingPairsPromise = import("./Services/AutoClosingPairs")
 
     const ConfigurationCommands = await configurationCommandsPromise
-    ConfigurationCommands.activate(commandManager, editorManager)
+    ConfigurationCommands.activate(commandManager, configuration, editorManager)
 
     const AutoClosingPairs = await autoClosingPairsPromise
     AutoClosingPairs.activate(configuration, editorManager, inputManager, languageManager)


### PR DESCRIPTION
The goal of this work is to allow different configuration edit strategies (TypeScript, Reason, ClojureScript, etc...). This factors out the logic these configuration edit providers will need into an interface, and creates an initial implementation for JavaScript.

Next up will be implementing the TypeScript configuration provider - which means the configuration file will have rich integration with language services (much better experience when experimenting with Oni's API layer).