### PR TITLE
Snippets - Bug Fix: Zero-length placeholders aren't handled correctly

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -674,6 +674,11 @@ export class NeovimEditor extends Editor implements IEditor {
         this._commands.deactivate()
     }
 
+    public async clearSelection(): Promise<void> {
+        await this._neovimInstance.input("<esc>")
+        await this._neovimInstance.input("a")
+    }
+
     public async setSelection(range: types.Range): Promise<void> {
         await this._neovimInstance.input("<esc>")
 

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -195,6 +195,10 @@ export class OniEditor implements IEditor {
         return this._neovimEditor.newFile(filePath)
     }
 
+    public async clearSelection(): Promise<void> {
+        return this._neovimEditor.clearSelection()
+    }
+
     public async setSelection(range: types.Range): Promise<void> {
         return this._neovimEditor.setSelection(range)
     }

--- a/browser/src/Services/Snippets/OniSnippet.ts
+++ b/browser/src/Services/Snippets/OniSnippet.ts
@@ -54,7 +54,7 @@ export class OniSnippet {
     }
 
     public getPlaceholderValue(index: number): string {
-        return this._placeholderValues[index] || null
+        return this._placeholderValues[index] || ""
     }
 
     public getPlaceholders(): OniSnippetPlaceholder[] {

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -177,13 +177,18 @@ export class SnippetSession {
                 : currentPlaceholder.character
         const placeHolderLength = currentPlaceholder.value.length
 
-        await this._editor.setSelection(
-            types.Range.create(
-                adjustedLine,
-                adjustedCharacter,
-                adjustedLine,
-                adjustedCharacter + placeHolderLength - 1,
-            ),
-        )
+        if (placeHolderLength === 0) {
+            await (this._editor as any).clearSelection()
+            await this._editor.activeBuffer.setCursorPosition(adjustedLine, adjustedCharacter)
+        } else {
+            await this._editor.setSelection(
+                types.Range.create(
+                    adjustedLine,
+                    adjustedCharacter,
+                    adjustedLine,
+                    adjustedCharacter + placeHolderLength - 1,
+                ),
+            )
+        }
     }
 }


### PR DESCRIPTION
For a snippet like:
```
import { ${0} } from "${1:module}"
```

The first placeholder won't be evaluated correctly - it'll try and select which isn't really the expected behavior. Instead, it should just put the cursor at the position.

In addition, there was an issue with synchronizing placeholder updates with an empty character - we'd get caught in an endless cycle of synchronizing due to a mismatch in typing (we always thought the placeholder was updated, because we were comparing `""` and `null`)