### PR TITLE
Improve shell scripts

### DIFF
--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-echo Travis build - detected OS is: $TRAVIS_OS_NAME
+echo Travis build - detected OS is: "$TRAVIS_OS_NAME"
 set -e
 
 node --version
 npm --version
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  export DISPLAY=:99.0
+  DISPLAY=:99.0
+  export DISPLAY
   sh -e /etc/init.d/xvfb start
   sleep 3
 
@@ -15,7 +16,8 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   curl -LO https://github.com/neovim/neovim/releases/download/v0.2.2/nvim.appimage
   chmod u+x nvim.appimage
   ./nvim.appimage --version
-  export ONI_NEOVIM_PATH="$(cd "$(dirname "$1")"; pwd)/nvim.appimage"
+  ONI_NEOVIM_PATH="$(cd "$(dirname "$1")"; pwd)/nvim.appimage"
+  export ONI_NEOVIM_PATH
 fi
 
 npm run build
@@ -23,7 +25,7 @@ npm run test:unit
 npm run lint
 npm run pack
 
-echo Using neovim path: $ONI_NEOVIM_PATH
+echo Using neovim path: "$ONI_NEOVIM_PATH"
 
 npm run test:integration
 

--- a/oni.sh
+++ b/oni.sh
@@ -14,14 +14,14 @@ self=$0
 OPEN_DIRECTORY="$PWD"
 
 # test if $self is a symlink
-if [ -L $self ] ; then
+if [ -L "$self" ] ; then
    # readlink returns the path to the file the link points to:
-   target=`readlink $self`
+   target=$(readlink "$self")
 else
    target=$self
 fi
 
-ONI_PATH=`dirname $target`
+ONI_PATH=$(dirname "$target")
 
 FULL_ONI_PATH="$ONI_PATH/../../MacOS/Oni"
 

--- a/scripts/webm2gif.sh
+++ b/scripts/webm2gif.sh
@@ -2,8 +2,8 @@
 # This script uses `ffmpeg` to convert a .webm file
 # (specified by the first argument) to an animated gif
 
-echo The argument is $1 $2
+echo The argument is "$1" "$2"
 
-ffmpeg -y -i $1 -vf fps=10,scale=0:0:flags=lanczos,palettegen palette.png
+ffmpeg -y -i "$1" -vf fps=10,scale=0:0:flags=lanczos,palettegen palette.png
 
-ffmpeg -i $1 -i palette.png -filter_complex "fps=10,scale=0:0:flags=lanczos[x];[x][1:v]paletteuse" output.gif
+ffmpeg -i "$1" -i palette.png -filter_complex "fps=10,scale=0:0:flags=lanczos[x];[x][1:v]paletteuse" output.gif


### PR DESCRIPTION
Hi,

I fixed various things spotted by ShellCheck using: `find -O3 . -type f -name '*.sh' -exec shellcheck -x {} \;`.

There are still these:

```sh
In ./oni.sh line 4:
    OS='Mac'
    ^-- SC2034: OS appears unused. Verify it or export it.


In ./oni.sh line 28:
ONI_CWD="$OPEN_DIRECTORY" open --new -a "$FULL_ONI_PATH" --args $*
                                                                ^-- SC2048: Use "$@" (with quotes) to prevent whitespace problems.
                                                                ^-- SC2086: Double quote to prevent globbing and word splitting.
```

For the first one, I think it'll be used in the future when Linux is supported.

For the second one, I'm not sure what's exactly expected here, replacing `$*` seems legit to me, but I'm not sure about adding quotes. Let me know what to do, I'll amend the commit if needed.
