### PR TITLE
Snippets - Bug Fix: Fix ordering of placeholders

### DIFF
--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -25,7 +25,9 @@ export const getSmallestPlaceholder = (
     placeholders: OniSnippetPlaceholder[],
 ): OniSnippetPlaceholder => {
     return placeholders.reduce((prev: OniSnippetPlaceholder, curr: OniSnippetPlaceholder) => {
-        if (!prev) return curr
+        if (!prev) {
+            return curr
+        }
 
         if (curr.index < prev.index) {
             return curr
@@ -95,10 +97,6 @@ export class SnippetSession {
         }
 
         await this.nextPlaceholder()
-    }
-
-    private _finish(): void {
-        this._onCancelEvent.dispatch()
     }
 
     public async nextPlaceholder(): Promise<void> {
@@ -176,6 +174,10 @@ export class SnippetSession {
         // Set placeholder value
         const newPlaceholderValue = currentLine.substring(startPosition, endPosition)
         await this.setPlaceholderValue(bounds.index, newPlaceholderValue)
+    }
+
+    private _finish(): void {
+        this._onCancelEvent.dispatch()
     }
 
     private _getBoundsForPlaceholder(): {

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -21,6 +21,32 @@ export const splitLineAtPosition = (line: string, position: number): [string, st
     return [prefix, post]
 }
 
+export const getSmallestPlaceholder = (
+    placeholders: OniSnippetPlaceholder[],
+): OniSnippetPlaceholder => {
+    return placeholders.reduce((prev: OniSnippetPlaceholder, curr: OniSnippetPlaceholder) => {
+        if (!prev) return curr
+
+        if (curr.index < prev.index) {
+            return curr
+        }
+        return prev
+    }, null)
+}
+
+export const getPlaceholderByIndex = (
+    placeholders: OniSnippetPlaceholder[],
+    index: number,
+): OniSnippetPlaceholder | null => {
+    const matchingPlaceholders = placeholders.filter(p => p.index === index)
+
+    if (matchingPlaceholders.length === 0) {
+        return null
+    }
+
+    return matchingPlaceholders[0]
+}
+
 export class SnippetSession {
     private _buffer: IBuffer
     private _position: types.Position
@@ -30,7 +56,7 @@ export class SnippetSession {
     private _prefix: string
     private _suffix: string
 
-    private _placeholderIndex: number = -1
+    private _currentPlaceholder: OniSnippetPlaceholder = null
 
     public get onCancel(): IEvent<void> {
         return this._onCancelEvent
@@ -60,25 +86,48 @@ export class SnippetSession {
 
         await this._buffer.setLines(cursorPosition.line, cursorPosition.line + 1, snippetLines)
 
+        const placeholders = this._snippet.getPlaceholders()
+
+        if (!placeholders || placeholders.length === 0) {
+            // If no placeholders, we're done with the session
+            this._finish()
+            return
+        }
+
         await this.nextPlaceholder()
+    }
+
+    private _finish(): void {
+        this._onCancelEvent.dispatch()
     }
 
     public async nextPlaceholder(): Promise<void> {
         const placeholders = this._snippet.getPlaceholders()
 
-        this._placeholderIndex = (this._placeholderIndex + 1) % placeholders.length
-        const currentPlaceholder = placeholders[this._placeholderIndex]
+        if (!this._currentPlaceholder) {
+            const newPlaceholder = getSmallestPlaceholder(placeholders)
+            this._currentPlaceholder = newPlaceholder
+        } else {
+            const nextPlaceholder = getPlaceholderByIndex(
+                placeholders,
+                this._currentPlaceholder.index + 1,
+            )
+            this._currentPlaceholder = nextPlaceholder || getSmallestPlaceholder(placeholders)
+        }
 
-        await this._highlightPlaceholder(currentPlaceholder)
+        await this._highlightPlaceholder(this._currentPlaceholder)
     }
 
     public async previousPlaceholder(): Promise<void> {
         const placeholders = this._snippet.getPlaceholders()
 
-        this._placeholderIndex = (this._placeholderIndex - 1) % placeholders.length
-        const currentPlaceholder = placeholders[this._placeholderIndex]
+        const nextPlaceholder = getPlaceholderByIndex(
+            placeholders,
+            this._currentPlaceholder.index - 1,
+        )
+        this._currentPlaceholder = nextPlaceholder || getSmallestPlaceholder(placeholders)
 
-        await this._highlightPlaceholder(currentPlaceholder)
+        await this._highlightPlaceholder(this._currentPlaceholder)
     }
 
     public async setPlaceholderValue(index: number, val: string): Promise<void> {
@@ -135,8 +184,7 @@ export class SnippetSession {
         start: number
         distanceFromEnd: number
     } {
-        const placeholders = this._snippet.getPlaceholders()
-        const currentPlaceholder = placeholders[this._placeholderIndex]
+        const currentPlaceholder = this._currentPlaceholder
 
         const currentSnippetLines = this._snippet.getLines()
 

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -117,7 +117,7 @@ describe("SnippetSession", () => {
             selection = await mockEditor.getSelection()
 
             // Validate we are highlighting the _second_ item now
-            const secondItemRange = types.Range.create(0, 1, 0, 4)
+            const secondItemRange = types.Range.create(0, 0, 0, 3)
             assert.strictEqual(selection.start.line, secondItemRange.start.line)
             assert.strictEqual(selection.start.character, secondItemRange.start.character)
             assert.strictEqual(selection.end.character, secondItemRange.end.character)
@@ -128,7 +128,7 @@ describe("SnippetSession", () => {
             snippetSession = new SnippetSession(mockEditor as any, snippet)
 
             const placeholder0Range = types.Range.create(0, 5, 0, 9)
-            const placeholder1Range = types.Range.create(0, 1, 0, 4)
+            const placeholder1Range = types.Range.create(0, 0, 0, 3)
 
             await snippetSession.start() // Placeholder 0
             await snippetSession.nextPlaceholder() // Placeholder 1

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -98,6 +98,29 @@ describe("SnippetSession", () => {
             assert.strictEqual(selection.start.character, expectedRange.start.character)
             assert.strictEqual(selection.end.character, expectedRange.end.character)
         })
+
+        it("traverses order correctly", async () => {
+            const snippet = new OniSnippet("${1:test} ${0:test2}")
+            snippetSession = new SnippetSession(mockEditor as any, snippet)
+
+            await snippetSession.start()
+
+            const selection = await mockEditor.getSelection()
+
+            // Validate we are highlighting the _second_ item now
+            const expectedRange = types.Range.create(0, 5, 0, 9)
+            assert.strictEqual(selection.start.line, expectedRange.start.line)
+            assert.strictEqual(selection.start.character, expectedRange.start.character)
+            assert.strictEqual(selection.end.character, expectedRange.end.character)
+
+            await snippetSession.nextPlaceholder()
+
+            // Validate we are highlighting the _second_ item now
+            const secondItemRange = types.Range.create(0, 1, 0, 4)
+            assert.strictEqual(selection.start.line, secondItemRange.start.line)
+            assert.strictEqual(selection.start.character, secondItemRange.start.character)
+            assert.strictEqual(selection.end.character, secondItemRange.end.character)
+        })
     })
 
     describe("synchronizeUpdatedPlaceholders", () => {

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -99,13 +99,13 @@ describe("SnippetSession", () => {
             assert.strictEqual(selection.end.character, expectedRange.end.character)
         })
 
-        it("traverses order correctly", async () => {
+        it("traverses order correctly, when placeholders are reversed", async () => {
             const snippet = new OniSnippet("${1:test} ${0:test2}")
             snippetSession = new SnippetSession(mockEditor as any, snippet)
 
             await snippetSession.start()
 
-            const selection = await mockEditor.getSelection()
+            let selection = await mockEditor.getSelection()
 
             // Validate we are highlighting the _second_ item now
             const expectedRange = types.Range.create(0, 5, 0, 9)
@@ -114,12 +114,38 @@ describe("SnippetSession", () => {
             assert.strictEqual(selection.end.character, expectedRange.end.character)
 
             await snippetSession.nextPlaceholder()
+            selection = await mockEditor.getSelection()
 
             // Validate we are highlighting the _second_ item now
             const secondItemRange = types.Range.create(0, 1, 0, 4)
             assert.strictEqual(selection.start.line, secondItemRange.start.line)
             assert.strictEqual(selection.start.character, secondItemRange.start.character)
             assert.strictEqual(selection.end.character, secondItemRange.end.character)
+        })
+
+        it("traverses order correctly, when there are multiple placeholders with the same index", async () => {
+            const snippet = new OniSnippet("${1:test} ${0:test2} ${1}")
+            snippetSession = new SnippetSession(mockEditor as any, snippet)
+
+            const placeholder0Range = types.Range.create(0, 5, 0, 9)
+            const placeholder1Range = types.Range.create(0, 1, 0, 4)
+
+            await snippetSession.start() // Placeholder 0
+            await snippetSession.nextPlaceholder() // Placeholder 1
+
+            let selection = await mockEditor.getSelection()
+
+            assert.strictEqual(selection.start.line, placeholder1Range.start.line)
+            assert.strictEqual(selection.start.character, placeholder1Range.start.character)
+            assert.strictEqual(selection.end.character, placeholder1Range.end.character)
+
+            await snippetSession.nextPlaceholder() // Wrap back to placeholder 0
+            selection = await mockEditor.getSelection()
+
+            // Validate we are highlighting the _second_ item now
+            assert.strictEqual(selection.start.line, placeholder0Range.start.line)
+            assert.strictEqual(selection.start.character, placeholder0Range.start.character)
+            assert.strictEqual(selection.end.character, placeholder0Range.end.character)
         })
     })
 

--- a/extensions/typescript/snippets/typescript.json
+++ b/extensions/typescript/snippets/typescript.json
@@ -21,7 +21,7 @@
     },
     "Import external module.": {
         "prefix": "import statement",
-        "body": ["import { $0 } from \"${1:module}\";"],
+        "body": ["import { $1 } from \"${0:module}\";"],
         "description": "Import external module."
     },
     "Property getter": {


### PR DESCRIPTION
__Issue:__ Oni doesn't respect the ordering of placeholders in snippets.

For example, a snippet like:
```
${1:test1} ${0:test0}
```
will highlighting the `test1` portion first, and then `test0`.