### PR TITLE
Build: Fix typo in 'CheckBinariesForBuild'

### DIFF
--- a/build/script/CheckBinariesForBuild.js
+++ b/build/script/CheckBinariesForBuild.js
@@ -52,11 +52,11 @@ const cacheFoldersExist = doBinFoldersExist(cachePath)
 console.log("- doBinFoldersExist in root: " + foldersExist)
 console.log("- doBinFoldersExist in cache: " + cacheFoldersExist)
 
-if (isAuthenticated && doBinFoldersExist) {
+if (isAuthenticated && foldersExist) {
     console.log("- Copying files to cache")
     copyFolders(rootPath, cachePath)
     console.log("- Copy complete")
-} else if (!isAuthenticated && !doBinFoldersExist && cacheFoldersExist) {
+} else if (!isAuthenticated && !foldersExist && cacheFoldersExist) {
     console.log("- Copying files from cache")
     copyFolders(cachePath, rootPath)
     console.log("- Copy complete!")

--- a/build/script/CheckBinariesForBuild.js
+++ b/build/script/CheckBinariesForBuild.js
@@ -13,7 +13,8 @@ const fsExtra = require("fs-extra")
 const rootPath = path.join(__dirname, "..", "..")
 const cachePath = path.join(rootPath, ".oni_build_cache")
 
-const modulesToCheck = ["oni-neovim-binaries", "oni-ripgrep"]
+const modulesToCheck =
+    os.platform() === "darwin" ? ["oni-neovim-binaries", "oni-ripgrep"] : ["oni-ripgrep"]
 
 const isAuthenticated = !!process.env["GITHUB_TOKEN"]
 

--- a/build/script/CheckBinariesForBuild.js
+++ b/build/script/CheckBinariesForBuild.js
@@ -9,6 +9,7 @@ const path = require("path")
 const fs = require("fs")
 const mkdirp = require("mkdirp")
 const fsExtra = require("fs-extra")
+const os = require("os")
 
 const rootPath = path.join(__dirname, "..", "..")
 const cachePath = path.join(rootPath, ".oni_build_cache")


### PR DESCRIPTION
Script was checking `doBinFoldersExist` instead of `foldersExist`, which would always fail in the non-authenticated (PR) case.
