### PR TITLE
Build: CheckCachedBinaries script - fix incorrect case

### DIFF
--- a/build/script/CheckBinariesForBuild.js
+++ b/build/script/CheckBinariesForBuild.js
@@ -62,7 +62,15 @@ if (isAuthenticated && foldersExist) {
     console.log("- Copying files from cache")
     copyFolders(cachePath, rootPath)
     console.log("- Copy complete!")
-} else {
+}
+
+// Check again, now that files were copied if they needed to be copied
+
+const finalCheckForBinaries = doBinFoldersExist(rootPath)
+
+console.log(" - Final check for binaries in node_modules: " + finalCheckForBinaries)
+
+if (!finalCheckForBinaries) {
     console.log("Binary folders do not exist, cancelling build")
     process.exit(1)
 }


### PR DESCRIPTION
In the unauthenticated case, the script assumes that there are no downloaded binaries. This isn't a correct assumption, because that only happens in the download-throttled-by-github case.

This just refactors that and we do a consistent check - at the end of the script, there definitely should be binaries available in the `node_modules` folder, whether they from the build cache or downloads.