### PR TITLE
Bugfix/Neovim instance can be undefined on startup

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from "events"
 
 import * as OniApi from "oni-api"
 
-import * as Process from "./Process"
+import Process from "./Process"
 import { Services } from "./Services"
 import { Ui } from "./Ui"
 

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -1,120 +1,146 @@
 import * as ChildProcess from "child_process"
+import { memoize } from "lodash"
 
+import * as Oni from "oni-api"
 import * as Log from "./../../Log"
 import * as Platform from "./../../Platform"
 import { configuration } from "./../../Services/Configuration"
 
-const getPathSeparator = () => {
-    return Platform.isWindows() ? ";" : ":"
+interface ProcessEnv {
+    [key: string]: string
 }
 
-const _spawnedProcessIds: number[] = []
+export class Process implements Oni.Process {
+    public _spawnedProcessIds: number[] = []
+    private _shellEnvPromise: Promise<any>
+    private _shellEnv: any
+    private _env: ProcessEnv
 
-const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[]): string => {
-    if (!pathsToAdd || !pathsToAdd.length) {
-        return currentPath
+    constructor() {
+        this._shellEnvPromise = import("shell-env")
     }
 
-    const separator = getPathSeparator()
+    private mergeSpawnOptions = memoize(
+        async (
+            originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions,
+        ): Promise<any> => {
+            let existingPath: string
 
-    const joinedPathsToAdd = pathsToAdd.join(separator)
+            try {
+                const t1 = performance.now()
+                if (!this._shellEnv) {
+                    this._shellEnv = await this._shellEnvPromise
+                }
+                if (!this._env) {
+                    this._env = await this._shellEnv()
+                }
+                process.env = { ...process.env, ...this._env }
+                existingPath = process.env.Path || process.env.PATH
+                const t2 = performance.now()
+                console.log("Time to get env async with dynamic import  ===========", t2 - t1)
+            } catch (e) {
+                existingPath = process.env.Path || process.env.PATH
+            }
 
-    return currentPath + separator + joinedPathsToAdd
-}
+            const requiredOptions = {
+                env: {
+                    ...process.env,
+                    ...originalSpawnOptions.env,
+                },
+            }
 
-const mergeSpawnOptions = async (
-    originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions,
-): Promise<any> => {
-    let existingPath: string
+            requiredOptions.env.PATH = this.mergePathEnvironmentVariable(
+                existingPath,
+                configuration.getValue("environment.additionalPaths"),
+            )
 
-    try {
-        const shellEnv = await import("shell-env")
-        const shellEnvironment = await shellEnv()
-        process.env = { ...process.env, ...shellEnvironment }
-        existingPath = process.env.Path || process.env.PATH
-    } catch (e) {
-        existingPath = process.env.Path || process.env.PATH
-    }
-
-    const requiredOptions = {
-        env: {
-            ...process.env,
-            ...originalSpawnOptions.env,
+            return {
+                ...originalSpawnOptions,
+                ...requiredOptions,
+            }
         },
-    }
-
-    requiredOptions.env.PATH = mergePathEnvironmentVariable(
-        existingPath,
-        configuration.getValue("environment.additionalPaths"),
     )
 
-    return {
-        ...originalSpawnOptions,
-        ...requiredOptions,
+    public getPathSeparator = () => {
+        return Platform.isWindows() ? ";" : ":"
+    }
+
+    public mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[]): string => {
+        if (!pathsToAdd || !pathsToAdd.length) {
+            return currentPath
+        }
+
+        const separator = this.getPathSeparator()
+
+        const joinedPathsToAdd = pathsToAdd.join(separator)
+
+        return currentPath + separator + joinedPathsToAdd
+    }
+
+    /**
+     * API surface area responsible for handling process-related tasks
+     * (spawning processes, managing running process, etc)
+     */
+    public execNodeScript = async (
+        scriptPath: string,
+        args: string[] = [],
+        options: ChildProcess.ExecOptions = {},
+        callback: (err: any, stdout: string, stderr: string) => void,
+    ): Promise<ChildProcess.ChildProcess> => {
+        const spawnOptions = await this.mergeSpawnOptions(options)
+        spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
+
+        const execOptions = [process.execPath, scriptPath].concat(args)
+        const execString = execOptions.map(s => `"${s}"`).join(" ")
+
+        const proc = ChildProcess.exec(execString, spawnOptions, callback)
+        this._spawnedProcessIds.push(proc.pid)
+        return proc
+    }
+
+    /**
+     * Get the set of process IDs that were spawned by Oni
+     */
+    public getPIDs = (): number[] => {
+        return [...this._spawnedProcessIds]
+    }
+
+    /**
+     * Wrapper around `child_process.exec` to run using electron as opposed to node
+     */
+    public spawnNodeScript = async (
+        scriptPath: string,
+        args: string[] = [],
+        options: ChildProcess.SpawnOptions = {},
+    ): Promise<ChildProcess.ChildProcess> => {
+        const spawnOptions = await this.mergeSpawnOptions(options)
+        spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
+
+        const allArgs = [scriptPath].concat(args)
+
+        const proc = ChildProcess.spawn(process.execPath, allArgs, spawnOptions)
+        this._spawnedProcessIds.push(proc.pid)
+        return proc
+    }
+
+    /**
+     * Spawn process - wrapper around `child_process.spawn`
+     */
+    public spawnProcess = async (
+        startCommand: string,
+        args: string[] = [],
+        options: ChildProcess.SpawnOptions = {},
+    ): Promise<ChildProcess.ChildProcess> => {
+        const spawnOptions = await this.mergeSpawnOptions(options)
+
+        const proc = ChildProcess.spawn(startCommand, args, spawnOptions)
+        this._spawnedProcessIds.push(proc.pid)
+        proc.on("error", (err: Error) => {
+            Log.error(err)
+        })
+
+        return proc
     }
 }
 
-/**
- * API surface area responsible for handling process-related tasks
- * (spawning processes, managing running process, etc)
- */
-export const execNodeScript = async (
-    scriptPath: string,
-    args: string[] = [],
-    options: ChildProcess.ExecOptions = {},
-    callback: (err: any, stdout: string, stderr: string) => void,
-): Promise<ChildProcess.ChildProcess> => {
-    const spawnOptions = await mergeSpawnOptions(options)
-    spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
-
-    const execOptions = [process.execPath, scriptPath].concat(args)
-    const execString = execOptions.map(s => `"${s}"`).join(" ")
-
-    const proc = ChildProcess.exec(execString, spawnOptions, callback)
-    _spawnedProcessIds.push(proc.pid)
-    return proc
-}
-
-/**
- * Get the set of process IDs that were spawned by Oni
- */
-export const getPIDs = (): number[] => {
-    return [..._spawnedProcessIds]
-}
-
-/**
- * Wrapper around `child_process.exec` to run using electron as opposed to node
- */
-export const spawnNodeScript = async (
-    scriptPath: string,
-    args: string[] = [],
-    options: ChildProcess.SpawnOptions = {},
-): Promise<ChildProcess.ChildProcess> => {
-    const spawnOptions = await mergeSpawnOptions(options)
-    spawnOptions.env.ELECTRON_RUN_AS_NODE = 1
-
-    const allArgs = [scriptPath].concat(args)
-
-    const proc = ChildProcess.spawn(process.execPath, allArgs, spawnOptions)
-    _spawnedProcessIds.push(proc.pid)
-    return proc
-}
-
-/**
- * Spawn process - wrapper around `child_process.spawn`
- */
-export const spawnProcess = async (
-    startCommand: string,
-    args: string[] = [],
-    options: ChildProcess.SpawnOptions = {},
-): Promise<ChildProcess.ChildProcess> => {
-    const spawnOptions = await mergeSpawnOptions(options)
-
-    const proc = ChildProcess.spawn(startCommand, args, spawnOptions)
-    _spawnedProcessIds.push(proc.pid)
-    proc.on("error", (err: Error) => {
-        Log.error(err)
-    })
-
-    return proc
-}
+export default new Process()

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -16,10 +16,6 @@ export class Process implements Oni.Process {
     private _shellEnv: any
     private _env: ProcessEnv
 
-    constructor() {
-        this._shellEnvPromise = import("shell-env")
-    }
-
     private mergeSpawnOptions = memoize(
         async (
             originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions,
@@ -60,6 +56,10 @@ export class Process implements Oni.Process {
             }
         },
     )
+
+    constructor() {
+        this._shellEnvPromise = import("shell-env")
+    }
 
     public getPathSeparator = () => {
         return Platform.isWindows() ? ";" : ":"

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -5,15 +5,11 @@ import * as Log from "./../../Log"
 import * as Platform from "./../../Platform"
 import { configuration } from "./../../Services/Configuration"
 
-interface ProcessEnv {
-    [key: string]: string
-}
-
 export class Process implements Oni.Process {
     public _spawnedProcessIds: number[] = []
     private _shellEnvPromise: Promise<any>
     private _shellEnv: any
-    private _env: ProcessEnv
+    private _env: NodeJS.ProcessEnv
 
     constructor() {
         this._shellEnvPromise = import("shell-env")

--- a/browser/src/Plugins/Api/shell-env.d.ts
+++ b/browser/src/Plugins/Api/shell-env.d.ts
@@ -1,1 +1,6 @@
-declare module "shell-env"
+declare module "shell-env" {
+    export namespace shellEnv {
+        export function sync(shell?: string): NodeJS.Env
+        export default function(shell?: string): Promise<NodeJS.Env>
+    }
+}

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -24,7 +24,7 @@ import { LanguageClientLogger } from "./../../Plugins/Api/LanguageClient/Languag
 
 import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
-import * as Process from "./../../Plugins/Api/Process"
+import Process from "./../../Plugins/Api/Process"
 
 import { IServerCapabilities } from "./ServerCapabilities"
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -3,7 +3,7 @@ import * as net from "net"
 import * as path from "path"
 
 import * as Platform from "./../Platform"
-import { spawnProcess } from "./../Plugins/Api/Process"
+import Process from "./../Plugins/Api/Process"
 
 import { Session } from "./Session"
 
@@ -129,7 +129,7 @@ export const startNeovim = async (
         "[NeovimProcessSpawner::startNeovim] Sending these args to Neovim: " +
             argsToPass.toString(),
     )
-    const nvimProc = await spawnProcess(nvimProcessPath, argsToPass, {})
+    const nvimProc = await Process.spawnProcess(nvimProcessPath, argsToPass, {})
     Log.info(`[NeovimProcessSpawner::startNeovim] Starting Neovim - process: ${nvimProc.pid}`) // tslint:disable-line no-console
 
     return getSessionFromProcess(nvimProc, options.transport)


### PR DESCRIPTION
<!-- Love oni? Please consider supporting our collective:
👉  https://opencollective.com/oni/donate -->

@bryphe whilst looking into #1583 re `shellEnv` behaviour I think I've found the cause of the request of undefined error that can occur/ occurs on the editor startup, btw this is not a fix for #1583 as the cause of that though related maybe is still unclear.

Having the call to `shellEnv` occur asynchronously in order to cut down on startup time means that when the editor window comes into view the promise to startup a neovim instance is often not actually complete so if you click the editor or try to go into the sidebar this was what was leading to the error

<img width="451" alt="screen shot 2018-02-25 at 11 10 55" src="https://user-images.githubusercontent.com/22454918/36640807-9f55888e-1a1d-11e8-8306-c3fd3f9a68ef.png">

By using the sync version of the shellEnv function the errors stop entirely as things block till the instance is actually initialised.

I know the concern was about performance, so I checked the profile logs

First is the async version with the associated error notifications and time stamps:
<img width="857" alt="screen shot 2018-02-25 at 12 30 42" src="https://user-images.githubusercontent.com/22454918/36641612-66ee9802-1a2a-11e8-84c3-4a2967de3545.png">

Sync version:
<img width="764" alt="screen shot 2018-02-25 at 12 31 28" src="https://user-images.githubusercontent.com/22454918/36641619-83a09464-1a2a-11e8-823a-8b0611dc2d98.png">

The difference in startup cost seems quite small (and tbh on multiple attempts varied a lot with the 300ms difference being the largest I observed) and I think especially at the cost of starting Oni up before the neovim instance is ready.

I think neovim is a crucial thing that needs to be ready before the editor appears otherwise thing's reliant on it begin to initiate functionality dependent on it before it exists (also I *think* its initial reliance on the import promise still makes that function async so while internally it blocks at the sync call it does all this in a promise.

I also looked at the `mergeSpawnOptions` function which uses `shellEnv` and is actually quite an expensive function.

<img width="444" alt="screen shot 2018-02-25 at 12 22 00" src="https://user-images.githubusercontent.com/22454918/36641642-0356f360-1a2b-11e8-9d9b-d67cb597cca5.png">

It seems that almost any attempt by oni to create a process calls this function which

1.) Dynamically imports shell-env
2.) Calls the shell-env method async

resulting in the calls above, the first is for `nvim`, second the `lsp` and third the `sidebar instance`.

I moved the files functionality into a class and saved the dynamic import on the first call then also saved the value of the call to shell-env to use in subsequent calls to this function which results in

<img width="435" alt="screen shot 2018-02-25 at 12 23 16" src="https://user-images.githubusercontent.com/22454918/36641667-7a3e76a6-1a2b-11e8-8c05-3a4cb1aeaab1.png">

fixes #1523

