### PR TITLE
Add comma after "editor.fontFamily" in "config.js"

### DIFF
--- a/configuration/config.default.js
+++ b/configuration/config.default.js
@@ -32,7 +32,7 @@ module.exports = {
     //"oni.bookmarks": ["~/Documents"],
     //"oni.loadInitVim": false,
     //"editor.fontSize": "14px",
-    //"editor.fontFamily": "Monaco"
+    //"editor.fontFamily": "Monaco",
 
     // UI customizations
     "ui.animations.enabled": true,


### PR DESCRIPTION
Missing comma, which makes uncomment this option
results in syntax error