### PR TITLE
Snippets - Bug Fix: Incorrect behavior when typing in a set placeholder value

### DIFF
--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -139,6 +139,8 @@ export class SnippetSession {
         }
 
         await this._snippet.setPlaceholder(index, val)
+        // Update current placeholder
+        this._currentPlaceholder = getPlaceholderByIndex(this._snippet.getPlaceholders(), index)
         await this._updateSnippet()
     }
 

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -167,5 +167,25 @@ describe("SnippetSession", () => {
             const [synchronizedLine] = await mockBuffer.getLines(0, 1)
             assert.strictEqual(synchronizedLine, "test3 test3 test3")
         })
+
+        it("updates placeholders when a placeholder becomes smaller", async () => {
+            const snippet = new OniSnippet('import { ${1} } from "${0:module}"') // tslint:disable-line
+
+            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            await snippetSession.start()
+
+            // Simulate shortening from "module" -> "a"
+            await mockEditor.setActiveBufferLine(0, 'import { } from "a"')
+
+            await snippetSession.synchronizeUpdatedPlaceholders()
+
+            const [synchronizedLine] = await mockBuffer.getLines(0, 1)
+            assert.strictEqual(synchronizedLine, 'import { } from "a"')
+
+            await snippetSession.synchronizeUpdatedPlaceholders()
+
+            const [synchronizedLine2] = await mockBuffer.getLines(0, 1)
+            assert.strictEqual(synchronizedLine2, 'import { } from "a"')
+        })
     })
 })


### PR DESCRIPTION
__Issue:__ When a placeholder has a value, and you start typing, you get unpredictable results.

An example repro would be:
```
Oni.snippets.insertSnippet("import { ${1} } from '${0:module}'")
```

When you start typing in place of 'module', it fills up with some invalid characters. We weren't updating the snippet placeholder value, so the synchronize logic wasn't synchronizing correctly in this case.