### PR TITLE
Feature: Enable text mate highlighting by default

### DIFF
--- a/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
@@ -78,7 +78,7 @@ export class HoverRenderer {
         // Remove falsy values as check below [null] is truthy
         const elements = [...errorElements, quickInfoElement].filter(Boolean)
 
-        if (this._configuration.getValue("experimental.editor.textMateHighlighting.debugScopes")) {
+        if (this._configuration.getValue("editor.textMateHighlighting.debugScopes")) {
             elements.push(this._getDebugScopesElement())
         }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -518,7 +518,7 @@ export class NeovimEditor extends Editor implements IEditor {
         )
 
         const textMateHighlightingEnabled = this._configuration.getValue(
-            "experimental.editor.textMateHighlighting.enabled",
+            "editor.textMateHighlighting.enabled",
         )
         this._syntaxHighlighter = textMateHighlightingEnabled
             ? new SyntaxHighlighter(this, this._tokenColors)

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -44,7 +44,6 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.fakeLag.languageServer": null,
     "debug.fakeLag.neovimInput": null,
 
-    "editor.textMateHighlighting.enabled": false,
     "wildmenu.mode": true,
     "commandline.mode": true,
     "commandline.icons": true,

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -44,7 +44,7 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.fakeLag.languageServer": null,
     "debug.fakeLag.neovimInput": null,
 
-    "experimental.editor.textMateHighlighting.enabled": false,
+    "editor.textMateHighlighting.enabled": false,
     "wildmenu.mode": true,
     "commandline.mode": true,
     "commandline.icons": true,
@@ -55,6 +55,7 @@ const BaseConfiguration: IConfigurationValues = {
     // "experimental.neovim.transport": Platform.isWindows() ? "pipe" : "stdio",
 
     "editor.maxLinesForLanguageServices": 2500,
+    "editor.textMateHighlighting.enabled": true,
 
     "autoClosingPairs.enabled": true,
     "autoClosingPairs.default": [

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -39,7 +39,7 @@ export interface IConfigurationValues {
     "configuration.editor": string
 
     // - textMateHighlighting
-    "experimental.editor.textMateHighlighting.enabled": boolean
+    "editor.textMateHighlighting.enabled": boolean
 
     // The transport to use for Neovim
     // Valid values are "stdio" and "pipe"

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
@@ -195,7 +195,7 @@ const updateTokenMiddleware = (store: any) => (next: any) => (action: any) => {
 
             if (
                 Object.keys(buffer.lines).length >=
-                configuration.getValue("experimental.editor.textMateHighlighting.maxLines")
+                configuration.getValue("editor.textMateHighlighting.maxLines")
             ) {
                 Log.info(
                     "[SyntaxHighlighting - fullBufferUpdateEpic]: Not applying syntax highlighting as the maxLines limit was exceeded",


### PR DESCRIPTION
This promotes the `TextmateHighlighting` to an on-by-default feature (The `experimental.editor.textMateHighlighting.enabled` has been migrated to `editor.textMateHighlighting.enabled`.

I've been using it on for a while, and most of the major bugs have been fixed (although there are still some minor issues). It's at the point where it is workable enough to be on-by-default, but there are some issues. It'd be great to migrate over some additional textmate grammars over, too!