### PR TITLE
API: Buffers - Add 'removeLayer' API

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -99,6 +99,10 @@ export class Buffer implements IBuffer {
         this._actions.addBufferLayer(parseInt(this._id, 10), layer)
     }
 
+    public removeLayer(layer: IBufferLayer): void {
+        this._actions.removeBufferLayer(parseInt(this._id, 10), layer)
+    }
+
     public async getCursorPosition(): Promise<types.Position> {
         const pos = await this._neovimInstance.callFunction("getpos", ["."])
         const [, oneBasedLine, oneBasedColumn] = pos

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -51,6 +51,14 @@ export interface IAddBufferLayerAction {
     }
 }
 
+export interface IRemoveBufferLayerAction {
+    type: "REMOVE_BUFFER_LAYER"
+    payload: {
+        bufferId: number
+        layer: IBufferLayer
+    }
+}
+
 export interface ISetViewportAction {
     type: "SET_VIEWPORT"
     payload: {
@@ -281,6 +289,7 @@ export type Action<K extends keyof IConfigurationValues> = SimpleAction | Action
 
 export type SimpleAction =
     | IAddBufferLayerAction
+    | IRemoveBufferLayerAction
     | IBufferEnterAction
     | IBufferSaveAction
     | IBufferUpdateAction
@@ -426,6 +435,17 @@ export const addBufferLayer = (
     layer: Oni.EditorLayer,
 ): IAddBufferLayerAction => ({
     type: "ADD_BUFFER_LAYER",
+    payload: {
+        bufferId,
+        layer,
+    },
+})
+
+export const removeBufferLayer = (
+    bufferId: number,
+    layer: Oni.EditorLayer,
+): IRemoveBufferLayerAction => ({
+    type: "REMOVE_BUFFER_LAYER",
     payload: {
         bufferId,
         layer,

--- a/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
@@ -166,12 +166,20 @@ export function reducer<K extends keyof IConfigurationValues>(
 
 export const layersReducer = (s: State.Layers, a: Actions.SimpleAction) => {
     switch (a.type) {
-        case "ADD_BUFFER_LAYER":
+        case "ADD_BUFFER_LAYER": {
             const currentLayers = s[a.payload.bufferId] || []
             return {
                 ...s,
                 [a.payload.bufferId]: [...currentLayers, a.payload.layer],
             }
+        }
+        case "REMOVE_BUFFER_LAYER": {
+            const currentLayers = s[a.payload.bufferId] || []
+            return {
+                ...s,
+                [a.payload.bufferId]: currentLayers.filter(l => l !== a.payload.layer),
+            }
+        }
         default:
             return s
     }

--- a/browser/test/Editor/NeovimEditor/NeovimEditorReducerTests.ts
+++ b/browser/test/Editor/NeovimEditor/NeovimEditorReducerTests.ts
@@ -11,21 +11,34 @@ import * as State from "./../../../src/Editor/NeovimEditor/NeovimEditorStore"
 
 describe("NeovimEditorReducer", () => {
     describe("layersReducer", () => {
-        it("Adds layer via 'ADD_BUFFER_LAYER'", () => {
-            const simpleLayer: Oni.EditorLayer = {
-                id: "test",
-                friendlyName: "Test",
-                render(): JSX.Element {
-                    return null
-                },
-            }
+        const simpleLayer: Oni.EditorLayer = {
+            id: "test",
+            friendlyName: "Test",
+            render(): JSX.Element {
+                return null
+            },
+        }
 
+        it("Adds layer via 'ADD_BUFFER_LAYER'", () => {
             const addLayerAction = Actions.addBufferLayer(1, simpleLayer)
 
             const newState = layersReducer({}, addLayerAction)
 
             const layers = newState[1]
             assert.deepEqual(layers, [simpleLayer], "Verify layer was added")
+        })
+
+        it("Removes layer via 'REMOVE_BUFFER_LAYER'", () => {
+            const stateWithLayer: State.Layers = {
+                1: [simpleLayer],
+            }
+
+            const removeLayerAction = Actions.removeBufferLayer(1, simpleLayer)
+            const stateWithoutLayer = layersReducer(stateWithLayer, removeLayerAction)
+
+            const layers = stateWithoutLayer[1]
+
+            assert.deepEqual(layers, [], "Verify layer was removed")
         })
     })
 


### PR DESCRIPTION
We currently have an `addLayer` API which allows us to render custom UX over the the buffer, but no way to remove it. This is important for functionality that may wish to ephemerally render custom UX