### PR TITLE
Snippets: Add buffer layer while snippet is active

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -91,6 +91,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     // Snippets
     input.bind("<tab>", "snippet.nextPlaceholder")
     input.bind("<s-tab>", "snippet.previousPlaceholder")
+    input.bind("<esc>", "snippet.cancel")
 
     // Completion
     input.bind(["<enter>"], "contextMenu.select")

--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -51,10 +51,13 @@ export class SnippetBufferLayerView extends React.PureComponent<ISnippetBufferLa
             return null
         }
 
-        // const fullScreenSize = this.props.context.dimensions
+        const fullScreenSize = this.props.context.dimensions
 
         // Get screen size in pixel space
-        // const fullSizeInPixels = this.props.context.screenToPixel({ screenX:fullScreenSize.width, screenY: fullScreenSize.height})
+        const fullSizeInPixels = this.props.context.screenToPixel({
+            screenX: fullScreenSize.width,
+            screenY: fullScreenSize.height,
+        })
 
         const snippetStartPosition = this.props.snippetSession.position.line
         const snippetEndPosition = this.props.snippetSession.position.line + 1 // TODO
@@ -76,14 +79,22 @@ export class SnippetBufferLayerView extends React.PureComponent<ISnippetBufferLa
 
         const bottomOverlay: React.CSSProperties = {
             position: "absolute",
-            height: endPositionInPixels.pixelY.toString() + "px",
+            height: (fullSizeInPixels.pixelY - endPositionInPixels.pixelY).toString() + "px",
             left: "0px",
             bottom: "0px",
             right: "0px",
         }
 
         return (
-            <div style={{ position: "relative" }}>
+            <div
+                style={{
+                    position: "absolute",
+                    top: "0px",
+                    bottom: "0px",
+                    left: "0px",
+                    right: "0px",
+                }}
+            >
                 <NonSnippetOverlayTop style={topOverlay} />
                 <NonSnippetOverlayBottom style={bottomOverlay} />
             </div>

--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -15,7 +15,9 @@ import * as types from "vscode-languageserver-types"
 import { SnippetSession } from "./SnippetSession"
 
 export class SnippetBufferLayer implements Oni.EditorLayer {
-    constructor(private _snippetSession: SnippetSession) {}
+    constructor(private _buffer: Oni.Buffer, private _snippetSession: SnippetSession) {
+        this._buffer.addLayer(this)
+    }
 
     public get id(): string {
         return "oni.layers.snippet"
@@ -27,6 +29,15 @@ export class SnippetBufferLayer implements Oni.EditorLayer {
 
     public render(context: Oni.EditorLayerRenderContext): JSX.Element {
         return <SnippetBufferLayerView context={context} snippetSession={this._snippetSession} />
+    }
+
+    public dispose(): void {
+        if (this._buffer) {
+            ;(this._buffer as any).removeLayer(this)
+
+            this._buffer = null
+            this._snippetSession = null
+        }
     }
 }
 

--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react"
 
-import styled from "styled-components"
+import styled, { keyframes } from "styled-components"
 
 import * as Oni from "oni-api"
 
@@ -35,12 +35,19 @@ export interface ISnippetBufferLayerViewProps {
     snippetSession: SnippetSession
 }
 
+const EntranceKeyFrames = keyframes`
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+`
+
 const NonSnippetOverlayTop = styled.div`
+    animation: ${EntranceKeyFrames} 0.2s ease-in;
     background-color: rgba(0, 0, 0, 0.1);
     box-shadow: inset 0 -5px 10px rgba(0, 0, 0, 0.2);
 `
 
 const NonSnippetOverlayBottom = styled.div`
+    animation: ${EntranceKeyFrames} 0.2s ease-in;
     background-color: rgba(0, 0, 0, 0.1);
     box-shadow: inset 0 5px 10px rgba(0, 0, 0, 0.2);
 `

--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -1,0 +1,38 @@
+/**
+ * SnippetBufferLayer.tsx
+ *
+ * UX for the Snippet functionality, implemented as a buffer layer
+ */
+
+import * as React from "React"
+
+import * as Oni from "oni-api"
+import { Event, IEvent } from "oni-types"
+
+import { SnippetSession } from "./SnippetSession"
+
+export class SnippetBufferLayer implements Oni.EditorLayer {
+    constructor(private _snippetSession: SnippetSession) {}
+    public get id(): string {
+        return "oni.layers.snippet"
+    }
+
+    public get friendlyName(): string {
+        return "Snippet"
+    }
+
+    public render(context: Oni.EditorLayerRenderContext): JSX.Element {
+        return <SnippetBufferLayerView context={context} snippetSession={this._snippetSession} />
+    }
+}
+
+export interface ISnippetBufferLayerViewProps {
+    context: Oni.EditorLayerRenderContext
+    snippetSession: SnippetSession
+}
+
+export class SnippetBufferLayerView extends React.PureComponent<ISnippetBufferLayerViewProps, {}> {
+    public render(): JSX.Element {
+        return <div>Hello World!</div>
+    }
+}

--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -78,7 +78,8 @@ export class SnippetBufferLayerView extends React.PureComponent<ISnippetBufferLa
         })
 
         const snippetStartPosition = this.props.snippetSession.position.line
-        const snippetEndPosition = this.props.snippetSession.position.line + 1 // TODO
+        const snippetEndPosition =
+            this.props.snippetSession.position.line + this.props.snippetSession.lines.length
 
         const startPositionInPixels = this.props.context.screenToPixel(
             this.props.context.bufferToScreen(types.Position.create(snippetStartPosition, 0)),

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -14,6 +14,7 @@ import { Subject } from "rxjs/Subject"
 import { EditorManager } from "./../EditorManager"
 
 import { OniSnippet } from "./OniSnippet"
+import { SnippetBufferLayer } from "./SnippetBufferLayer"
 import { CompositeSnippetProvider, ISnippetProvider } from "./SnippetProvider"
 import { SnippetSession } from "./SnippetSession"
 
@@ -59,6 +60,9 @@ export class SnippetManager {
         const activeEditor = this._editorManager.activeEditor as any
         const snippetSession = new SnippetSession(activeEditor as any, snip)
         await snippetSession.start()
+
+        const buffer = this._editorManager.activeEditor.activeBuffer
+        buffer.addLayer(new SnippetBufferLayer(snippetSession))
 
         const s2 = activeEditor.onBufferChanged.subscribe(() => {
             this._synchronizeSnippetObseravble.next()

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -23,6 +23,7 @@ import { ISnippet } from "./ISnippet"
 export class SnippetManager {
     private _activeSession: SnippetSession
     private _disposables: IDisposable[] = []
+    private _currentLayer: SnippetBufferLayer = null
 
     private _snippetProvider: CompositeSnippetProvider
     private _synchronizeSnippetObseravble: Subject<void> = new Subject<void>()
@@ -62,7 +63,7 @@ export class SnippetManager {
         await snippetSession.start()
 
         const buffer = this._editorManager.activeEditor.activeBuffer
-        buffer.addLayer(new SnippetBufferLayer(snippetSession))
+        this._currentLayer = new SnippetBufferLayer(buffer, snippetSession)
 
         const s2 = activeEditor.onBufferChanged.subscribe(() => {
             this._synchronizeSnippetObseravble.next()
@@ -96,6 +97,10 @@ export class SnippetManager {
     public cancel(): void {
         if (this._activeSession) {
             this._cleanupAfterSession()
+        }
+
+        if (this._currentLayer) {
+            this._currentLayer.dispose()
         }
     }
 

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -68,6 +68,10 @@ export class SnippetSession {
         return this._onCancelEvent
     }
 
+    public get position(): types.Position {
+        return this._position
+    }
+
     constructor(private _editor: IEditor, private _snippet: OniSnippet) {}
 
     public async start(): Promise<void> {

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -60,6 +60,10 @@ export class SnippetSession {
 
     private _currentPlaceholder: OniSnippetPlaceholder = null
 
+    public get buffer(): IBuffer {
+        return this._buffer
+    }
+
     public get onCancel(): IEvent<void> {
         return this._onCancelEvent
     }

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -72,6 +72,10 @@ export class SnippetSession {
         return this._position
     }
 
+    public get lines(): string[] {
+        return this._snippet.getLines()
+    }
+
     constructor(private _editor: IEditor, private _snippet: OniSnippet) {}
 
     public async start(): Promise<void> {

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -265,6 +265,14 @@ export class MockBuffer {
     ) {
         updateFunction(this._mockHighlights)
     }
+
+    public addLayer(): void {
+        // tslint:disable-line
+    }
+
+    public removeLayer(): void {
+        // tslint:disable-line
+    }
 }
 
 export class MockBufferHighlightsUpdater implements IBufferHighlightsUpdater {


### PR DESCRIPTION
This adds a 'buffer layer' while a snippet is active, which highlights the 'snippet session' is active:
![image](https://user-images.githubusercontent.com/13532591/36688679-0ed5bcd2-1ae2-11e8-8e05-52665368dc9a.png)

In the future, I'd also like to show an extra 'cursor' for mirrored placeholders - this would be the place to add that functionality.