### PR TITLE
feature/ change vim directory if oni workspace changes

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -422,7 +422,7 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         // These functions are mirrors of each other if vim changes dir then oni responds
-        // and if oni intiates the dir change them we inform vim
+        // and if oni initiates the dir change then we inform vim
         // NOTE: the gates to check that the dirs being passed aren't already set prevent
         // an infinite loop!!
         this._neovimInstance.onDirectoryChanged.subscribe(async newDirectory => {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -421,8 +421,20 @@ export class NeovimEditor extends Editor implements IEditor {
             this._actions.setNeovimError(true)
         })
 
+        // These functions are mirrors of each other if vim changes dir then oni responds
+        // and if oni intiates the dir change them we inform vim
+        // NOTE: the gates to check that the dirs being passed aren't already set prevent
+        // an infinite loop!!
         this._neovimInstance.onDirectoryChanged.subscribe(async newDirectory => {
-            await this._workspace.changeDirectory(newDirectory)
+            if (newDirectory !== this._workspace.activeWorkspace) {
+                await this._workspace.changeDirectory(newDirectory)
+            }
+        })
+
+        this._workspace.onDirectoryChanged.subscribe(async newDirectory => {
+            if (newDirectory !== this._neovimInstance.currentVimDirectory) {
+                await this._neovimInstance.chdir(newDirectory)
+            }
         })
 
         this._neovimInstance.on("action", (action: any) => {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -190,6 +190,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _neovim: Session
     private _initPromise: Promise<void>
     private _isLeaving: boolean
+    private _currentVimDirectory: string
 
     private _inputQueue: PromiseQueue = new PromiseQueue()
 
@@ -340,6 +341,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     public get tokenColorSynchronizer(): NeovimTokenColorSynchronizer {
         return this._tokenColorSynchronizer
+    }
+
+    public get currentVimDirectory(): string {
+        return this._currentVimDirectory
     }
 
     constructor(widthInPixels: number, heightInPixels: number, configuration: Configuration) {
@@ -875,8 +880,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     private async _updateProcessDirectory(): Promise<void> {
-        const newDirectory = await this.getCurrentWorkingDirectory()
-        this._onDirectoryChanged.dispatch(newDirectory)
+        this._currentVimDirectory = await this.getCurrentWorkingDirectory()
+        this._onDirectoryChanged.dispatch(this._currentVimDirectory)
     }
 
     private async _attachUI(columns: number, rows: number): Promise<void> {


### PR DESCRIPTION
This PR relates to #1575 and #1397, at present if `Oni` updates its workspace directory nvim's directory remains unchanged meaning a user might attempt to execute an nvim command with the expectation that they are in the directory `oni` reports but actually they are in different nvim dir as Oni and nvim are out of sync.

The reverse currently does happen already aka. if vim switches its dir Oni's workspace switches its directory to match.