### PR TITLE
Feature/use absolute path in quickopen

### DIFF
--- a/browser/src/Services/QuickOpen/FinderProcess.ts
+++ b/browser/src/Services/QuickOpen/FinderProcess.ts
@@ -9,6 +9,7 @@ import { ChildProcess, spawn } from "child_process"
 import { Event, IEvent } from "oni-types"
 
 import * as Log from "./../../Log"
+import { getInstance } from "./../Workspace"
 
 export class FinderProcess {
     private _process: ChildProcess
@@ -18,6 +19,7 @@ export class FinderProcess {
     private _onData = new Event<string[]>()
     private _onError = new Event<string>()
     private _onComplete = new Event<void>()
+    private _workspace = getInstance()
 
     public get onData(): IEvent<string[]> {
         return this._onData
@@ -41,7 +43,10 @@ export class FinderProcess {
             )
         }
 
-        this._process = spawn(this._command, [], { shell: true })
+        this._process = spawn(this._command, [], {
+            shell: true,
+            cwd: this._workspace.activeWorkspace,
+        })
         this._process.stdout.on("data", data => {
             if (!data) {
                 return

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -15,6 +15,8 @@ import { INeovimInstance } from "./../../neovim"
 import { commandManager } from "./../CommandManager"
 import { configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
+import { getInstance as getWorkspaceInstance } from "./../Workspace"
+
 import { fuseFilter, Menu, MenuManager } from "./../Menu"
 
 import { FinderProcess } from "./FinderProcess"
@@ -32,6 +34,7 @@ export class QuickOpen {
     private _neovimInstance: INeovimInstance
     private _menu: Menu
     private _lastCommand: string | null = null
+    private _workspace = getWorkspaceInstance()
 
     constructor(menuManager: MenuManager, neovimInstance: INeovimInstance) {
         this._neovimInstance = neovimInstance
@@ -212,7 +215,7 @@ export class QuickOpen {
             }
             this._neovimInstance.command(`${arg.label}`)
         } else {
-            let fullPath = path.join(arg.detail, arg.label)
+            let fullPath = path.join(this._workspace.activeWorkspace, arg.detail, arg.label)
 
             this._seenItems.push(fullPath)
 

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -215,7 +215,12 @@ export class QuickOpen {
             }
             this._neovimInstance.command(`${arg.label}`)
         } else {
-            let fullPath = path.join(this._workspace.activeWorkspace, arg.detail, arg.label)
+            const { activeWorkspace } = this._workspace
+            const pathArgs = activeWorkspace
+                ? [activeWorkspace, arg.detail, arg.label]
+                : [arg.detail, arg.label]
+
+            let fullPath = path.join(...pathArgs)
 
             this._seenItems.push(fullPath)
 


### PR DESCRIPTION
This PR is intended to fix #1397, it solves the issue of files being opened with relative as opposed to absolute paths. In order to solve this given that the filenames are sourced via a `ripgrep` command spawned by a `child_process` which uses the `cwd` of the process which defaults to the current if not specified I made some decisions that need review.

I believe that the child process' cwd is oni's cwd aka the active workspace, implicitly, but to be explicit I pass it in to process as an option as the assumption I made is that files being searched by oni ought to check from the workspace directory, plus not sure if it consistently sources the right `cwd` if not explicitly set.

Then in `Quickfix.ts` I appended the `activeWorkspace` to the the open command nvim is using so rather than `e! /browser/src/index.ts` it now opens `e! /Users/myPathToOni/oni/browser/src/index.ts`.