### PR TITLE
Bugfix - Snippets: Fix boundary case when placeholder is empty and at end of line

### DIFF
--- a/browser/src/Services/Snippets/OniSnippet.ts
+++ b/browser/src/Services/Snippets/OniSnippet.ts
@@ -29,7 +29,7 @@ export const getLineCharacterFromOffset = (
     let idx = 0
     let currentOffset = 0
     while (idx < lines.length) {
-        if (offset >= currentOffset && offset < currentOffset + lines[idx].length) {
+        if (offset >= currentOffset && offset <= currentOffset + lines[idx].length) {
             return { line: idx, character: offset - currentOffset }
         }
 

--- a/browser/test/Services/Snippets/OniSnippetTests.ts
+++ b/browser/test/Services/Snippets/OniSnippetTests.ts
@@ -72,6 +72,18 @@ describe("OniSnippet", () => {
                 value: "b",
             })
         })
+
+        it("gets placeholder at end of line", () => {
+            const oniSnippet = new OniSnippet("foo\nbar${0}") // tslint:disable-line
+            const placeholders = oniSnippet.getPlaceholders()
+
+            assert.deepEqual(placeholders[0], {
+                index: 0,
+                line: 1,
+                character: 3,
+                value: "",
+            })
+        })
     })
 
     describe("setPlaceholder", () => {


### PR DESCRIPTION
__Issue:__ The `for` snippet was not behaving correctly when it was going to the initial placeholder - we were getting an exception that `length` is undefined.

__Defect:__ The position wasn't being resolved correctly, due to an off-by-one error in our conversion from offset to line/character.