### PR TITLE
Snippet: Show cursors in placeholder positions

### DIFF
--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -26,12 +26,12 @@ export class SnippetManager {
     private _currentLayer: SnippetBufferLayer = null
 
     private _snippetProvider: CompositeSnippetProvider
-    private _synchronizeSnippetObseravble: Subject<void> = new Subject<void>()
+    private _synchronizeSnippetObservable: Subject<void> = new Subject<void>()
 
     constructor(private _editorManager: EditorManager) {
         this._snippetProvider = new CompositeSnippetProvider()
 
-        this._synchronizeSnippetObseravble.auditTime(50).subscribe(() => {
+        this._synchronizeSnippetObservable.auditTime(50).subscribe(() => {
             const activeEditor = this._editorManager.activeEditor as any
             const activeSession = this._activeSession
 
@@ -65,15 +65,21 @@ export class SnippetManager {
         const buffer = this._editorManager.activeEditor.activeBuffer
         this._currentLayer = new SnippetBufferLayer(buffer, snippetSession)
 
+        const s1 = activeEditor.onCursorMoved.subscribe(() => {
+            if (this.isSnippetActive()) {
+                this._activeSession.updateCursorPosition()
+            }
+        })
+
         const s2 = activeEditor.onBufferChanged.subscribe(() => {
-            this._synchronizeSnippetObseravble.next()
+            this._synchronizeSnippetObservable.next()
         })
 
         const s3 = snippetSession.onCancel.subscribe(() => {
             this.cancel()
         })
 
-        this._disposables = [s2, s3]
+        this._disposables = [s1, s2, s3]
 
         this._activeSession = snippetSession
     }

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -49,10 +49,17 @@ export const getPlaceholderByIndex = (
     return matchingPlaceholders[0]
 }
 
+export interface IMirrorCursorUpdateEvent {
+    cursors: types.Position[]
+}
+
 export class SnippetSession {
     private _buffer: IBuffer
     private _position: types.Position
     private _onCancelEvent: Event<void> = new Event<void>()
+    private _onCursorMovedEvent: Event<IMirrorCursorUpdateEvent> = new Event<
+        IMirrorCursorUpdateEvent
+    >()
 
     // Get state of line where we inserted
     private _prefix: string
@@ -66,6 +73,10 @@ export class SnippetSession {
 
     public get onCancel(): IEvent<void> {
         return this._onCancelEvent
+    }
+
+    public get onCursorMoved(): IEvent<IMirrorCursorUpdateEvent> {
+        return this._onCursorMovedEvent
     }
 
     public get position(): types.Position {
@@ -156,6 +167,42 @@ export class SnippetSession {
         await this._updateSnippet()
     }
 
+    // Update the cursor position relative to all placeholders
+    public async updateCursorPosition(): Promise<void> {
+        const pos = await this._buffer.getCursorPosition()
+
+        if (
+            !this._currentPlaceholder ||
+            pos.line !== this._currentPlaceholder.line + this._position.line
+        ) {
+            return
+        }
+
+        const boundsForPlaceholder = this._getBoundsForPlaceholder()
+
+        const offset = pos.character - boundsForPlaceholder.start
+
+        const allPlaceholdersAtIndex = this._snippet
+            .getPlaceholders()
+            .filter(
+                f =>
+                    f.index === this._currentPlaceholder.index &&
+                    !(
+                        f.line === this._currentPlaceholder.line &&
+                        f.character === this._currentPlaceholder.character
+                    ),
+            )
+
+        const cursorPositions: types.Position[] = allPlaceholdersAtIndex.map(p => {
+            const bounds = this._getBoundsForPlaceholder(p)
+            return types.Position.create(bounds.line, bounds.start + offset)
+        })
+
+        this._onCursorMovedEvent.dispatch({
+            cursors: cursorPositions,
+        })
+    }
+
     // Helper method to query the value of the current placeholder,
     // propagate that to any other placeholders, and update the snippet
     public async synchronizeUpdatedPlaceholders(): Promise<void> {
@@ -194,14 +241,14 @@ export class SnippetSession {
         this._onCancelEvent.dispatch()
     }
 
-    private _getBoundsForPlaceholder(): {
+    private _getBoundsForPlaceholder(
+        currentPlaceholder: OniSnippetPlaceholder = this._currentPlaceholder,
+    ): {
         index: number
         line: number
         start: number
         distanceFromEnd: number
     } {
-        const currentPlaceholder = this._currentPlaceholder
-
         const currentSnippetLines = this._snippet.getLines()
 
         const start =

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -171,6 +171,8 @@ export class SnippetSession {
     public async updateCursorPosition(): Promise<void> {
         const pos = await this._buffer.getCursorPosition()
 
+        const mode = this._editor.mode
+
         if (
             !this._currentPlaceholder ||
             pos.line !== this._currentPlaceholder.line + this._position.line
@@ -180,7 +182,7 @@ export class SnippetSession {
 
         const boundsForPlaceholder = this._getBoundsForPlaceholder()
 
-        const offset = pos.character - boundsForPlaceholder.start
+        const offset = mode === "visual" ? 0 : pos.character - boundsForPlaceholder.start
 
         const allPlaceholdersAtIndex = this._snippet
             .getPlaceholders()


### PR DESCRIPTION
This adds functionality in the `SnippetBufferLayer` to show the mirrored cursor positions.

Stuff remaining:
- [x] Need to show different experience when in `visual` mode
- [ ] Need to fix bug with different lines (perhaps related to #1647)
- [x] Need to fix styling