### PR TITLE
API - Buffer: Add 'detectIndentation' API

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -46,6 +46,31 @@ export interface IBuffer extends Oni.Buffer {
     handleInput(key: string): boolean
 }
 
+export type IndentationType = "tab" | "space"
+
+export interface BufferIndentationInfo {
+    type: IndentationType
+
+    // If indentation is 'space', this is how
+    // many spaces are at a particular tabstop
+    amount: number
+
+    // String value for indentation
+    indent: string
+}
+
+const getStringFromTypeAndAmount = (type: IndentationType, amount: number): string => {
+    if (type === "tab") {
+        return "\t"
+    } else {
+        let str = ""
+        for (let i = 0; i < amount; i++) {
+            str += " "
+        }
+        return str
+    }
+}
+
 export class Buffer implements IBuffer {
     private _id: string
     private _filePath: string
@@ -137,6 +162,36 @@ export class Buffer implements IBuffer {
             "filetype",
             language,
         ])
+    }
+
+    public async detectIndentation(): Promise<BufferIndentationInfo> {
+        const bufferLinesPromise = this.getLines(0, 1024)
+        const detectIndentPromise = import("detect-indent")
+
+        await Promise.all([bufferLinesPromise, detectIndentPromise])
+
+        const bufferLines = await bufferLinesPromise
+        const detectIndent = await detectIndentPromise
+
+        const ret = detectIndent(bufferLines.join("\n"))
+
+        // We were able to infer tab settings from lines, so return
+        if (ret.type === "tab" || ret.type === "space") {
+            return ret
+        }
+
+        // Otherwise, we'll fall back to getting vim tab settings
+        const isSpaces = await this._neovimInstance.request<boolean>("nvim_get_option", [
+            "expandtab",
+        ])
+        const tabSize = await this._neovimInstance.request<number>("nvim_get_option", ["tabstop"])
+
+        const tabType = isSpaces ? "space" : "tab"
+        return {
+            amount: tabSize,
+            type: tabType,
+            indent: getStringFromTypeAndAmount(tabType, tabSize),
+        }
     }
 
     public async applyTextEdits(textEdits: types.TextEdit | types.TextEdit[]): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "devDependencies": {
         "@types/classnames": "0.0.32",
         "@types/color": "2.0.0",
+        "@types/detect-indent": "^5.0.0",
         "@types/dompurify": "^0.0.31",
         "@types/electron-settings": "^3.1.1",
         "@types/jsdom": "11.0.0",
@@ -252,6 +253,7 @@
         "concurrently": "3.1.0",
         "cross-env": "3.1.3",
         "css-loader": "0.28.4",
+        "detect-indent": "^5.0.0",
         "electron": "^1.8.2-beta.5",
         "electron-builder": "19.46.4",
         "electron-devtools-installer": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,10 @@
   dependencies:
     "@types/color-convert" "*"
 
+"@types/detect-indent@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/detect-indent/-/detect-indent-5.0.0.tgz#8b1bbd7891268d5ed20d23ecd23ae333d33934cd"
+
 "@types/dompurify@^0.0.31":
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-0.0.31.tgz#f152d5a81f2b5625e29f11eb016cd9b301d0d4b4"
@@ -1971,6 +1975,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+detect-indent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
 
 detect-libc@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This adds a helper API for detecting indentation in buffers. This is important for snippets, so that we can match the whitespace for snippets appropriately. It could also be used later for an auto-detect indentation setting.