### PR TITLE
Sneak: Implement async provider API

### DIFF
--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -9,9 +9,9 @@ import * as React from "react"
 import { Shapes } from "oni-api"
 import { IDisposable } from "oni-types"
 
-import { Overlay, OverlayManager } from "./Overlay"
+import { Overlay, OverlayManager } from "./../Overlay"
 
-import { TextInputView } from "./../UI/components/LightweightText"
+import { SneakView } from "./SneakView"
 
 export interface ISneakInfo {
     rectangle: Shapes.Rectangle
@@ -22,7 +22,7 @@ export interface IAugmentedSneakInfo extends ISneakInfo {
     triggerKeys: string
 }
 
-export type SneakProvider = () => Promise<ISneakInfo[]>
+export type SneakProvider = () => ISneakInfo[]
 
 export class Sneak {
     private _activeOverlay: Overlay
@@ -92,112 +92,5 @@ export class Sneak {
         }, [])
 
         return ret
-    }
-}
-
-export interface ISneakViewProps {
-    sneaks: IAugmentedSneakInfo[]
-    onComplete: (sneakInfo: ISneakInfo) => void
-}
-
-export const TestSneaks = [
-    {
-        triggerKeys: "AA",
-        rectangle: Shapes.Rectangle.create(10, 10, 100, 100),
-        callback: () => {
-            alert("testing")
-        },
-    },
-    {
-        triggerKeys: "AB",
-        rectangle: Shapes.Rectangle.create(50, 50, 50, 50),
-        callback: () => {
-            alert("testing2")
-        },
-    },
-]
-
-import { boxShadow, OverlayWrapper } from "./../UI/components/common"
-
-export interface ISneakViewState {
-    filterText: string
-}
-
-// Render a keyboard input?
-// Grab input while 'sneaking'?
-export class SneakView extends React.PureComponent<ISneakViewProps, ISneakViewState> {
-    constructor(props: ISneakViewProps) {
-        super(props)
-
-        this.state = {
-            filterText: "",
-        }
-    }
-
-    public render(): JSX.Element {
-        const normalizedFilterText = this.state.filterText.toUpperCase()
-        const filteredSneaks = this.props.sneaks.filter(
-            sneak => sneak.triggerKeys.indexOf(normalizedFilterText) === 0,
-        )
-        const sneaks = filteredSneaks.map(si => (
-            <SneakItemView sneak={si} filterLength={normalizedFilterText.length} />
-        ))
-
-        if (filteredSneaks.length === 1) {
-            this.props.onComplete(filteredSneaks[0])
-        }
-
-        return (
-            <OverlayWrapper style={{ backgroundColor: "rgba(0, 0, 0, 0.1)" }}>
-                <div style={{ opacity: 0.01 }}>
-                    <TextInputView
-                        onChange={evt => {
-                            this.setState({ filterText: evt.currentTarget.value })
-                        }}
-                    />
-                </div>
-                {sneaks}
-            </OverlayWrapper>
-        )
-    }
-}
-
-export interface ISneakItemViewProps {
-    sneak: IAugmentedSneakInfo
-    filterLength: number
-}
-
-import styled from "styled-components"
-
-const SneakItemWrapper = styled.div`
-    ${boxShadow} background-color: ${props => props.theme["highlight.mode.visual.background"]};
-    color: ${props => props.theme["highlight.mode.visual.foreground"]};
-`
-
-const SneakItemViewSize = 20
-const px = (num: number): string => num.toString() + "px"
-export class SneakItemView extends React.PureComponent<ISneakItemViewProps, {}> {
-    public render(): JSX.Element {
-        const style: React.CSSProperties = {
-            position: "absolute",
-            left: px(this.props.sneak.rectangle.x),
-            top: px(this.props.sneak.rectangle.y),
-            width: px(SneakItemViewSize),
-            height: px(SneakItemViewSize),
-        }
-
-        return (
-            <SneakItemWrapper style={style}>
-                <span style={{ fontWeight: "bold" }}>
-                    {this.props.sneak.triggerKeys.substring(0, this.props.filterLength)}
-                </span>
-                <span>
-                    {this.props.sneak.triggerKeys.substring(
-                        this.props.filterLength,
-                        this.props.sneak.triggerKeys.length,
-                    )}
-                </span>
-            </SneakItemWrapper>
-        )
     }
 }

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -74,12 +74,12 @@ export class Sneak {
         return sneaks.map((sneak, idx) => {
             return {
                 ...sneak,
-                triggerKeys: this._getLabelFromIndex(idx, sneaks.length),
+                triggerKeys: this._getLabelFromIndex(idx),
             }
         })
     }
 
-    private _getLabelFromIndex(index: number, max: number): string {
+    private _getLabelFromIndex(index: number): string {
         const firstDigit = Math.floor(index / 26)
         const secondDigit = index - firstDigit * 26
         return String.fromCharCode(97 + firstDigit, 97 + secondDigit).toUpperCase()

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -49,7 +49,7 @@ export class Sneak {
 
         this._activeOverlay.setContents(
             <Provider store={this._store}>
-                <ConnectedSneakView onComplete={info => this._onComplete(info)} />,
+                <ConnectedSneakView onComplete={info => this._onComplete(info)} />
             </Provider>,
         )
         this._activeOverlay.show()

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -9,8 +9,6 @@ import * as React from "react"
 import { Shapes } from "oni-api"
 import { IDisposable } from "oni-types"
 
-import { CallbackCommand, CommandManager } from "./CommandManager"
-
 import { Overlay, OverlayManager } from "./Overlay"
 
 import { TextInputView } from "./../UI/components/LightweightText"
@@ -24,7 +22,7 @@ export interface IAugmentedSneakInfo extends ISneakInfo {
     triggerKeys: string
 }
 
-export type SneakProvider = () => ISneakInfo[]
+export type SneakProvider = () => Promise<ISneakInfo[]>
 
 export class Sneak {
     private _activeOverlay: Overlay
@@ -202,35 +200,4 @@ export class SneakItemView extends React.PureComponent<ISneakItemViewProps, {}> 
             </SneakItemWrapper>
         )
     }
-}
-
-let _sneak: Sneak
-
-export const activate = (commandManager: CommandManager, overlayManager: OverlayManager) => {
-    _sneak = new Sneak(overlayManager)
-
-    commandManager.registerCommand(
-        new CallbackCommand(
-            "sneak.show",
-            "Sneak: Current Window",
-            "Show commands for current window",
-            () => {
-                _sneak.show()
-            },
-        ),
-    )
-
-    commandManager.registerCommand(
-        new CallbackCommand(
-            "sneak.hide",
-            "Sneak: Hide",
-            "Hide sneak view",
-            () => _sneak.close(),
-            () => _sneak.isActive,
-        ),
-    )
-}
-
-export const getInstance = (): Sneak => {
-    return _sneak
 }

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -5,8 +5,8 @@
  */
 
 import * as React from "react"
-import { Store } from "redux"
 import { Provider } from "react-redux"
+import { Store } from "redux"
 
 import { IDisposable } from "oni-types"
 

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -6,21 +6,12 @@
 
 import * as React from "react"
 
-import { Shapes } from "oni-api"
 import { IDisposable } from "oni-types"
 
 import { Overlay, OverlayManager } from "./../Overlay"
 
+import { ISneakInfo, IAugmentedSneakInfo } from "./SneakStore"
 import { SneakView } from "./SneakView"
-
-export interface ISneakInfo {
-    rectangle: Shapes.Rectangle
-    callback: () => void
-}
-
-export interface IAugmentedSneakInfo extends ISneakInfo {
-    triggerKeys: string
-}
 
 export type SneakProvider = () => ISneakInfo[]
 

--- a/browser/src/Services/Sneak/SneakStore.ts
+++ b/browser/src/Services/Sneak/SneakStore.ts
@@ -1,0 +1,63 @@
+/**
+ * SneakStore.ts
+ *
+ * State management for Sneaks
+ */
+
+import { Reducer, Store } from "redux"
+import { createStore as createReduxStore } from "./../../Redux"
+
+export interface ISneakInfo {
+    rectangle: Shapes.Rectangle
+    callback: () => void
+}
+
+export interface IAugmentedSneakInfo extends ISneakInfo {
+    triggerKeys: string
+}
+
+export interface ISneakState {
+    isActive: boolean
+    currentIndex: number
+    sneaks: IAugmentedSneakInfo[]
+}
+
+const DefaultSneakState: ISneakState = {
+    isActive: true,
+    currentIndex: 0,
+    sneaks: [],
+}
+
+export type SneakAction =
+    | {
+          type: "START"
+      }
+    | {
+          type: "END"
+      }
+    | {
+          type: "ADD_SNEAKS"
+          sneaks: ISneakInfo[]
+      }
+
+export const sneakReducer: Reducer<ISneakState> = (
+    state: ISneakState = DefaultSneakState,
+    action: SneakAction,
+) => {
+    switch (action.type) {
+        case "START":
+            return DefaultSneakState
+        case "END":
+            return {
+                ...DefaultSneakState,
+                isActive: false,
+            }
+        case "ADD_SNEAKS":
+        default:
+            return state
+    }
+}
+
+export const createStore = (): Store<ISneakState> => {
+    return createReduxStore("Sneaks", sneakReducer, DefaultSneakState)
+}

--- a/browser/src/Services/Sneak/SneakStore.ts
+++ b/browser/src/Services/Sneak/SneakStore.ts
@@ -5,6 +5,9 @@
  */
 
 import { Reducer, Store } from "redux"
+
+import { Shapes } from "oni-api"
+
 import { createStore as createReduxStore } from "./../../Redux"
 
 export interface ISneakInfo {

--- a/browser/src/Services/Sneak/SneakStore.ts
+++ b/browser/src/Services/Sneak/SneakStore.ts
@@ -21,13 +21,11 @@ export interface IAugmentedSneakInfo extends ISneakInfo {
 
 export interface ISneakState {
     isActive: boolean
-    currentIndex: number
     sneaks: IAugmentedSneakInfo[]
 }
 
 const DefaultSneakState: ISneakState = {
     isActive: true,
-    currentIndex: 0,
     sneaks: [],
 }
 
@@ -56,9 +54,30 @@ export const sneakReducer: Reducer<ISneakState> = (
                 isActive: false,
             }
         case "ADD_SNEAKS":
+            if (!state.isActive) {
+                return state
+            }
+
+            const newSneaks: IAugmentedSneakInfo[] = action.sneaks.map((sneak, idx) => {
+                return {
+                    ...sneak,
+                    triggerKeys: getLabelFromIndex(idx + state.sneaks.length),
+                }
+            })
+
+            return {
+                ...state,
+                sneaks: [...state.sneaks, ...newSneaks],
+            }
         default:
             return state
     }
+}
+
+export const getLabelFromIndex = (index: number): string => {
+    const firstDigit = Math.floor(index / 26)
+    const secondDigit = index - firstDigit * 26
+    return String.fromCharCode(97 + firstDigit, 97 + secondDigit).toUpperCase()
 }
 
 export const createStore = (): Store<ISneakState> => {

--- a/browser/src/Services/Sneak/SneakView.tsx
+++ b/browser/src/Services/Sneak/SneakView.tsx
@@ -5,15 +5,19 @@
  */
 
 import * as React from "react"
+import { connect } from "react-redux"
 
 import { boxShadow, OverlayWrapper } from "./../../UI/components/common"
 import { TextInputView } from "./../../UI/components/LightweightText"
 
-import { ISneakInfo, IAugmentedSneakInfo } from "./SneakStore"
+import { IAugmentedSneakInfo, ISneakInfo, ISneakState } from "./SneakStore"
 
-export interface ISneakViewProps {
-    sneaks: IAugmentedSneakInfo[]
+export interface ISneakContainerProps {
     onComplete: (sneakInfo: ISneakInfo) => void
+}
+
+export interface ISneakViewProps extends ISneakContainerProps {
+    sneaks: IAugmentedSneakInfo[]
 }
 
 export interface ISneakViewState {
@@ -98,3 +102,15 @@ export class SneakItemView extends React.PureComponent<ISneakItemViewProps, {}> 
         )
     }
 }
+
+const mapStateToProps = (
+    state: ISneakState,
+    containerProps?: ISneakContainerProps,
+): ISneakViewProps => {
+    return {
+        ...containerProps,
+        sneaks: state.sneaks || [],
+    }
+}
+
+export const ConnectedSneakView = connect(mapStateToProps)(SneakView)

--- a/browser/src/Services/Sneak/SneakView.tsx
+++ b/browser/src/Services/Sneak/SneakView.tsx
@@ -1,0 +1,100 @@
+/**
+ * SneakView.tsx
+ *
+ * UX for the sneak functionality
+ */
+
+import * as React from "react"
+
+import { boxShadow, OverlayWrapper } from "./../../UI/components/common"
+import { TextInputView } from "./../../UI/components/LightweightText"
+
+import { ISneakInfo, IAugmentedSneakInfo } from "./Sneak"
+
+export interface ISneakViewProps {
+    sneaks: IAugmentedSneakInfo[]
+    onComplete: (sneakInfo: ISneakInfo) => void
+}
+
+export interface ISneakViewState {
+    filterText: string
+}
+
+// Render a keyboard input?
+// Grab input while 'sneaking'?
+export class SneakView extends React.PureComponent<ISneakViewProps, ISneakViewState> {
+    constructor(props: ISneakViewProps) {
+        super(props)
+
+        this.state = {
+            filterText: "",
+        }
+    }
+
+    public render(): JSX.Element {
+        const normalizedFilterText = this.state.filterText.toUpperCase()
+        const filteredSneaks = this.props.sneaks.filter(
+            sneak => sneak.triggerKeys.indexOf(normalizedFilterText) === 0,
+        )
+        const sneaks = filteredSneaks.map(si => (
+            <SneakItemView sneak={si} filterLength={normalizedFilterText.length} />
+        ))
+
+        if (filteredSneaks.length === 1) {
+            this.props.onComplete(filteredSneaks[0])
+        }
+
+        return (
+            <OverlayWrapper style={{ backgroundColor: "rgba(0, 0, 0, 0.1)" }}>
+                <div style={{ opacity: 0.01 }}>
+                    <TextInputView
+                        onChange={evt => {
+                            this.setState({ filterText: evt.currentTarget.value })
+                        }}
+                    />
+                </div>
+                {sneaks}
+            </OverlayWrapper>
+        )
+    }
+}
+
+export interface ISneakItemViewProps {
+    sneak: IAugmentedSneakInfo
+    filterLength: number
+}
+
+import styled from "styled-components"
+
+const SneakItemWrapper = styled.div`
+    ${boxShadow} background-color: ${props => props.theme["highlight.mode.visual.background"]};
+    color: ${props => props.theme["highlight.mode.visual.foreground"]};
+`
+
+const SneakItemViewSize = 20
+const px = (num: number): string => num.toString() + "px"
+export class SneakItemView extends React.PureComponent<ISneakItemViewProps, {}> {
+    public render(): JSX.Element {
+        const style: React.CSSProperties = {
+            position: "absolute",
+            left: px(this.props.sneak.rectangle.x),
+            top: px(this.props.sneak.rectangle.y),
+            width: px(SneakItemViewSize),
+            height: px(SneakItemViewSize),
+        }
+
+        return (
+            <SneakItemWrapper style={style}>
+                <span style={{ fontWeight: "bold" }}>
+                    {this.props.sneak.triggerKeys.substring(0, this.props.filterLength)}
+                </span>
+                <span>
+                    {this.props.sneak.triggerKeys.substring(
+                        this.props.filterLength,
+                        this.props.sneak.triggerKeys.length,
+                    )}
+                </span>
+            </SneakItemWrapper>
+        )
+    }
+}

--- a/browser/src/Services/Sneak/SneakView.tsx
+++ b/browser/src/Services/Sneak/SneakView.tsx
@@ -9,7 +9,7 @@ import * as React from "react"
 import { boxShadow, OverlayWrapper } from "./../../UI/components/common"
 import { TextInputView } from "./../../UI/components/LightweightText"
 
-import { ISneakInfo, IAugmentedSneakInfo } from "./Sneak"
+import { ISneakInfo, IAugmentedSneakInfo } from "./SneakStore"
 
 export interface ISneakViewProps {
     sneaks: IAugmentedSneakInfo[]

--- a/browser/src/Services/Sneak/index.tsx
+++ b/browser/src/Services/Sneak/index.tsx
@@ -4,6 +4,9 @@
  * Entry point for sneak functionality
  */
 
+import { CallbackCommand, CommandManager } from "./../CommandManager"
+import { OverlayManager } from "./../Overlay"
+
 import { Sneak } from "./Sneak"
 
 let _sneak: Sneak

--- a/browser/src/Services/Sneak/index.tsx
+++ b/browser/src/Services/Sneak/index.tsx
@@ -1,0 +1,38 @@
+/**
+ * Sneak/index.tsx
+ *
+ * Entry point for sneak functionality
+ */
+
+import { Sneak } from "./Sneak"
+
+let _sneak: Sneak
+
+export const activate = (commandManager: CommandManager, overlayManager: OverlayManager) => {
+    _sneak = new Sneak(overlayManager)
+
+    commandManager.registerCommand(
+        new CallbackCommand(
+            "sneak.show",
+            "Sneak: Current Window",
+            "Show commands for current window",
+            () => {
+                _sneak.show()
+            },
+        ),
+    )
+
+    commandManager.registerCommand(
+        new CallbackCommand(
+            "sneak.hide",
+            "Sneak: Hide",
+            "Hide sneak view",
+            () => _sneak.close(),
+            () => _sneak.isActive,
+        ),
+    )
+}
+
+export const getInstance = (): Sneak => {
+    return _sneak
+}

--- a/browser/src/UI/components/Sneakable.tsx
+++ b/browser/src/UI/components/Sneakable.tsx
@@ -22,7 +22,7 @@ export class Sneakable extends React.PureComponent<ISneakableProps, {}> {
     public componentDidMount() {
         this._cleanupSubscription()
 
-        this._subscription = getSneak().addSneakProvider(() => {
+        this._subscription = getSneak().addSneakProvider(async () => {
             if (this._element) {
                 const rect = this._element.getBoundingClientRect()
 

--- a/browser/test/Services/Sneak/SneakStoreTests.ts
+++ b/browser/test/Services/Sneak/SneakStoreTests.ts
@@ -1,0 +1,56 @@
+import * as assert from "assert"
+
+import * as Oni from "oni-api"
+
+import { createStore, ISneakInfo } from "./../../../src/Services/Sneak/SneakStore"
+
+const createTestSneak = (callback: () => void): ISneakInfo => {
+    return {
+        rectangle: Oni.Shapes.Rectangle.create(0, 0, 0, 0),
+        callback,
+    }
+}
+
+describe("SneakStore", () => {
+    it("ADD_SNEAKS is ignored if not active", () => {
+        const store = createStore()
+
+        const sneaks = [createTestSneak(null), createTestSneak(null)]
+
+        store.dispatch({
+            type: "END",
+        })
+
+        store.dispatch({
+            type: "ADD_SNEAKS",
+            sneaks,
+        })
+
+        const state = store.getState()
+
+        assert.deepEqual(state.sneaks, [])
+    })
+
+    it("Multiple ADD_SNEAKS actions are correctly labelled", () => {
+        const store = createStore()
+
+        const sneaksRound1 = [createTestSneak(null), createTestSneak(null)]
+
+        store.dispatch({ type: "START" })
+        store.dispatch({
+            type: "ADD_SNEAKS",
+            sneaks: sneaksRound1,
+        })
+
+        const sneaksRound2 = [createTestSneak(null), createTestSneak(null)]
+
+        store.dispatch({
+            type: "ADD_SNEAKS",
+            sneaks: sneaksRound2,
+        })
+
+        const keys = store.getState().sneaks.map(s => s.triggerKeys)
+
+        assert.deepEqual(keys, ["AA", "AB", "AC", "AD"])
+    })
+})


### PR DESCRIPTION
This is a pre-requisite to implementing the sneak functionality in our embedded browser. For that scenario to work, there needs to be a way to _asynchronously_ resolve sneaks, since there won't be a synchronous API to get sneaks in the browser window.

This pushes some of the logic for sneaks into a redux store, and updates the provider API to be async. This should be transparent though for our existing scenarios - those should work the same.