### PR TITLE
Bugfix - Snippets: Match whitespace when inserting into buffers

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -44,6 +44,7 @@ import { IBufferLayer } from "./NeovimEditor/BufferLayerManager"
 export interface IBuffer extends Oni.Buffer {
     getCursorPosition(): Promise<types.Position>
     handleInput(key: string): boolean
+    detectIndentation(): Promise<BufferIndentationInfo>
 }
 
 export type IndentationType = "tab" | "space"

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -13,7 +13,6 @@ import { Subject } from "rxjs/Subject"
 
 import { EditorManager } from "./../EditorManager"
 
-import { OniSnippet } from "./OniSnippet"
 import { SnippetBufferLayer } from "./SnippetBufferLayer"
 import { CompositeSnippetProvider, ISnippetProvider } from "./SnippetProvider"
 import { SnippetSession } from "./SnippetSession"
@@ -56,10 +55,8 @@ export class SnippetManager {
         this.cancel()
         Log.info("[SnippetManager::insertSnippet]")
 
-        const snip = new OniSnippet(snippet)
-
         const activeEditor = this._editorManager.activeEditor as any
-        const snippetSession = new SnippetSession(activeEditor as any, snip)
+        const snippetSession = new SnippetSession(activeEditor as any, snippet)
         await snippetSession.start()
 
         const buffer = this._editorManager.activeEditor.activeBuffer

--- a/browser/test/Mocks/MockBuffer.ts
+++ b/browser/test/Mocks/MockBuffer.ts
@@ -13,6 +13,7 @@ import * as Oni from "oni-api"
 import * as types from "vscode-languageserver-types"
 
 import { IBufferHighlightsUpdater } from "./../../src/Editor/BufferHighlights"
+import { BufferIndentationInfo } from "./../../src/Editor/BufferManager"
 
 import { HighlightInfo } from "./../../src/Services/SyntaxHighlighting"
 
@@ -20,6 +21,12 @@ export class MockBuffer {
     private _mockHighlights = new MockBufferHighlightsUpdater()
     private _cursor = { line: 0, column: 0 }
     private _modified = false
+
+    private _indentationInfo: BufferIndentationInfo = {
+        indent: "   ",
+        type: "space",
+        amount: 3,
+    }
 
     public get id(): number {
         return this._id
@@ -56,6 +63,10 @@ export class MockBuffer {
         private _id: number = 1,
     ) {}
 
+    public async detectIndentation(): Promise<BufferIndentationInfo> {
+        return this._indentationInfo
+    }
+
     public async getCursorPosition(): Promise<types.Position> {
         return types.Position.create(this._cursor.line, this._cursor.column)
     }
@@ -77,6 +88,10 @@ export class MockBuffer {
 
         this._lines[line] = lineContents
         this._modified = true
+    }
+
+    public setWhitespace(indentationInfo: BufferIndentationInfo): void {
+        this._indentationInfo = indentationInfo
     }
 
     public async setLines(start: number, end: number, lines: string[]): Promise<void> {

--- a/browser/test/Mocks/MockBuffer.ts
+++ b/browser/test/Mocks/MockBuffer.ts
@@ -1,0 +1,132 @@
+/**
+ * Mocks/index.ts
+ *
+ * Implementations of test mocks and doubles,
+ * to exercise boundaries of class implementations
+ */
+
+export * from "./MockPluginManager"
+export * from "./MockThemeLoader"
+
+import * as Oni from "oni-api"
+
+import * as types from "vscode-languageserver-types"
+
+import { IBufferHighlightsUpdater } from "./../../src/Editor/BufferHighlights"
+
+import { HighlightInfo } from "./../../src/Services/SyntaxHighlighting"
+
+export class MockBuffer {
+    private _mockHighlights = new MockBufferHighlightsUpdater()
+    private _cursor = { line: 0, column: 0 }
+    private _modified = false
+
+    public get id(): number {
+        return this._id
+    }
+
+    public get language(): string {
+        return this._language
+    }
+
+    public get filePath(): string {
+        return this._filePath
+    }
+
+    public get lineCount(): number {
+        return this._lines.length
+    }
+
+    public get mockHighlights(): MockBufferHighlightsUpdater {
+        return this._mockHighlights
+    }
+
+    public get cursor(): Oni.Cursor {
+        return this._cursor
+    }
+
+    public get modified(): boolean {
+        return this._modified
+    }
+
+    public constructor(
+        private _language: string = "test_language",
+        private _filePath: string = "test_filepath",
+        private _lines: string[] = [],
+        private _id: number = 1,
+    ) {}
+
+    public async getCursorPosition(): Promise<types.Position> {
+        return types.Position.create(this._cursor.line, this._cursor.column)
+    }
+
+    public setCursorPosition(line: number, column: number) {
+        this._cursor.column = column
+        this._cursor.line = line
+    }
+
+    public setLinesSync(lines: string[]): void {
+        this._lines = lines
+        this._modified = true
+    }
+
+    public setLineSync(line: number, lineContents: string): void {
+        while (this._lines.length <= line) {
+            this._lines.push("")
+        }
+
+        this._lines[line] = lineContents
+        this._modified = true
+    }
+
+    public async setLines(start: number, end: number, lines: string[]): Promise<void> {
+        while (this._lines.length <= end) {
+            this._lines.push("")
+        }
+
+        for (let i = 0; i < lines.length; i++) {
+            this._lines[start + i] = lines[i]
+        }
+
+        this._modified = true
+    }
+
+    public getLines(start: number = 0, end?: number): Promise<string[]> {
+        if (typeof end !== "number") {
+            end = this._lines.length
+        }
+
+        return Promise.resolve(this._lines.slice(start, end))
+    }
+
+    public updateHighlights(
+        tokenColors: any[],
+        updateFunction: (highlightUpdater: IBufferHighlightsUpdater) => void,
+    ) {
+        updateFunction(this._mockHighlights)
+    }
+
+    public addLayer(): void {
+        // tslint:disable-line
+    }
+
+    public removeLayer(): void {
+        // tslint:disable-line
+    }
+}
+
+export class MockBufferHighlightsUpdater implements IBufferHighlightsUpdater {
+    private _linesToHighlights: { [line: number]: HighlightInfo[] } = {}
+
+    public setHighlightsForLine(line: number, highlights: HighlightInfo[]): void {
+        this._linesToHighlights[line] = highlights
+    }
+
+    public clearHighlightsForLine(line: number): void {
+        this._linesToHighlights[line] = null
+    }
+
+    public getHighlightsForLine(line: number): HighlightInfo[] {
+        return this._linesToHighlights[line] || []
+    }
+}

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -14,13 +14,11 @@ import { Event, IEvent } from "oni-types"
 
 import * as types from "vscode-languageserver-types"
 
-import { IBufferHighlightsUpdater } from "./../../src/Editor/BufferHighlights"
 import { Editor } from "./../../src/Editor/Editor"
 
 import * as Language from "./../../src/Services/Language"
 import { createCompletablePromise, ICompletablePromise } from "./../../src/Utility"
 
-import { HighlightInfo } from "./../../src/Services/SyntaxHighlighting"
 import { TokenColor } from "./../../src/Services/TokenColors"
 import { IWorkspace } from "./../../src/Services/Workspace"
 

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -5,6 +5,7 @@
  * to exercise boundaries of class implementations
  */
 
+export * from "./MockBuffer"
 export * from "./MockPluginManager"
 export * from "./MockThemeLoader"
 
@@ -30,6 +31,8 @@ export class MockTokenColors {
         return this._tokenColors
     }
 }
+
+import { MockBuffer } from "./MockBuffer"
 
 export class MockConfiguration {
     private _currentConfigurationFiles: string[] = []
@@ -174,121 +177,6 @@ export class MockEditor extends Editor {
                 },
             ],
         })
-    }
-}
-
-export class MockBuffer {
-    private _mockHighlights = new MockBufferHighlightsUpdater()
-    private _cursor = { line: 0, column: 0 }
-    private _modified = false
-
-    public get id(): number {
-        return this._id
-    }
-
-    public get language(): string {
-        return this._language
-    }
-
-    public get filePath(): string {
-        return this._filePath
-    }
-
-    public get lineCount(): number {
-        return this._lines.length
-    }
-
-    public get mockHighlights(): MockBufferHighlightsUpdater {
-        return this._mockHighlights
-    }
-
-    public get cursor(): Oni.Cursor {
-        return this._cursor
-    }
-
-    public get modified(): boolean {
-        return this._modified
-    }
-
-    public constructor(
-        private _language: string = "test_language",
-        private _filePath: string = "test_filepath",
-        private _lines: string[] = [],
-        private _id: number = 1,
-    ) {}
-
-    public async getCursorPosition(): Promise<types.Position> {
-        return types.Position.create(this._cursor.line, this._cursor.column)
-    }
-
-    public setCursorPosition(line: number, column: number) {
-        this._cursor.column = column
-        this._cursor.line = line
-    }
-
-    public setLinesSync(lines: string[]): void {
-        this._lines = lines
-        this._modified = true
-    }
-
-    public setLineSync(line: number, lineContents: string): void {
-        while (this._lines.length <= line) {
-            this._lines.push("")
-        }
-
-        this._lines[line] = lineContents
-        this._modified = true
-    }
-
-    public async setLines(start: number, end: number, lines: string[]): Promise<void> {
-        while (this._lines.length <= end) {
-            this._lines.push("")
-        }
-
-        for (let i = 0; i < lines.length; i++) {
-            this._lines[start + i] = lines[i]
-        }
-
-        this._modified = true
-    }
-
-    public getLines(start: number = 0, end?: number): Promise<string[]> {
-        if (typeof end !== "number") {
-            end = this._lines.length
-        }
-
-        return Promise.resolve(this._lines.slice(start, end))
-    }
-
-    public updateHighlights(
-        tokenColors: any[],
-        updateFunction: (highlightUpdater: IBufferHighlightsUpdater) => void,
-    ) {
-        updateFunction(this._mockHighlights)
-    }
-
-    public addLayer(): void {
-        // tslint:disable-line
-    }
-
-    public removeLayer(): void {
-        // tslint:disable-line
-    }
-}
-
-export class MockBufferHighlightsUpdater implements IBufferHighlightsUpdater {
-    private _linesToHighlights: { [line: number]: HighlightInfo[] } = {}
-
-    public setHighlightsForLine(line: number, highlights: HighlightInfo[]): void {
-        this._linesToHighlights[line] = highlights
-    }
-
-    public clearHighlightsForLine(line: number): void {
-        this._linesToHighlights[line] = null
-    }
-
-    public getHighlightsForLine(line: number): HighlightInfo[] {
-        return this._linesToHighlights[line] || []
     }
 }
 

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -24,8 +24,7 @@ describe("SnippetSession", () => {
     })
 
     it("inserts into empty line", async () => {
-        const snippet = new OniSnippet("foo")
-        snippetSession = new SnippetSession(mockEditor as any, snippet)
+        snippetSession = new SnippetSession(mockEditor as any, "foo")
 
         await snippetSession.start()
 
@@ -35,8 +34,7 @@ describe("SnippetSession", () => {
     })
 
     it("inserts between characters", async () => {
-        const snippet = new OniSnippet("foo")
-        snippetSession = new SnippetSession(mockEditor as any, snippet)
+        snippetSession = new SnippetSession(mockEditor as any, "foo")
 
         // Add a line, and move cursor to line
         mockBuffer.setLinesSync(["someline"])
@@ -50,8 +48,7 @@ describe("SnippetSession", () => {
     })
 
     it("handles multiple lines", async () => {
-        const snippet = new OniSnippet("foo\nbar")
-        snippetSession = new SnippetSession(mockEditor as any, snippet)
+        snippetSession = new SnippetSession(mockEditor as any, "foo\nbar")
 
         // Add a line, and move cursor to line
         mockBuffer.setLinesSync(["someline"])
@@ -66,8 +63,7 @@ describe("SnippetSession", () => {
     })
 
     it("highlights first placeholder", async () => {
-        const snippet = new OniSnippet("${0:test}")
-        snippetSession = new SnippetSession(mockEditor as any, snippet)
+        snippetSession = new SnippetSession(mockEditor as any, "${0:test}")
 
         mockBuffer.setLinesSync(["abc"])
         mockBuffer.setCursorPosition(0, 1)
@@ -84,8 +80,7 @@ describe("SnippetSession", () => {
 
     describe("next placeholder", () => {
         it("highlights correct placeholder after calling nextPlaceholder", async () => {
-            const snippet = new OniSnippet("${0:test} ${1:test2}")
-            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            snippetSession = new SnippetSession(mockEditor as any, "${0:test} ${1:test2}")
 
             await snippetSession.start()
 
@@ -100,8 +95,7 @@ describe("SnippetSession", () => {
         })
 
         it("traverses order correctly, when placeholders are reversed", async () => {
-            const snippet = new OniSnippet("${1:test} ${0:test2}")
-            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            snippetSession = new SnippetSession(mockEditor as any, "${1:test} ${0:test2}")
 
             await snippetSession.start()
 
@@ -124,8 +118,7 @@ describe("SnippetSession", () => {
         })
 
         it("traverses order correctly, when there are multiple placeholders with the same index", async () => {
-            const snippet = new OniSnippet("${1:test} ${0:test2} ${1}")
-            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            snippetSession = new SnippetSession(mockEditor as any, "${1:test} ${0:test2} ${1}")
 
             const placeholder0Range = types.Range.create(0, 5, 0, 9)
             const placeholder1Range = types.Range.create(0, 0, 0, 3)
@@ -151,8 +144,7 @@ describe("SnippetSession", () => {
 
     describe("synchronizeUpdatedPlaceholders", () => {
         it("updates placeholders", async () => {
-            const snippet = new OniSnippet("${1:test} ${1} ${1}")
-            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            snippetSession = new SnippetSession(mockEditor as any, "${1:test} ${1} ${1}")
             await snippetSession.start()
 
             // Validate
@@ -169,9 +161,10 @@ describe("SnippetSession", () => {
         })
 
         it("updates placeholders when a placeholder becomes smaller", async () => {
-            const snippet = new OniSnippet('import { ${1} } from "${0:module}"') // tslint:disable-line
-
-            snippetSession = new SnippetSession(mockEditor as any, snippet)
+            snippetSession = new SnippetSession(
+                mockEditor as any,
+                'import { ${1} } from "${0:module}"',
+            )
             await snippetSession.start()
 
             // Simulate shortening from "module" -> "a"

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -48,7 +48,7 @@ describe("SnippetSession", () => {
         })
 
         it("matches existing whitespace - 2 spaces", async () => {
-            const snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
+            snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
 
             const indentationInfo = {
                 type: "space",
@@ -64,7 +64,7 @@ describe("SnippetSession", () => {
         })
 
         it("matches existing whitespace - tabs", async () => {
-            const snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
+            snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
 
             const indentationInfo = {
                 type: "tab",

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -22,28 +22,62 @@ describe("SnippetSession", () => {
         mockEditor.simulateBufferEnter(mockBuffer)
     })
 
-    it("inserts into empty line", async () => {
-        snippetSession = new SnippetSession(mockEditor as any, "foo")
+    describe("insertion", () => {
+        it("inserts into empty line", async () => {
+            snippetSession = new SnippetSession(mockEditor as any, "foo")
 
-        await snippetSession.start()
+            await snippetSession.start()
 
-        const [firstLine] = await mockBuffer.getLines(0, 1)
+            const [firstLine] = await mockBuffer.getLines(0, 1)
 
-        assert.strictEqual(firstLine, "foo")
-    })
+            assert.strictEqual(firstLine, "foo")
+        })
 
-    it("inserts between characters", async () => {
-        snippetSession = new SnippetSession(mockEditor as any, "foo")
+        it("inserts between characters", async () => {
+            snippetSession = new SnippetSession(mockEditor as any, "foo")
 
-        // Add a line, and move cursor to line
-        mockBuffer.setLinesSync(["someline"])
-        mockBuffer.setCursorPosition(0, 4)
+            // Add a line, and move cursor to line
+            mockBuffer.setLinesSync(["someline"])
+            mockBuffer.setCursorPosition(0, 4)
 
-        await snippetSession.start()
+            await snippetSession.start()
 
-        const [firstLine] = await mockBuffer.getLines(0, 1)
+            const [firstLine] = await mockBuffer.getLines(0, 1)
 
-        assert.strictEqual(firstLine, "somefooline")
+            assert.strictEqual(firstLine, "somefooline")
+        })
+
+        it("matches existing whitespace - 2 spaces", async () => {
+            const snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
+
+            const indentationInfo = {
+                type: "space",
+                amount: 2,
+                indent: "  ",
+            }
+
+            mockBuffer.setWhitespace(indentationInfo as any)
+            await snippetSession.start()
+
+            const [firstLine] = await mockBuffer.getLines(0, 1)
+            assert.strictEqual(firstLine, "    foo")
+        })
+
+        it("matches existing whitespace - tabs", async () => {
+            const snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
+
+            const indentationInfo = {
+                type: "tab",
+                amount: 0,
+                indent: "\t",
+            }
+
+            mockBuffer.setWhitespace(indentationInfo as any)
+            await snippetSession.start()
+
+            const [firstLine] = await mockBuffer.getLines(0, 1)
+            assert.strictEqual(firstLine, "\t\tfoo")
+        })
     })
 
     it("handles multiple lines", async () => {

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -5,7 +5,6 @@
 import * as assert from "assert"
 import * as types from "vscode-languageserver-types"
 
-import { OniSnippet } from "./../../../src/Services/Snippets/OniSnippet"
 import { SnippetSession } from "./../../../src/Services/Snippets/SnippetSession"
 
 import * as Mocks from "./../../Mocks"


### PR DESCRIPTION
This leverages the `detectIndentation` API so that snippets will have whitespace matching the destination buffer. Otherwise, we'd always get hard tabs, which isn't ideal.