### PR TITLE
Bugfix: Fix heisenbug where process.env changes during execution

### DIFF
--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -114,7 +114,7 @@ export class Process implements Oni.Process {
         const requiredOptions = {
             env: {
                 ...process.env,
-                this._env,
+                ...this._env,
                 ...originalSpawnOptions.env,
             },
         }

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -106,7 +106,6 @@ export class Process implements Oni.Process {
                 this._shellEnv = await this._shellEnvPromise
                 this._env = this._shellEnv.sync()
             }
-            process.env = { ...process.env, ...this._env }
             existingPath = process.env.Path || process.env.PATH
         } catch (e) {
             existingPath = process.env.Path || process.env.PATH
@@ -115,6 +114,7 @@ export class Process implements Oni.Process {
         const requiredOptions = {
             env: {
                 ...process.env,
+                this._env,
                 ...originalSpawnOptions.env,
             },
         }

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -5,15 +5,33 @@ import * as Log from "./../../Log"
 import * as Platform from "./../../Platform"
 import { configuration } from "./../../Services/Configuration"
 
-export class Process implements Oni.Process {
-    public _spawnedProcessIds: number[] = []
+export interface IShellEnvironmentFetcher {
+    getEnvironmentVariables(): Promise<any>
+}
+
+export class ShellEnvironmentFetcher implements IShellEnvironmentFetcher {
     private _shellEnvPromise: Promise<any>
     private _shellEnv: any
-    private _env: NodeJS.ProcessEnv
 
     constructor() {
         this._shellEnvPromise = import("shell-env")
     }
+
+    public async getEnvironmentVariables(): Promise<any> {
+        if (!this._shellEnv) {
+            this._shellEnv = await this._shellEnvPromise
+            return this._shellEnv.sync()
+        }
+    }
+}
+
+export class Process implements Oni.Process {
+    public _spawnedProcessIds: number[] = []
+    private _env: NodeJS.ProcessEnv
+
+    constructor(
+        private _shellEnvironmentFetcher: IShellEnvironmentFetcher = new ShellEnvironmentFetcher(),
+    ) {}
 
     public getPathSeparator = () => {
         return Platform.isWindows() ? ";" : ":"
@@ -96,15 +114,14 @@ export class Process implements Oni.Process {
         return proc
     }
 
-    private mergeSpawnOptions = async (
+    public mergeSpawnOptions = async (
         originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions,
     ): Promise<any> => {
         let existingPath: string
 
         try {
-            if (!this._shellEnv || !this._env) {
-                this._shellEnv = await this._shellEnvPromise
-                this._env = this._shellEnv.sync()
+            if (!this._env) {
+                this._env = (await this._shellEnvironmentFetcher.getEnvironmentVariables()) || {}
             }
             existingPath = process.env.Path || process.env.PATH
         } catch (e) {

--- a/browser/test/Plugins/Api/ProcessTests.ts
+++ b/browser/test/Plugins/Api/ProcessTests.ts
@@ -1,0 +1,31 @@
+/**
+ * ProcessTests.ts
+ */
+
+import * as assert from "assert"
+
+import { Process, IShellEnvironmentFetcher } from "./../../../src/Plugins/Api/Process"
+
+class MockShellEnvironmentFetcher implements IShellEnvironmentFetcher {
+    constructor(private _env: any) {}
+
+    public async getEnvironmentVariables(): Promise<any> {
+        return this._env
+    }
+}
+
+describe("ProcessTests", () => {
+    it("mergeSpawnOptions takes into account shell environment", async () => {
+        const mockShellEnv = new MockShellEnvironmentFetcher({ test2: true })
+        const process = new Process(mockShellEnv)
+
+        const newOptions = await process.mergeSpawnOptions({
+            env: {
+                test1: true,
+            },
+        })
+
+        assert.strictEqual(newOptions.env["test1"], true)
+        assert.strictEqual(newOptions.env["test2"], true)
+    })
+})

--- a/browser/test/Plugins/Api/ProcessTests.ts
+++ b/browser/test/Plugins/Api/ProcessTests.ts
@@ -4,7 +4,7 @@
 
 import * as assert from "assert"
 
-import { Process, IShellEnvironmentFetcher } from "./../../../src/Plugins/Api/Process"
+import { IShellEnvironmentFetcher, Process } from "./../../../src/Plugins/Api/Process"
 
 class MockShellEnvironmentFetcher implements IShellEnvironmentFetcher {
     constructor(private _env: any) {}
@@ -25,7 +25,7 @@ describe("ProcessTests", () => {
             },
         })
 
-        assert.strictEqual(newOptions.env["test1"], true)
-        assert.strictEqual(newOptions.env["test2"], true)
+        assert.strictEqual(newOptions.env.test1, true)
+        assert.strictEqual(newOptions.env.test2, true)
     })
 })


### PR DESCRIPTION
__Issue:__ While debugging automation, I noticed cases where the `process.env` would be changing seemingly at random through the course of running Oni.

__Defect:__ The `mergeSpawnOptions` method has a side effect of setting `process.env`. We shouldn't need to update `process.env` during runtime, and doing so can have unpredictable results (aka, heisenbugs)

__Fix:__ Don't set `process.env` - instead, just pass it, along with other environment variables, to the child process.