### PR TITLE
Bug fix - Snippets - Previous selection can break placeholders

### DIFF
--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -68,15 +68,21 @@ export class SnippetManager {
             }
         })
 
-        const s2 = activeEditor.onBufferChanged.subscribe(() => {
+        const s2 = activeEditor.onModeChanged.subscribe(() => {
+            if (this.isSnippetActive()) {
+                this._activeSession.updateCursorPosition()
+            }
+        })
+
+        const s3 = activeEditor.onBufferChanged.subscribe(() => {
             this._synchronizeSnippetObservable.next()
         })
 
-        const s3 = snippetSession.onCancel.subscribe(() => {
+        const s4 = snippetSession.onCancel.subscribe(() => {
             this.cancel()
         })
 
-        this._disposables = [s1, s2, s3]
+        this._disposables = [s1, s2, s3, s4]
 
         this._activeSession = snippetSession
     }


### PR DESCRIPTION
__Repro:__

- Open a file that has snippets (ie, js)
- Go to a line and press `V` to linewise select
- Escape and insert a snippet with a placeholder

Expected: The placeholder should be highlighted correctly
Actual: The entire line is highlighted

This actually isn't a bug with snippets (just happens to be exposed by them), but with the `setSelection` method. The problem is, for some selections, it gets persisted - this change explicitly sets the selection range via cursor navigation.