### PR TITLE
Bugfix - Buffer Layers: Fix duplicate layers being added

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -48,7 +48,16 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
 
             const layerElements = layers.map(l => {
                 return (
-                    <div key={l.id} style={InnerLayerStyle}>
+                    <div
+                        key={
+                            l.id +
+                            "." +
+                            windowState.windowId.toString() +
+                            "." +
+                            windowState.bufferId.toString()
+                        }
+                        style={InnerLayerStyle}
+                    >
                         {l.render(layerContext)}
                     </div>
                 )

--- a/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
@@ -168,6 +168,11 @@ export const layersReducer = (s: State.Layers, a: Actions.SimpleAction) => {
     switch (a.type) {
         case "ADD_BUFFER_LAYER": {
             const currentLayers = s[a.payload.bufferId] || []
+
+            if (currentLayers.find(layer => layer.id === a.payload.layer.id)) {
+                return s
+            }
+
             return {
                 ...s,
                 [a.payload.bufferId]: [...currentLayers, a.payload.layer],


### PR DESCRIPTION
__Issue:__ On the filetype event, we were re-adding existing buffer layers to the same buffer. This caused duplicate buffers to be added, with duplicate ids, which then caused issues with rendering / react DOM reconciliation.

__Fix:__ Don't add duplicate layers with the same id.