### PR TITLE
bugfix/ add a filter for image layers

### DIFF
--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -146,9 +146,10 @@ export class OniEditor implements IEditor {
             wrapReactComponentWithLayer("oni.layer.errors", <ErrorsContainer />),
         )
 
-        this._neovimEditor.bufferLayers.addBufferLayer(buf => {
-            return [".png", ".jpg"].includes(path.extname(buf.filePath))
-        }, buf => new ImageBufferLayer(buf))
+        this._neovimEditor.bufferLayers.addBufferLayer(
+            buf => [".gif", ".jpg", ".jpeg", ".bmp", ".png"].includes(path.extname(buf.filePath)),
+            buf => new ImageBufferLayer(buf),
+        )
     }
 
     public dispose(): void {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -6,6 +6,7 @@
  * Extends the capabilities of the NeovimEditor
  */
 
+import * as path from "path"
 import * as React from "react"
 
 import * as types from "vscode-languageserver-types"
@@ -145,7 +146,9 @@ export class OniEditor implements IEditor {
             wrapReactComponentWithLayer("oni.layer.errors", <ErrorsContainer />),
         )
 
-        this._neovimEditor.bufferLayers.addBufferLayer("image", buf => new ImageBufferLayer(buf))
+        this._neovimEditor.bufferLayers.addBufferLayer(buf => {
+            return [".png", ".jpg"].includes(path.extname(buf.filePath))
+        }, buf => new ImageBufferLayer(buf))
     }
 
     public dispose(): void {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -146,8 +146,9 @@ export class OniEditor implements IEditor {
             wrapReactComponentWithLayer("oni.layer.errors", <ErrorsContainer />),
         )
 
+        const extensions = this._configuration.getValue("editor.imageLayerExtensions")
         this._neovimEditor.bufferLayers.addBufferLayer(
-            buf => [".gif", ".jpg", ".jpeg", ".bmp", ".png"].includes(path.extname(buf.filePath)),
+            buf => extensions.includes(path.extname(buf.filePath)),
             buf => new ImageBufferLayer(buf),
         )
     }

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -121,6 +121,8 @@ const BaseConfiguration: IConfigurationValues = {
 
     "editor.tokenColors": [],
 
+    "editor.imageLayerExtensions": [".gif", ".jpg", ".jpeg", ".bmp", ".png"],
+
     "environment.additionalPaths": [],
 
     "language.html.languageServer.command": htmlLanguageServerPath,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -159,6 +159,9 @@ export interface IConfigurationValues {
     // (and available in terminal integration, later)
     "environment.additionalPaths": string[]
 
+    // User configurable array of files for which
+    // the image layer opens
+    "editor.imageLayerExtensions": string[]
     // Command to list files for 'quick open'
     // For example, to use 'ag': ag --nocolor -l .
     //


### PR DESCRIPTION
Currently image layers pop up whenever a split is made, or rather I observe this using any plugins that create splits. This PR aims to fix this which I raised as #1673, using the filter functionality of the add bufferLayer method, which is very cool re api design 👍.

I added a filter to only open the image layer for `jpg` and `png` formats (the only 2 that came to mind at the time)