### PR TITLE
feature/ add a check to open in a tab if in tabs mode otherwise open buffer

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -751,7 +751,7 @@ export class NeovimEditor extends Editor implements IEditor {
                 [Oni.FileOpenMode.NewTab]: "tabnew!",
                 [Oni.FileOpenMode.HorizontalSplit]: "sp!",
                 [Oni.FileOpenMode.VerticalSplit]: "vsp!",
-                [Oni.FileOpenMode.Edit]: tabsMode ? "tabe!" : "e!",
+                [Oni.FileOpenMode.Edit]: tabsMode ? "tab drop" : "e!",
                 [Oni.FileOpenMode.ExistingTab]: "e!",
             },
             {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -745,12 +745,13 @@ export class NeovimEditor extends Editor implements IEditor {
         file: string,
         openOptions: Oni.FileOpenOptions = Oni.DefaultFileOpenOptions,
     ): Promise<Oni.Buffer> {
+        const tabsMode = this._configuration.getValue("tabs.mode") === "tabs"
         const cmd = new Proxy(
             {
                 [Oni.FileOpenMode.NewTab]: "tabnew!",
                 [Oni.FileOpenMode.HorizontalSplit]: "sp!",
                 [Oni.FileOpenMode.VerticalSplit]: "vsp!",
-                [Oni.FileOpenMode.Edit]: "tab drop",
+                [Oni.FileOpenMode.Edit]: tabsMode ? "tabe!" : "e!",
                 [Oni.FileOpenMode.ExistingTab]: "e!",
             },
             {


### PR DESCRIPTION
Relates and hopefully fixes #1675, I added a check to open with a regular edit command if a user is using buffers mode otherwise it uses the `tabedit` command which for all I know is probably not the desired effect, the `tab drop` command does nothing for me locally though I wasn't using tabs so not sure if it would have been working for tab users.

The main aim of this PR is to have the quick open open files depending on the users `tabs.mode` settings, happy to revert the tab drop change as it likely does exactly what was intended but seemed to do nothing locally so attempted a fix for that ^^