### PR TITLE
Externalized UI: Implement Oni split mode

### DIFF
--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -44,7 +44,7 @@ import { ErrorsContainer } from "./containers/ErrorsContainer"
 
 import { NeovimEditor } from "./../NeovimEditor"
 
-import { windowManager } from "./../../Services/WindowManager"
+import { windowManager, SplitDirection } from "./../../Services/WindowManager"
 
 import { ImageBufferLayer } from "./ImageBufferLayer"
 
@@ -177,8 +177,9 @@ export class OniEditor implements IEditor {
                 openMode === Oni.FileOpenMode.HorizontalSplit ||
                 openMode === Oni.FileOpenMode.VerticalSplit
             ) {
-                // TODO
-                const newEditor = await this._split("horizontal")
+                const splitDirection =
+                    openMode === Oni.FileOpenMode.HorizontalSplit ? "horizontal" : "vertical"
+                const newEditor = await this._split(splitDirection)
                 return newEditor.openFile(file, { openMode: Oni.FileOpenMode.Edit })
             }
         }
@@ -230,7 +231,7 @@ export class OniEditor implements IEditor {
         return this._neovimEditor.render()
     }
 
-    private async _split(direction: any): Promise<OniEditor> {
+    private async _split(direction: SplitDirection): Promise<OniEditor> {
         const newEditor = new OniEditor(
             this._colors,
             this._completionProviders,

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -18,6 +18,7 @@ import * as Log from "./../../Log"
 import { PluginManager } from "./../../Plugins/PluginManager"
 
 import { IColors } from "./../../Services/Colors"
+import { commandManager } from "./../../Services/CommandManager"
 import { CompletionProviders } from "./../../Services/Completion"
 import { Configuration } from "./../../Services/Configuration"
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
@@ -160,6 +161,22 @@ export class OniEditor implements IEditor {
         this._neovimEditor.enter()
 
         editorManager.setActiveEditor(this)
+
+        commandManager.registerCommand({
+            command: "editor.split.horizontal",
+            execute: () => this._split("horizontal"),
+            enabled: () => editorManager.activeEditor === this,
+            name: null,
+            detail: null,
+        })
+
+        commandManager.registerCommand({
+            command: "editor.split.vertical",
+            execute: () => this._split("vertical"),
+            enabled: () => editorManager.activeEditor === this,
+            name: null,
+            detail: null,
+        })
     }
 
     public leave(): void {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -249,6 +249,16 @@ export class OniEditor implements IEditor {
     }
 
     private async _split(direction: SplitDirection): Promise<OniEditor> {
+        if (this._configuration.getValue("editor.split.mode") !== "oni") {
+            if (direction === "horizontal") {
+                await this._neovimEditor.neovim.command(":sp")
+            } else {
+                await this._neovimEditor.neovim.command(":vsp")
+            }
+
+            return this
+        }
+
         const newEditor = new OniEditor(
             this._colors,
             this._completionProviders,

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -280,7 +280,6 @@ export class OniEditor implements IEditor {
             this._workspace,
         )
 
-        // TODO
         windowManager.createSplit(direction, newEditor, this)
         await newEditor.init([])
         return newEditor

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -178,7 +178,7 @@ export class OniEditor implements IEditor {
                 openMode === Oni.FileOpenMode.VerticalSplit
             ) {
                 // TODO
-                const newEditor = await this._split("vertical")
+                const newEditor = await this._split("horizontal")
                 return newEditor.openFile(file, { openMode: Oni.FileOpenMode.Edit })
             }
         }

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -177,30 +177,36 @@ export class OniEditor implements IEditor {
                 openMode === Oni.FileOpenMode.HorizontalSplit ||
                 openMode === Oni.FileOpenMode.VerticalSplit
             ) {
-                const newEditor = new OniEditor(
-                    this._colors,
-                    this._completionProviders,
-                    this._configuration,
-                    this._diagnostics,
-                    this._languageManager,
-                    this._menuManager,
-                    this._overlayManager,
-                    this._pluginManager,
-                    this._snippetManager,
-                    this._tasks,
-                    this._themeManager,
-                    this._tokenColors,
-                    this._workspace,
-                )
-
                 // TODO
-                windowManager.createSplit("vertical", newEditor)
-                await newEditor.init([])
+                const newEditor = await this._split("vertical")
                 return newEditor.openFile(file, { openMode: Oni.FileOpenMode.Edit })
             }
         }
 
         return this._neovimEditor.openFile(file, openOptions)
+    }
+
+    private async _split(direction: any): Promise<OniEditor> {
+        const newEditor = new OniEditor(
+            this._colors,
+            this._completionProviders,
+            this._configuration,
+            this._diagnostics,
+            this._languageManager,
+            this._menuManager,
+            this._overlayManager,
+            this._pluginManager,
+            this._snippetManager,
+            this._tasks,
+            this._themeManager,
+            this._tokenColors,
+            this._workspace,
+        )
+
+        // TODO
+        windowManager.createSplit(direction, newEditor, this)
+        await newEditor.init([])
+        return newEditor
     }
 
     public async newFile(filePath: string): Promise<Oni.Buffer> {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -44,7 +44,7 @@ import { ErrorsContainer } from "./containers/ErrorsContainer"
 
 import { NeovimEditor } from "./../NeovimEditor"
 
-import { windowManager, SplitDirection } from "./../../Services/WindowManager"
+import { SplitDirection, windowManager } from "./../../Services/WindowManager"
 
 import { ImageBufferLayer } from "./ImageBufferLayer"
 

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -186,29 +186,6 @@ export class OniEditor implements IEditor {
         return this._neovimEditor.openFile(file, openOptions)
     }
 
-    private async _split(direction: any): Promise<OniEditor> {
-        const newEditor = new OniEditor(
-            this._colors,
-            this._completionProviders,
-            this._configuration,
-            this._diagnostics,
-            this._languageManager,
-            this._menuManager,
-            this._overlayManager,
-            this._pluginManager,
-            this._snippetManager,
-            this._tasks,
-            this._themeManager,
-            this._tokenColors,
-            this._workspace,
-        )
-
-        // TODO
-        windowManager.createSplit(direction, newEditor, this)
-        await newEditor.init([])
-        return newEditor
-    }
-
     public async newFile(filePath: string): Promise<Oni.Buffer> {
         return this._neovimEditor.newFile(filePath)
     }
@@ -251,5 +228,28 @@ export class OniEditor implements IEditor {
 
     public render(): JSX.Element {
         return this._neovimEditor.render()
+    }
+
+    private async _split(direction: any): Promise<OniEditor> {
+        const newEditor = new OniEditor(
+            this._colors,
+            this._completionProviders,
+            this._configuration,
+            this._diagnostics,
+            this._languageManager,
+            this._menuManager,
+            this._overlayManager,
+            this._pluginManager,
+            this._snippetManager,
+            this._tasks,
+            this._themeManager,
+            this._tokenColors,
+            this._workspace,
+        )
+
+        // TODO
+        windowManager.createSplit(direction, newEditor, this)
+        await newEditor.init([])
+        return newEditor
     }
 }

--- a/browser/src/Services/WindowManager/LinearSplitProvider.ts
+++ b/browser/src/Services/WindowManager/LinearSplitProvider.ts
@@ -76,7 +76,7 @@ export class LinearSplitProvider implements IWindowSplitProvider {
             return false
         }
 
-        const result = containingSplit.split(split, direction)
+        const result = containingSplit.split(split, direction, referenceSplit)
 
         // Containing split handled it, so we're good
         if (result) {

--- a/browser/src/Services/WindowManager/LinearSplitProvider.ts
+++ b/browser/src/Services/WindowManager/LinearSplitProvider.ts
@@ -8,10 +8,10 @@
 import {
     Direction,
     IAugmentedSplitInfo,
+    ISplitInfo,
     IWindowSplitProvider,
     SingleSplitProvider,
     SplitDirection,
-    ISplitInfo,
 } from "./index"
 
 export const getInverseDirection = (splitDirection: SplitDirection): SplitDirection => {

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -80,6 +80,10 @@ export class AugmentedWindow implements IAugmentedSplitInfo {
 
     constructor(private _id: string, private _innerSplit: Oni.IWindowSplit | any) {}
 
+    public get innerSplit(): Oni.IWindowSplit {
+        return this._innerSplit
+    }
+
     public render(): JSX.Element {
         return this._innerSplit.render()
     }
@@ -146,27 +150,10 @@ export class WindowManager {
         this._rootNavigator.setRelationship(this._leftDock, this._primarySplit, "right")
     }
 
-    // public split(
-    //     direction: SplitDirection,
-    //     newSplit: Oni.IWindowSplit,
-    //     referenceSplit?: Oni.IWindowSplit,
-    // ) {
-
-    //     this._primarySplit.split(augmentedWindow, direction, referenceSplit)
-    //     const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
-
-    //     this._store.dispatch({
-    //         type: "SET_PRIMARY_SPLITS",
-    //         splits: newState,
-    //     })
-
-    //     this._focusNewSplit(newSplit)
-    // }
-
     public createSplit(
         splitLocation: Direction | SplitDirection,
         newSplit: Oni.IWindowSplit,
-        referenceSplit?: any,
+        referenceSplit?: Oni.IWindowSplit,
     ): WindowSplitHandle {
         const nextId = this._lastId++
         const windowId = "oni.window." + nextId.toString()
@@ -189,7 +176,8 @@ export class WindowManager {
             }
             case "horizontal":
             case "vertical":
-                this._primarySplit.split(augmentedWindow, splitLocation, referenceSplit)
+                const augmentedRefSplit = this._getAugmentedWindowSplitFromSplit(referenceSplit)
+                this._primarySplit.split(augmentedWindow, splitLocation, augmentedRefSplit)
                 const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
 
                 this._store.dispatch({
@@ -201,6 +189,11 @@ export class WindowManager {
         }
 
         return new WindowSplitHandle(this._store, this, windowId)
+    }
+
+    private _getAugmentedWindowSplitFromSplit(split: Oni.IWindowSplit): IAugmentedSplitInfo {
+        const augmentedWindows = Object.values(this._idToSplit)
+        return augmentedWindows.find(aw => aw.innerSplit === split) || null
     }
 
     public move(direction: Direction): void {

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -191,9 +191,9 @@ export class WindowManager {
         return new WindowSplitHandle(this._store, this, windowId)
     }
 
-    private _getAugmentedWindowSplitFromSplit(split: Oni.IWindowSplit): IAugmentedSplitInfo {
-        const augmentedWindows = Object.values(this._idToSplit)
-        return augmentedWindows.find(aw => aw.innerSplit === split) || null
+    public getSplitHandle(split: Oni.IWindowSplit): WindowSplitHandle {
+        const augmentedSplit = this._getAugmentedWindowSplitFromSplit(split)
+        return new WindowSplitHandle(this._store, this, augmentedSplit.id)
     }
 
     public move(direction: Direction): void {
@@ -250,6 +250,11 @@ export class WindowManager {
     public focusSplit(splitId: string): void {
         const split = this._idToSplit[splitId]
         this._focusNewSplit(split)
+    }
+
+    private _getAugmentedWindowSplitFromSplit(split: Oni.IWindowSplit): IAugmentedSplitInfo {
+        const augmentedWindows = Object.values(this._idToSplit)
+        return augmentedWindows.find(aw => aw.innerSplit === split) || null
     }
 
     private _focusNewSplit(newSplit: any): void {

--- a/browser/src/Services/WindowManager/WindowManagerStore.ts
+++ b/browser/src/Services/WindowManager/WindowManagerStore.ts
@@ -15,6 +15,8 @@ export interface IAugmentedSplitInfo extends Oni.IWindowSplit {
     // Internal bookkeeping
     id: string
 
+    innerSplit: Oni.IWindowSplit
+
     // Potential API methods
     enter?(): void
     leave?(): void

--- a/browser/src/Services/WindowManager/index.ts
+++ b/browser/src/Services/WindowManager/index.ts
@@ -8,6 +8,7 @@
  * to the active editor, and managing transitions between editors.
  */
 
+export * from "./layoutFromSplitInfo"
 export * from "./LinearSplitProvider"
 export * from "./RelationalSplitNavigator"
 export * from "./SingleSplitProvider"

--- a/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
+++ b/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
@@ -44,6 +44,8 @@ const layoutFromSplitInfoHelper = (
     }
 
     // Recursive case
+    //
+    // TODO: Handle specified sizes for the windows. We're just distributing the space evenly, currently.
     const splitWidth =
         split.direction === "horizontal" ? rectangle.width / split.splits.length : rectangle.width
     const splitHeight =

--- a/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
+++ b/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
@@ -8,7 +8,9 @@ import * as Oni from "oni-api"
 
 import { IAugmentedSplitInfo, ISplitInfo, SplitOrLeaf } from "./WindowManagerStore"
 
-export type LayoutResult = { [windowId: string]: Oni.Shapes.Rectangle }
+export interface LayoutResult {
+    [windowId: string]: Oni.Shapes.Rectangle
+}
 
 export const layoutFromSplitInfo = (
     splits: ISplitInfo<IAugmentedSplitInfo>,

--- a/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
+++ b/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
@@ -8,8 +8,13 @@ import * as Oni from "oni-api"
 
 import { IAugmentedSplitInfo, ISplitInfo, SplitOrLeaf } from "./WindowManagerStore"
 
+export interface LayoutResultInfo {
+    rectangle: Oni.Shapes.Rectangle
+    split: IAugmentedSplitInfo
+}
+
 export interface LayoutResult {
-    [windowId: string]: Oni.Shapes.Rectangle
+    [windowId: string]: LayoutResultInfo
 }
 
 export const layoutFromSplitInfo = (
@@ -26,7 +31,12 @@ const layoutFromSplitInfoHelper = (
 ): LayoutResult => {
     // Base case..
     if (split.type === "Leaf") {
-        return { [split.contents.id]: rectangle }
+        return {
+            [split.contents.id]: {
+                rectangle,
+                split: split.contents,
+            },
+        }
     }
 
     if (split.splits.length === 0) {

--- a/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
+++ b/browser/src/Services/WindowManager/layoutFromSplitInfo.ts
@@ -1,0 +1,55 @@
+/**
+ * layoutFromSplitInfo.ts
+ *
+ * Function to layout splits into a particular window
+ */
+
+import * as Oni from "oni-api"
+
+import { IAugmentedSplitInfo, ISplitInfo, SplitOrLeaf } from "./WindowManagerStore"
+
+export type LayoutResult = { [windowId: string]: Oni.Shapes.Rectangle }
+
+export const layoutFromSplitInfo = (
+    splits: ISplitInfo<IAugmentedSplitInfo>,
+    width: number,
+    height: number,
+): LayoutResult => {
+    return layoutFromSplitInfoHelper(splits, Oni.Shapes.Rectangle.create(0, 0, width, height))
+}
+
+const layoutFromSplitInfoHelper = (
+    split: SplitOrLeaf<IAugmentedSplitInfo>,
+    rectangle: Oni.Shapes.Rectangle,
+): LayoutResult => {
+    // Base case..
+    if (split.type === "Leaf") {
+        return { [split.contents.id]: rectangle }
+    }
+
+    if (split.splits.length === 0) {
+        return {}
+    }
+
+    // Recursive case
+    const splitWidth =
+        split.direction === "horizontal" ? rectangle.width / split.splits.length : rectangle.width
+    const splitHeight =
+        split.direction === "vertical" ? rectangle.height / split.splits.length : rectangle.height
+
+    let ret = {}
+
+    for (let i = 0; i < split.splits.length; i++) {
+        const x = split.direction === "horizontal" ? rectangle.x + splitWidth * i : rectangle.x
+        const y = split.direction === "vertical" ? rectangle.y + splitHeight * i : rectangle.y
+
+        const rect = Oni.Shapes.Rectangle.create(x, y, splitWidth, splitHeight)
+
+        ret = {
+            ...ret,
+            ...layoutFromSplitInfoHelper(split.splits[i], rect),
+        }
+    }
+
+    return ret
+}

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -100,7 +100,7 @@ export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, 
                                 <div style={style}>
                                     <WindowSplitHost
                                         key={item.split.id}
-                                        containerClassName="split"
+                                        containerClassName="editor"
                                         split={item.split}
                                         isFocused={this.props.activeSplitId === item.split.id}
                                         onClick={() => {

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -5,14 +5,15 @@
  */
 
 import * as React from "react"
-
 import { connect } from "react-redux"
+import { AutoSizer } from "react-virtualized"
 
 import { WindowSplitHost } from "./WindowSplitHost"
 
 import {
     IAugmentedSplitInfo,
     ISplitInfo,
+    layoutFromSplitInfo,
     leftDockSelector,
     WindowManager,
     WindowState,
@@ -61,10 +62,6 @@ export interface IWindowSplitViewProps {
     split: ISplitInfo<IAugmentedSplitInfo>
     windowManager: WindowManager
 }
-
-import { layoutFromSplitInfo } from "./../../Services/WindowManager"
-
-import { AutoSizer } from "react-virtualized"
 
 const px = (num: number): string => num.toString() + "px"
 

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -85,6 +85,7 @@ export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, 
     public render(): JSX.Element {
         const className = "container horizontal full"
 
+        // TODO: Add drag handles here to allow for resizing!
         return (
             <div className={className}>
                 <AutoSizer>

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -69,12 +69,14 @@ import { AutoSizer } from "react-virtualized"
 const px = (num: number): string => num.toString() + "px"
 
 const rectangleToStyleProperties = (rect: Oni.Shapes.Rectangle): React.CSSProperties => {
+    const halfPadding = 3
+    const topPosition = rect.y === 0 ? 0 : Math.ceil(rect.y) + halfPadding
     return {
         position: "absolute",
-        top: px(rect.y),
-        left: px(rect.x),
-        width: px(rect.width),
-        height: px(rect.height),
+        top: px(topPosition),
+        left: px(Math.ceil(rect.x) + halfPadding),
+        width: px(Math.floor(rect.width) - halfPadding * 2),
+        height: px(Math.floor(rect.height) - halfPadding * 2),
     }
 }
 import * as Oni from "oni-api"

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -98,7 +98,9 @@ export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, 
                                         containerClassName="split"
                                         split={item.split}
                                         isFocused={this.props.activeSplitId === item.split.id}
-                                        onClick={noop}
+                                        onClick={() => {
+                                            this.props.windowManager.focusSplit(split.id)
+                                        }}
                                     />
                                 </div>
                             )

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -65,15 +65,20 @@ export interface IWindowSplitViewProps {
 
 const px = (num: number): string => num.toString() + "px"
 
-const rectangleToStyleProperties = (rect: Oni.Shapes.Rectangle): React.CSSProperties => {
+const rectangleToStyleProperties = (
+    rect: Oni.Shapes.Rectangle,
+    totalHeight: number,
+): React.CSSProperties => {
     const halfPadding = 3
     const topPosition = rect.y === 0 ? 0 : Math.ceil(rect.y) + halfPadding
+
+    const bottomPadding = Math.ceil(rect.y + rect.height) >= totalHeight ? 0 : halfPadding * 2
     return {
         position: "absolute",
         top: px(topPosition),
         left: px(Math.ceil(rect.x) + halfPadding),
         width: px(Math.floor(rect.width) - halfPadding * 2),
-        height: px(Math.floor(rect.height) - halfPadding * 2),
+        height: px(Math.floor(rect.height) - bottomPadding),
     }
 }
 import * as Oni from "oni-api"
@@ -90,7 +95,7 @@ export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, 
                         // return <div>{width}{height}</div>
                         const items = layoutFromSplitInfo(this.props.split, width, height)
                         const vals: JSX.Element[] = Object.values(items).map(item => {
-                            const style = rectangleToStyleProperties(item.rectangle)
+                            const style = rectangleToStyleProperties(item.rectangle, height)
                             return (
                                 <div style={style}>
                                     <WindowSplitHost

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -99,7 +99,7 @@ export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, 
                                         split={item.split}
                                         isFocused={this.props.activeSplitId === item.split.id}
                                         onClick={() => {
-                                            this.props.windowManager.focusSplit(split.id)
+                                            this.props.windowManager.focusSplit(item.split.id)
                                         }}
                                     />
                                 </div>

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -62,53 +62,52 @@ export interface IWindowSplitViewProps {
     windowManager: WindowManager
 }
 
+import { layoutFromSplitInfo } from "./../../Services/WindowManager"
+
+import { AutoSizer } from "react-virtualized"
+
+const px = (num: number): string => num.toString() + "px"
+
+const rectangleToStyleProperties = (rect: Oni.Shapes.Rectangle): React.CSSProperties => {
+    return {
+        position: "absolute",
+        top: px(rect.y),
+        left: px(rect.x),
+        width: px(rect.width),
+        height: px(rect.height),
+    }
+}
+import * as Oni from "oni-api"
+
 export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, {}> {
     public render(): JSX.Element {
-        const className =
-            this.props.split.direction === "horizontal"
-                ? "container horizontal full"
-                : "container vertical full"
-        const dividerClassName =
-            this.props.split.direction === "horizontal"
-                ? "split-spacer vertical"
-                : "split-spacer horizontal"
+        const className = "container horizontal full"
 
-        const splits = this.props.split.splits
-        const editors = splits.map((splitNode, i) => {
-            if (splitNode.type === "Split") {
-                return (
-                    <WindowSplitView
-                        split={splitNode}
-                        activeSplitId={this.props.activeSplitId}
-                        windowManager={this.props.windowManager}
-                    />
-                )
-            } else {
-                const split: IAugmentedSplitInfo = splitNode.contents
-
-                if (!split) {
-                    return null
-                } else {
-                    const divider = i !== 0 ? <div className={dividerClassName} /> : null
-                    return (
-                        <div className={className}>
-                            {divider}
-                            <WindowSplitHost
-                                containerClassName={"editor"}
-                                key={i}
-                                split={split}
-                                isFocused={split.id === this.props.activeSplitId}
-                                onClick={() => {
-                                    this.props.windowManager.focusSplit(split.id)
-                                }}
-                            />
-                        </div>
-                    )
-                }
-            }
-        })
-
-        return <div className={className}>{editors}</div>
+        return (
+            <div className={className}>
+                <AutoSizer>
+                    {({ height, width }) => {
+                        // return <div>{width}{height}</div>
+                        const items = layoutFromSplitInfo(this.props.split, width, height)
+                        const vals: JSX.Element[] = Object.values(items).map(item => {
+                            const style = rectangleToStyleProperties(item.rectangle)
+                            return (
+                                <div style={style}>
+                                    <WindowSplitHost
+                                        key={item.split.id}
+                                        containerClassName="split"
+                                        split={item.split}
+                                        isFocused={this.props.activeSplitId === item.split.id}
+                                        onClick={noop}
+                                    />
+                                </div>
+                            )
+                        })
+                        return <div style={{ position: "relative" }}>{vals}</div>
+                    }}
+                </AutoSizer>
+            </div>
+        )
     }
 }
 

--- a/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
+++ b/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
@@ -157,9 +157,9 @@ describe("LinearSplitProviderTests", () => {
             splitProvider.split(mockSplit1, "vertical", mockSplit0)
 
             // Now, add a horizontal split against mockSplit1
-            const split2 = new MockWindowSplit()
+            const mockSplit2 = new MockWindowSplit()
 
-            splitProvider.split(split2, "horizontal", mockSplit1)
+            splitProvider.split(mockSplit2, "horizontal", mockSplit1)
 
             const state = splitProvider.getState()
 
@@ -178,7 +178,7 @@ describe("LinearSplitProviderTests", () => {
                 .splits[1] as any
 
             assert.strictEqual(verticalSplitRightChild0.contents, mockSplit1)
-            assert.strictEqual(verticalSplitRightChild1.contents, split2)
+            assert.strictEqual(verticalSplitRightChild1.contents, mockSplit2)
         })
 
         // Test split arrangement like:
@@ -196,9 +196,9 @@ describe("LinearSplitProviderTests", () => {
             splitProvider.split(mockSplit1, "horizontal", mockSplit0)
 
             // Now, add a horizontal split against mockSplit1
-            const split2 = new MockWindowSplit("split2")
+            const mockSplit2 = new MockWindowSplit("mockSplit2")
 
-            splitProvider.split(split2, "vertical", mockSplit0)
+            splitProvider.split(mockSplit2, "vertical", mockSplit0)
 
             const state = splitProvider.getState()
 
@@ -223,7 +223,7 @@ describe("LinearSplitProviderTests", () => {
                 .splits[1] as any
 
             assert.strictEqual(horizontalSplitTopChild0.contents, mockSplit0)
-            assert.strictEqual(horizontalSplitTopChild1.contents, split2)
+            assert.strictEqual(horizontalSplitTopChild1.contents, mockSplit2)
         })
     })
 })

--- a/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
+++ b/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
@@ -4,11 +4,13 @@
 
 import * as assert from "assert"
 
-import { LinearSplitProvider } from "./../../../src/Services/WindowManager"
+import { LinearSplitProvider, ISplitLeaf, ISplitInfo } from "./../../../src/Services/WindowManager"
 
 export class MockWindowSplit {
+    constructor(private _id: string = "mock.window") {}
+
     public get id(): string {
-        return "mock.window"
+        return this._id
     }
 
     public get innerSplit(): any {
@@ -34,12 +36,12 @@ describe("LinearSplitProviderTests", () => {
         split2 = new MockWindowSplit()
 
         horizontalSplits = new LinearSplitProvider("horizontal")
-        horizontalSplits.split(split1, "horizontal")
-        horizontalSplits.split(split2, "horizontal", split1)
+        horizontalSplits.split(split1, "vertical")
+        horizontalSplits.split(split2, "vertical", split1)
 
         verticalSplits = new LinearSplitProvider("vertical")
-        verticalSplits.split(split1, "vertical")
-        verticalSplits.split(split2, "vertical")
+        verticalSplits.split(split1, "horizontal")
+        verticalSplits.split(split2, "horizontal")
     })
 
     it("contains returns true for included splits", () => {
@@ -91,6 +93,137 @@ describe("LinearSplitProviderTests", () => {
         it("creates nested split for different orientation", () => {
             const newSplit = new MockWindowSplit()
             horizontalSplits.split(newSplit, "vertical", split2)
+        })
+
+        it("switches orientation if there is no child", () => {
+            const splitProvider = new LinearSplitProvider("vertical")
+            const newSplit = new MockWindowSplit()
+            splitProvider.split(newSplit, "vertical")
+
+            const state = splitProvider.getState()
+
+            assert.strictEqual(state.direction, "horizontal")
+        })
+
+        it("simple vertical split case", () => {
+            const splitProvider = new LinearSplitProvider("horizontal")
+
+            const split0 = new MockWindowSplit()
+            const split1 = new MockWindowSplit()
+
+            splitProvider.split(split0, "vertical")
+            splitProvider.split(split1, "vertical", split0)
+
+            const state = splitProvider.getState()
+
+            const splitState0: ISplitLeaf<MockWindowSplit> = state.splits[0] as any
+            const splitState1: ISplitLeaf<MockWindowSplit> = state.splits[1] as any
+
+            assert.strictEqual(state.direction, "horizontal")
+            assert.strictEqual(splitState0.contents, split0)
+            assert.strictEqual(splitState1.contents, split1)
+        })
+
+        it("simple horizontal split case", () => {
+            const splitProvider = new LinearSplitProvider("vertical")
+
+            const split0 = new MockWindowSplit()
+            const split1 = new MockWindowSplit()
+
+            splitProvider.split(split0, "horizontal")
+            splitProvider.split(split1, "horizontal", split0)
+
+            const state = splitProvider.getState()
+
+            const splitState0: ISplitLeaf<MockWindowSplit> = state.splits[0] as any
+            const splitState1: ISplitLeaf<MockWindowSplit> = state.splits[1] as any
+
+            assert.strictEqual(state.direction, "vertical")
+            assert.strictEqual(splitState0.contents, split0)
+            assert.strictEqual(splitState1.contents, split1)
+        })
+
+        // Test split arrangement like:
+        // 0|1
+        // ---
+        // 0|2
+        it("nested horizontal split case", () => {
+            const splitProvider = new LinearSplitProvider("horizontal")
+
+            const split0 = new MockWindowSplit()
+            const split1 = new MockWindowSplit()
+
+            splitProvider.split(split0, "vertical")
+            splitProvider.split(split1, "vertical", split0)
+
+            // Now, add a horizontal split against split1
+            const split2 = new MockWindowSplit()
+
+            splitProvider.split(split2, "horizontal", split1)
+
+            const state = splitProvider.getState()
+
+            assert.strictEqual(state.direction, "horizontal", "Verify root is still horizontal")
+            const verticalSplitLeft = state.splits[0] as ISplitLeaf<MockWindowSplit>
+            assert.strictEqual(verticalSplitLeft.type, "Leaf")
+            assert.strictEqual(verticalSplitLeft.contents, split0)
+
+            const verticalSplitRight = state.splits[1] as ISplitInfo<MockWindowSplit>
+            assert.strictEqual(verticalSplitRight.type, "Split")
+            assert.strictEqual(verticalSplitRight.direction, "vertical", "Verify child is vertical")
+
+            const verticalSplitRightChild0: ISplitLeaf<MockWindowSplit> = verticalSplitRight
+                .splits[0] as any
+            const verticalSplitRightChild1: ISplitLeaf<MockWindowSplit> = verticalSplitRight
+                .splits[1] as any
+
+            assert.strictEqual(verticalSplitRightChild0.contents, split1)
+            assert.strictEqual(verticalSplitRightChild1.contents, split2)
+        })
+
+        // Test split arrangement like:
+        // 0|2
+        // ---
+        // 111
+
+        it("nested vertical split case", () => {
+            const splitProvider = new LinearSplitProvider("vertical")
+
+            const split0 = new MockWindowSplit("split0")
+            const split1 = new MockWindowSplit("split1")
+
+            splitProvider.split(split0, "horizontal")
+            splitProvider.split(split1, "horizontal", split0)
+
+            // Now, add a horizontal split against split1
+            const split2 = new MockWindowSplit("split2")
+
+            splitProvider.split(split2, "vertical", split0)
+
+            const state = splitProvider.getState()
+
+            assert.strictEqual(state.direction, "vertical", "Verify root is still vertical")
+
+            // Verify bottom leaf is as expected
+            const horizontalSplitBottom = state.splits[1] as ISplitLeaf<MockWindowSplit>
+            assert.strictEqual(horizontalSplitBottom.type, "Leaf")
+            assert.strictEqual(horizontalSplitBottom.contents, split1)
+
+            const horizontalSplitTop = state.splits[0] as ISplitInfo<MockWindowSplit>
+            assert.strictEqual(horizontalSplitTop.type, "Split")
+            assert.strictEqual(
+                horizontalSplitTop.direction,
+                "horizontal",
+                "Verify child is horizontal",
+            )
+
+            const horizontalSplitTopChild0: ISplitLeaf<MockWindowSplit> = horizontalSplitTop
+                .splits[0] as any
+            const horizontalSplitTopChild1: ISplitLeaf<MockWindowSplit> = horizontalSplitTop
+                .splits[1] as any
+
+            assert.strictEqual(horizontalSplitTopChild0.contents, split0)
+            assert.strictEqual(horizontalSplitTopChild1.contents, split2)
         })
     })
 })

--- a/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
+++ b/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
@@ -4,7 +4,7 @@
 
 import * as assert from "assert"
 
-import { LinearSplitProvider, ISplitLeaf, ISplitInfo } from "./../../../src/Services/WindowManager"
+import { ISplitInfo, ISplitLeaf, LinearSplitProvider } from "./../../../src/Services/WindowManager"
 
 export class MockWindowSplit {
     constructor(private _id: string = "mock.window") {}
@@ -108,11 +108,11 @@ describe("LinearSplitProviderTests", () => {
         it("simple vertical split case", () => {
             const splitProvider = new LinearSplitProvider("horizontal")
 
-            const split0 = new MockWindowSplit()
-            const split1 = new MockWindowSplit()
+            const mockSplit0 = new MockWindowSplit()
+            const mockSplit1 = new MockWindowSplit()
 
-            splitProvider.split(split0, "vertical")
-            splitProvider.split(split1, "vertical", split0)
+            splitProvider.split(mockSplit0, "vertical")
+            splitProvider.split(mockSplit1, "vertical", mockSplit0)
 
             const state = splitProvider.getState()
 
@@ -120,18 +120,18 @@ describe("LinearSplitProviderTests", () => {
             const splitState1: ISplitLeaf<MockWindowSplit> = state.splits[1] as any
 
             assert.strictEqual(state.direction, "horizontal")
-            assert.strictEqual(splitState0.contents, split0)
-            assert.strictEqual(splitState1.contents, split1)
+            assert.strictEqual(splitState0.contents, mockSplit0)
+            assert.strictEqual(splitState1.contents, mockSplit1)
         })
 
         it("simple horizontal split case", () => {
             const splitProvider = new LinearSplitProvider("vertical")
 
-            const split0 = new MockWindowSplit()
-            const split1 = new MockWindowSplit()
+            const mockSplit0 = new MockWindowSplit()
+            const mockSplit1 = new MockWindowSplit()
 
-            splitProvider.split(split0, "horizontal")
-            splitProvider.split(split1, "horizontal", split0)
+            splitProvider.split(mockSplit0, "horizontal")
+            splitProvider.split(mockSplit1, "horizontal", mockSplit0)
 
             const state = splitProvider.getState()
 
@@ -139,8 +139,8 @@ describe("LinearSplitProviderTests", () => {
             const splitState1: ISplitLeaf<MockWindowSplit> = state.splits[1] as any
 
             assert.strictEqual(state.direction, "vertical")
-            assert.strictEqual(splitState0.contents, split0)
-            assert.strictEqual(splitState1.contents, split1)
+            assert.strictEqual(splitState0.contents, mockSplit0)
+            assert.strictEqual(splitState1.contents, mockSplit1)
         })
 
         // Test split arrangement like:
@@ -150,23 +150,23 @@ describe("LinearSplitProviderTests", () => {
         it("nested horizontal split case", () => {
             const splitProvider = new LinearSplitProvider("horizontal")
 
-            const split0 = new MockWindowSplit()
-            const split1 = new MockWindowSplit()
+            const mockSplit0 = new MockWindowSplit()
+            const mockSplit1 = new MockWindowSplit()
 
-            splitProvider.split(split0, "vertical")
-            splitProvider.split(split1, "vertical", split0)
+            splitProvider.split(mockSplit0, "vertical")
+            splitProvider.split(mockSplit1, "vertical", mockSplit0)
 
-            // Now, add a horizontal split against split1
+            // Now, add a horizontal split against mockSplit1
             const split2 = new MockWindowSplit()
 
-            splitProvider.split(split2, "horizontal", split1)
+            splitProvider.split(split2, "horizontal", mockSplit1)
 
             const state = splitProvider.getState()
 
             assert.strictEqual(state.direction, "horizontal", "Verify root is still horizontal")
             const verticalSplitLeft = state.splits[0] as ISplitLeaf<MockWindowSplit>
             assert.strictEqual(verticalSplitLeft.type, "Leaf")
-            assert.strictEqual(verticalSplitLeft.contents, split0)
+            assert.strictEqual(verticalSplitLeft.contents, mockSplit0)
 
             const verticalSplitRight = state.splits[1] as ISplitInfo<MockWindowSplit>
             assert.strictEqual(verticalSplitRight.type, "Split")
@@ -177,7 +177,7 @@ describe("LinearSplitProviderTests", () => {
             const verticalSplitRightChild1: ISplitLeaf<MockWindowSplit> = verticalSplitRight
                 .splits[1] as any
 
-            assert.strictEqual(verticalSplitRightChild0.contents, split1)
+            assert.strictEqual(verticalSplitRightChild0.contents, mockSplit1)
             assert.strictEqual(verticalSplitRightChild1.contents, split2)
         })
 
@@ -189,16 +189,16 @@ describe("LinearSplitProviderTests", () => {
         it("nested vertical split case", () => {
             const splitProvider = new LinearSplitProvider("vertical")
 
-            const split0 = new MockWindowSplit("split0")
-            const split1 = new MockWindowSplit("split1")
+            const mockSplit0 = new MockWindowSplit("mockSplit0")
+            const mockSplit1 = new MockWindowSplit("mockSplit1")
 
-            splitProvider.split(split0, "horizontal")
-            splitProvider.split(split1, "horizontal", split0)
+            splitProvider.split(mockSplit0, "horizontal")
+            splitProvider.split(mockSplit1, "horizontal", mockSplit0)
 
-            // Now, add a horizontal split against split1
+            // Now, add a horizontal split against mockSplit1
             const split2 = new MockWindowSplit("split2")
 
-            splitProvider.split(split2, "vertical", split0)
+            splitProvider.split(split2, "vertical", mockSplit0)
 
             const state = splitProvider.getState()
 
@@ -207,7 +207,7 @@ describe("LinearSplitProviderTests", () => {
             // Verify bottom leaf is as expected
             const horizontalSplitBottom = state.splits[1] as ISplitLeaf<MockWindowSplit>
             assert.strictEqual(horizontalSplitBottom.type, "Leaf")
-            assert.strictEqual(horizontalSplitBottom.contents, split1)
+            assert.strictEqual(horizontalSplitBottom.contents, mockSplit1)
 
             const horizontalSplitTop = state.splits[0] as ISplitInfo<MockWindowSplit>
             assert.strictEqual(horizontalSplitTop.type, "Split")
@@ -222,7 +222,7 @@ describe("LinearSplitProviderTests", () => {
             const horizontalSplitTopChild1: ISplitLeaf<MockWindowSplit> = horizontalSplitTop
                 .splits[1] as any
 
-            assert.strictEqual(horizontalSplitTopChild0.contents, split0)
+            assert.strictEqual(horizontalSplitTopChild0.contents, mockSplit0)
             assert.strictEqual(horizontalSplitTopChild1.contents, split2)
         })
     })

--- a/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
+++ b/browser/test/Services/WindowManager/LinearSplitProviderTests.ts
@@ -11,6 +11,10 @@ export class MockWindowSplit {
         return "mock.window"
     }
 
+    public get innerSplit(): any {
+        return null
+    }
+
     public render(): JSX.Element {
         return null
     }

--- a/browser/test/Services/WindowManager/RelationalSplitNavigatorTests.ts.ts
+++ b/browser/test/Services/WindowManager/RelationalSplitNavigatorTests.ts.ts
@@ -14,6 +14,10 @@ export class MockWindowSplit {
         return "mock.window"
     }
 
+    public get innerSplit(): any {
+        return null
+    }
+
     public render(): JSX.Element {
         return null
     }

--- a/browser/test/Services/WindowManager/layoutFromSplitInfoTests.ts
+++ b/browser/test/Services/WindowManager/layoutFromSplitInfoTests.ts
@@ -1,0 +1,129 @@
+/**
+ * layoutFromSplitInfoTests.ts
+ */
+
+import * as assert from "assert"
+import * as Oni from "oni-api"
+
+import { ISplitInfo, layoutFromSplitInfo } from "./../../../src/Services/WindowManager"
+
+import { MockWindowSplit } from "./LinearSplitProviderTests"
+
+describe("layoutFromSplitInfoTests", () => {
+    it("returns empty if no splits", () => {
+        const emptySplit: ISplitInfo<MockWindowSplit> = {
+            type: "Split",
+            splits: [] as any,
+            direction: "horizontal",
+        }
+
+        const result = layoutFromSplitInfo(emptySplit, 100, 100)
+        assert.deepEqual(result, {})
+    })
+
+    it("gives full layout to a single item", () => {
+        const split: ISplitInfo<MockWindowSplit> = {
+            type: "Split",
+            splits: [
+                {
+                    type: "Leaf",
+                    contents: new MockWindowSplit("windowSplit1"),
+                },
+            ] as any,
+            direction: "horizontal",
+        }
+
+        const result = layoutFromSplitInfo(split, 100, 100)
+
+        assert.deepEqual(result, {
+            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 100, 100),
+        })
+    })
+
+    it("splits layout between two vertical items", () => {
+        const split: ISplitInfo<MockWindowSplit> = {
+            type: "Split",
+            splits: [
+                {
+                    type: "Leaf",
+                    contents: new MockWindowSplit("windowSplit1"),
+                },
+                {
+                    type: "Leaf",
+                    contents: new MockWindowSplit("windowSplit2"),
+                },
+            ] as any,
+            direction: "horizontal",
+        }
+
+        const result = layoutFromSplitInfo(split, 100, 100)
+
+        assert.deepEqual(result, {
+            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 50, 100),
+            windowSplit2: Oni.Shapes.Rectangle.create(50, 0, 50, 100),
+        })
+    })
+
+    it("splits layout between two horizontal items", () => {
+        const split: ISplitInfo<MockWindowSplit> = {
+            type: "Split",
+            splits: [
+                {
+                    type: "Leaf",
+                    contents: new MockWindowSplit("windowSplit1"),
+                },
+                {
+                    type: "Leaf",
+                    contents: new MockWindowSplit("windowSplit2"),
+                },
+            ] as any,
+            direction: "vertical",
+        }
+
+        const result = layoutFromSplitInfo(split, 100, 100)
+
+        assert.deepEqual(result, {
+            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 100, 50),
+            windowSplit2: Oni.Shapes.Rectangle.create(0, 50, 100, 50),
+        })
+    })
+
+    it("nested layout - splits between a vertical item, and then nested horizontal items", () => {
+        // 1|2
+        // ---
+        // 1|3
+
+        const split: ISplitInfo<MockWindowSplit> = {
+            type: "Split",
+            splits: [
+                {
+                    type: "Leaf",
+                    contents: new MockWindowSplit("windowSplit1"),
+                },
+                {
+                    type: "Split",
+                    splits: [
+                        {
+                            type: "Leaf",
+                            contents: new MockWindowSplit("windowSplit2"),
+                        },
+                        {
+                            type: "Leaf",
+                            contents: new MockWindowSplit("windowSplit3"),
+                        },
+                    ],
+                    direction: "vertical",
+                },
+            ] as any,
+            direction: "horizontal",
+        }
+
+        const result = layoutFromSplitInfo(split, 100, 100)
+
+        assert.deepEqual(result, {
+            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 50, 100),
+            windowSplit2: Oni.Shapes.Rectangle.create(50, 0, 50, 50),
+            windowSplit3: Oni.Shapes.Rectangle.create(50, 50, 50, 50),
+        })
+    })
+})

--- a/browser/test/Services/WindowManager/layoutFromSplitInfoTests.ts
+++ b/browser/test/Services/WindowManager/layoutFromSplitInfoTests.ts
@@ -9,6 +9,11 @@ import { ISplitInfo, layoutFromSplitInfo } from "./../../../src/Services/WindowM
 
 import { MockWindowSplit } from "./LinearSplitProviderTests"
 
+const resultFromSplitAndRect = (rectangle: Oni.Shapes.Rectangle, split: MockWindowSplit) => ({
+    split,
+    rectangle,
+})
+
 describe("layoutFromSplitInfoTests", () => {
     it("returns empty if no splits", () => {
         const emptySplit: ISplitInfo<MockWindowSplit> = {
@@ -22,12 +27,13 @@ describe("layoutFromSplitInfoTests", () => {
     })
 
     it("gives full layout to a single item", () => {
+        const split1 = new MockWindowSplit("windowSplit1")
         const split: ISplitInfo<MockWindowSplit> = {
             type: "Split",
             splits: [
                 {
                     type: "Leaf",
-                    contents: new MockWindowSplit("windowSplit1"),
+                    contents: split1,
                 },
             ] as any,
             direction: "horizontal",
@@ -36,21 +42,26 @@ describe("layoutFromSplitInfoTests", () => {
         const result = layoutFromSplitInfo(split, 100, 100)
 
         assert.deepEqual(result, {
-            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 100, 100),
+            windowSplit1: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(0, 0, 100, 100),
+                split1,
+            ),
         })
     })
 
     it("splits layout between two vertical items", () => {
+        const split1 = new MockWindowSplit("windowSplit1")
+        const split2 = new MockWindowSplit("windowSplit2")
         const split: ISplitInfo<MockWindowSplit> = {
             type: "Split",
             splits: [
                 {
                     type: "Leaf",
-                    contents: new MockWindowSplit("windowSplit1"),
+                    contents: split1,
                 },
                 {
                     type: "Leaf",
-                    contents: new MockWindowSplit("windowSplit2"),
+                    contents: split2,
                 },
             ] as any,
             direction: "horizontal",
@@ -59,22 +70,31 @@ describe("layoutFromSplitInfoTests", () => {
         const result = layoutFromSplitInfo(split, 100, 100)
 
         assert.deepEqual(result, {
-            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 50, 100),
-            windowSplit2: Oni.Shapes.Rectangle.create(50, 0, 50, 100),
+            windowSplit1: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(0, 0, 50, 100),
+                split1,
+            ),
+            windowSplit2: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(50, 0, 50, 100),
+                split2,
+            ),
         })
     })
 
     it("splits layout between two horizontal items", () => {
+        const split1 = new MockWindowSplit("windowSplit1")
+        const split2 = new MockWindowSplit("windowSplit2")
+
         const split: ISplitInfo<MockWindowSplit> = {
             type: "Split",
             splits: [
                 {
                     type: "Leaf",
-                    contents: new MockWindowSplit("windowSplit1"),
+                    contents: split1,
                 },
                 {
                     type: "Leaf",
-                    contents: new MockWindowSplit("windowSplit2"),
+                    contents: split2,
                 },
             ] as any,
             direction: "vertical",
@@ -83,8 +103,14 @@ describe("layoutFromSplitInfoTests", () => {
         const result = layoutFromSplitInfo(split, 100, 100)
 
         assert.deepEqual(result, {
-            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 100, 50),
-            windowSplit2: Oni.Shapes.Rectangle.create(0, 50, 100, 50),
+            windowSplit1: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(0, 0, 100, 50),
+                split1,
+            ),
+            windowSplit2: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(0, 50, 100, 50),
+                split2,
+            ),
         })
     })
 
@@ -92,24 +118,27 @@ describe("layoutFromSplitInfoTests", () => {
         // 1|2
         // ---
         // 1|3
+        const split1 = new MockWindowSplit("windowSplit1")
+        const split2 = new MockWindowSplit("windowSplit2")
+        const split3 = new MockWindowSplit("windowSplit3")
 
         const split: ISplitInfo<MockWindowSplit> = {
             type: "Split",
             splits: [
                 {
                     type: "Leaf",
-                    contents: new MockWindowSplit("windowSplit1"),
+                    contents: split1,
                 },
                 {
                     type: "Split",
                     splits: [
                         {
                             type: "Leaf",
-                            contents: new MockWindowSplit("windowSplit2"),
+                            contents: split2,
                         },
                         {
                             type: "Leaf",
-                            contents: new MockWindowSplit("windowSplit3"),
+                            contents: split3,
                         },
                     ],
                     direction: "vertical",
@@ -121,9 +150,18 @@ describe("layoutFromSplitInfoTests", () => {
         const result = layoutFromSplitInfo(split, 100, 100)
 
         assert.deepEqual(result, {
-            windowSplit1: Oni.Shapes.Rectangle.create(0, 0, 50, 100),
-            windowSplit2: Oni.Shapes.Rectangle.create(50, 0, 50, 50),
-            windowSplit3: Oni.Shapes.Rectangle.create(50, 50, 50, 50),
+            windowSplit1: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(0, 0, 50, 100),
+                split1,
+            ),
+            windowSplit2: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(50, 0, 50, 50),
+                split2,
+            ),
+            windowSplit3: resultFromSplitAndRect(
+                Oni.Shapes.Rectangle.create(50, 50, 50, 50),
+                split3,
+            ),
         })
     })
 })

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -243,3 +243,8 @@ nnoremap <silent> <C-w><C-h> :<C-u>call OniNextWindow('h')<CR>
 nnoremap <silent> <C-w><C-j> :<C-u>call OniNextWindow('j')<CR>
 nnoremap <silent> <C-w><C-k> :<C-u>call OniNextWindow('k')<CR>
 nnoremap <silent> <C-w><C-l> :<C-u>call OniNextWindow('l')<CR>
+
+nnoremap <silent> <C-w><s> :<C-u>call OniCommand('editor.split.horizontal')<CR>)
+nnoremap <silent> <C-w><C-s> :<C-u>call OniCommand('editor.split.horizontal')<CR>)
+nnoremap <silent> <C-w><v> :<C-u>call OniCommand('editor.split.vertical')<CR>)
+nnoremap <silent> <C-w><C-v> :<C-u>call OniCommand('editor.split.vertical')<CR>)


### PR DESCRIPTION
This implements basic split rendering for Oni (this isn't on by default, is only available with `oni.splits.mode`: `'oni'`, and there isn't an entry point to hit this other than calling directly in the console)

But it lets you do crazy stuff like this:
![image](https://user-images.githubusercontent.com/13532591/36869175-b6ee5e46-1d4f-11e8-9b4b-00a5f4f4919d.png)

I don't even know what is going on there 😄


