### PR TITLE
Scripts: Remove 'lib_test' folder prior to building / running unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && npm run build",
         "build:test": "npm run build:test:unit && npm run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
-        "build:test:unit": "cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit": "rimraf lib_test && cd browser && tsc -p tsconfig.test.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
         "copy-dist-to-s3": "node build/script/CopyPackedFilesForS3Upload.js",


### PR DESCRIPTION
Stale files cause problems in the unit tests folder, especially when hopping between branches. Sometimes an outdated / moved file that was built earlier sticks around, gets run, and fails. I don't want anyone to waste time debugging those, so deleting that folder prior to build makes sense IMO