### PR TITLE
QuickOpen: Add key to open existing tab

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -259,7 +259,6 @@ export class NeovimEditor extends Editor implements IEditor {
             this._contextMenuManager,
             this._definition,
             this._languageIntegration,
-            this._menuManager,
             this._neovimInstance,
             this._rename,
             this._symbols,

--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -13,7 +13,6 @@ import { NeovimInstance } from "./../../neovim"
 import { CallbackCommand, CommandManager } from "./../../Services/CommandManager"
 import { ContextMenuManager } from "./../../Services/ContextMenu"
 import { findAllReferences, format, LanguageEditorIntegration } from "./../../Services/Language"
-import { MenuManager } from "./../../Services/Menu"
 import { replaceAll } from "./../../Utility"
 
 import { Definition } from "./Definition"
@@ -28,7 +27,6 @@ export class NeovimEditorCommands {
         private _contextMenuManager: ContextMenuManager,
         private _definition: Definition,
         private _languageEditorIntegration: LanguageEditorIntegration,
-        private _menuManager: MenuManager,
         private _neovimInstance: NeovimInstance,
         private _rename: Rename,
         private _symbols: Symbols,
@@ -76,10 +74,6 @@ export class NeovimEditorCommands {
             await neovimInstance.command("set paste")
             await neovimInstance.input(sanitizedText)
             await neovimInstance.command("set nopaste")
-        }
-
-        const shouldShowMenu = () => {
-            return !this._menuManager.isMenuOpen()
         }
 
         const commands = [

--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -14,7 +14,6 @@ import { CallbackCommand, CommandManager } from "./../../Services/CommandManager
 import { ContextMenuManager } from "./../../Services/ContextMenu"
 import { findAllReferences, format, LanguageEditorIntegration } from "./../../Services/Language"
 import { MenuManager } from "./../../Services/Menu"
-import { QuickOpen } from "./../../Services/QuickOpen"
 import { replaceAll } from "./../../Utility"
 
 import { Definition } from "./Definition"
@@ -37,27 +36,6 @@ export class NeovimEditorCommands {
 
     public activate(): void {
         const isContextMenuOpen = () => this._contextMenuManager.isMenuOpen()
-
-        // TODO: This should be extracted
-        // - Should not depend on NeovimInstance
-        // - Should be able to work against the public 'IEditor' interface
-        const quickOpen = new QuickOpen(this._menuManager, this._neovimInstance)
-
-        const quickOpenCommand = (innerCommand: Oni.Commands.CommandCallback) => (
-            qo: QuickOpen,
-        ) => {
-            return () => {
-                if (qo.isOpen()) {
-                    return innerCommand(qo)
-                }
-
-                return false
-            }
-        }
-
-        const quickOpenFileNewTab = quickOpenCommand((qo: QuickOpen) => qo.openFileNewTab())
-        const quickOpenFileHorizontal = quickOpenCommand((qo: QuickOpen) => qo.openFileHorizontal())
-        const quickOpenFileVertical = quickOpenCommand((qo: QuickOpen) => qo.openFileVertical())
 
         /**
          * Higher-order function for commands dealing with completion
@@ -194,36 +172,6 @@ export class NeovimEditorCommands {
                 "Configuration: Edit Neovim Config",
                 "Edit configuration file ('init.vim') for Neovim",
                 () => this._neovimInstance.openInitVim(),
-            ),
-
-            // TODO: Factor these out
-            new CallbackCommand(
-                "quickOpen.show",
-                null,
-                null,
-                () => quickOpen.show(),
-                shouldShowMenu,
-            ),
-            new CallbackCommand("quickOpen.showBufferLines", null, null, () =>
-                quickOpen.showBufferLines(),
-            ),
-            new CallbackCommand(
-                "quickOpen.openFileNewTab",
-                null,
-                null,
-                quickOpenFileNewTab(quickOpen),
-            ),
-            new CallbackCommand(
-                "quickOpen.openFileVertical",
-                null,
-                null,
-                quickOpenFileVertical(quickOpen),
-            ),
-            new CallbackCommand(
-                "quickOpen.openFileHorizontal",
-                null,
-                null,
-                quickOpenFileHorizontal(quickOpen),
             ),
         ]
 

--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -84,9 +84,10 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
 
     // QuickOpen
     input.bind("<C-/>", "quickOpen.showBufferLines", isNormalMode)
-    input.bind(["<c-enter", "<C-v>"], "quickOpen.openFileVertical")
-    input.bind(["<s-enter", "<C-s>"], "quickOpen.openFileHorizontal")
+    input.bind(["<C-v>"], "quickOpen.openFileVertical")
+    input.bind(["<C-s>"], "quickOpen.openFileHorizontal")
     input.bind("<C-t>", "quickOpen.openFileNewTab")
+    input.bind(["<C-enter>"], "quickOpen.openFileExistingTab")
 
     // Snippets
     input.bind("<tab>", "snippet.nextPlaceholder")

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -10,6 +10,7 @@ import * as path from "path"
 
 import * as Oni from "oni-api"
 
+import { CommandManager } from "./../CommandManager"
 import { configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 import { Workspace } from "./../Workspace"
@@ -109,7 +110,7 @@ export class QuickOpen {
     public async showBufferLines() {
         let nu = 0
 
-        const currentLines = await editorManager.activeEditor.activeBuffer.getLines()
+        const currentLines = await this._editorManager.activeEditor.activeBuffer.getLines()
 
         const options = currentLines.map((line: string) => {
             return {

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -63,24 +63,10 @@ export class QuickOpen {
         return this._menu && this._menu.isOpen()
     }
 
-    public openFileNewTab(): void {
+    public openFile(openFileMode: Oni.FileOpenMode = Oni.FileOpenMode.NewTab): void {
         const selectedItem = this._menu.selectedItem
         if (selectedItem) {
-            this._onItemSelected(selectedItem, Oni.FileOpenMode.NewTab)
-        }
-    }
-
-    public openFileHorizontal(): void {
-        const selectedItem = this._menu.selectedItem
-        if (selectedItem) {
-            this._onItemSelected(selectedItem, Oni.FileOpenMode.HorizontalSplit)
-        }
-    }
-
-    public openFileVertical(): void {
-        const selectedItem = this._menu.selectedItem
-        if (selectedItem) {
-            this._onItemSelected(selectedItem, Oni.FileOpenMode.VerticalSplit)
+            this._onItemSelected(selectedItem, openFileMode)
         }
     }
 

--- a/browser/src/Services/QuickOpen/index.ts
+++ b/browser/src/Services/QuickOpen/index.ts
@@ -3,8 +3,8 @@ export * from "./QuickOpen"
 import * as Oni from "oni-api"
 
 import { CommandManager } from "./../CommandManager"
-import { MenuManager } from "./../Menu"
 import { EditorManager } from "./../EditorManager"
+import { MenuManager } from "./../Menu"
 import { Workspace } from "./../Workspace"
 
 import { QuickOpen } from "./QuickOpen"

--- a/browser/src/Services/QuickOpen/index.ts
+++ b/browser/src/Services/QuickOpen/index.ts
@@ -1,1 +1,75 @@
 export * from "./QuickOpen"
+
+import * as Oni from "oni-api"
+
+import { CommandManager } from "./../CommandManager"
+import { MenuManager } from "./../Menu"
+import { EditorManager } from "./../EditorManager"
+import { Workspace } from "./../Workspace"
+
+import { QuickOpen } from "./QuickOpen"
+
+let _quickOpen: QuickOpen = null
+
+export const activate = (
+    commandManager: CommandManager,
+    menuManager: MenuManager,
+    editorManager: EditorManager,
+    workspace: Workspace,
+) => {
+    const shouldShowMenu = () => {
+        return !menuManager.isMenuOpen()
+    }
+
+    const isOpen = () => _quickOpen.isOpen()
+
+    _quickOpen = new QuickOpen(menuManager, editorManager.activeEditor.neovim as any)
+
+    commandManager.registerCommand({
+        command: "quickOpen.show",
+        name: null,
+        detail: null,
+        execute: () => _quickOpen.show(),
+        enabled: shouldShowMenu,
+    })
+
+    commandManager.registerCommand({
+        command: "quickOpen.showBufferLines",
+        name: null,
+        detail: null,
+        execute: () => _quickOpen.showBufferLines(),
+        enabled: shouldShowMenu,
+    })
+
+    commandManager.registerCommand({
+        command: "quickOpen.openFileNewTab",
+        name: null,
+        detail: null,
+        execute: () => _quickOpen.openFile(Oni.FileOpenMode.NewTab),
+        enabled: isOpen,
+    })
+
+    commandManager.registerCommand({
+        command: "quickOpen.openFileExistingTab",
+        name: null,
+        detail: null,
+        execute: () => _quickOpen.openFile(Oni.FileOpenMode.ExistingTab),
+        enabled: isOpen,
+    })
+
+    commandManager.registerCommand({
+        command: "quickOpen.openFileVertical",
+        name: null,
+        detail: null,
+        execute: () => _quickOpen.openFile(Oni.FileOpenMode.VerticalSplit),
+        enabled: isOpen,
+    })
+
+    commandManager.registerCommand({
+        command: "quickOpen.openFileHorizontal",
+        name: null,
+        detail: null,
+        execute: () => _quickOpen.openFile(Oni.FileOpenMode.HorizontalSplit),
+        enabled: isOpen,
+    })
+}

--- a/browser/src/Services/QuickOpen/index.ts
+++ b/browser/src/Services/QuickOpen/index.ts
@@ -23,7 +23,7 @@ export const activate = (
 
     const isOpen = () => _quickOpen.isOpen()
 
-    _quickOpen = new QuickOpen(menuManager, editorManager.activeEditor.neovim as any)
+    _quickOpen = new QuickOpen(commandManager, editorManager, menuManager, workspace)
 
     commandManager.registerCommand({
         command: "quickOpen.show",

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -47,6 +47,7 @@ const start = async (args: string[]): Promise<void> => {
     const notificationsPromise = import("./Services/Notifications")
     const snippetPromise = import("./Services/Snippets")
     const keyDisplayerPromise = import("./Services/KeyDisplayer")
+    const quickOpenPromise = import("./Services/QuickOpen")
     const taksPromise = import("./Services/Tasks")
     const workspacePromise = import("./Services/Workspace")
     const workspaceCommandsPromise = import("./Services/Workspace/WorkspaceCommands")
@@ -133,6 +134,9 @@ const start = async (args: string[]): Promise<void> => {
     const Menu = await menuPromise
     Menu.activate(configuration, overlayManager)
     const menuManager = Menu.getInstance()
+
+    const QuickOpen = await quickOpenPromise
+    QuickOpen.activate(commandManager, menuManager, editorManager, workspace)
 
     const Notifications = await notificationsPromise
     Notifications.activate(configuration, overlayManager)


### PR DESCRIPTION
One behavior I missed from the pre-tabification behavior is being able to open a file directly in a split. For example, I might go to a tab, `:vsp`, and then `Control+P` to open a file - but it opens in the new tab vs the new split. This is the desired behavior, as it works the way you expect in Atom/VSCode/Sublime/etc, but I still want a way to target the current _split_.

This changes adds a `Control-Enter` keybinding to open in the current split (existing tab). Note that we already have `C-v`, which opens in a vertical split, and `C-s`, which opens in a horizontal split, too (from QuickOpen).