### PR TITLE
Fix #1681 - Paths with spaces

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -403,6 +403,9 @@ export class NeovimEditor extends Editor implements IEditor {
         this._neovimInstance.autoCommands.onBufEnter.subscribe((evt: BufferEventContext) =>
             this._onBufEnter(evt),
         )
+        this._neovimInstance.autoCommands.onBufWinEnter.subscribe((evt: BufferEventContext) =>
+            this._onBufEnter(evt),
+        )
 
         this._neovimInstance.autoCommands.onFileTypeChanged.subscribe((evt: EventContext) =>
             this._onFileTypeChanged(evt),

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -760,7 +760,9 @@ export class NeovimEditor extends Editor implements IEditor {
             },
         )
 
-        await this._neovimInstance.command(`:${cmd[openOptions.openMode]} ${file}`)
+        await this._neovimInstance.command(
+            `:${cmd[openOptions.openMode]} ${this._escapeSpaces(file)}`,
+        )
         return this.activeBuffer
     }
 
@@ -985,6 +987,10 @@ export class NeovimEditor extends Editor implements IEditor {
         const buffers = [evt.current, ...existingBuffersWithoutCurrent].filter(b => !!b)
 
         this._actions.bufferEnter(buffers)
+    }
+
+    private _escapeSpaces(str: string): string {
+        return str.split(" ").join("\\ ")
     }
 
     private _onImeStart(): void {

--- a/browser/src/neovim/NeovimAutoCommands.ts
+++ b/browser/src/neovim/NeovimAutoCommands.ts
@@ -14,7 +14,7 @@ export interface INeovimAutoCommands {
     // Autocommands
     onBufEnter: IEvent<BufferEventContext>
     onBufWipeout: IEvent<BufferEventContext>
-    onBufWinEnter: IEvent<EventContext>
+    onBufWinEnter: IEvent<BufferEventContext>
     onBufDelete: IEvent<BufferEventContext>
     onBufUnload: IEvent<BufferEventContext>
     onBufWritePost: IEvent<EventContext>
@@ -35,7 +35,7 @@ export class NeovimAutoCommands {
     private _onBufWipeoutEvent = new Event<BufferEventContext>()
     private _onBufDeleteEvent = new Event<BufferEventContext>()
     private _onBufUnloadEvent = new Event<BufferEventContext>()
-    private _onBufWinEnterEvent = new Event<EventContext>()
+    private _onBufWinEnterEvent = new Event<BufferEventContext>()
     private _onFileTypeChangedEvent = new Event<EventContext>()
     private _onWinEnterEvent = new Event<EventContext>()
     private _onCursorMovedEvent = new Event<EventContext>()
@@ -58,7 +58,7 @@ export class NeovimAutoCommands {
         return this._onBufWritePostEvent
     }
 
-    public get onBufWinEnter(): IEvent<EventContext> {
+    public get onBufWinEnter(): IEvent<BufferEventContext> {
         return this._onBufWinEnterEvent
     }
 

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -63,7 +63,9 @@ export class NeovimWindowManager {
         const updateScroll = (evt: EventContext) => this._scrollObservable.next(evt)
         // First element of the BufEnter event is the current buffer
         this._neovimInstance.autoCommands.onBufEnter.subscribe(bufs => updateScroll(bufs.current))
-        this._neovimInstance.autoCommands.onBufWinEnter.subscribe(updateScroll)
+        this._neovimInstance.autoCommands.onBufWinEnter.subscribe(bufs =>
+            updateScroll(bufs.current),
+        )
         this._neovimInstance.onBufferUpdate.subscribe(buf => updateScroll(buf.eventContext))
         this._neovimInstance.autoCommands.onWinEnter.subscribe(updateScroll)
         this._neovimInstance.autoCommands.onCursorMoved.subscribe(updateScroll)

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -9,33 +9,35 @@ import { IFailedTest, Oni, runInProcTest } from "./common"
 
 const LongTimeout = 5000
 
-const CiTests = [
-    // Core functionality tests
-    "Api.Buffer.AddLayer",
-    "Api.Overlays.AddRemoveTest",
-    "AutoClosingPairsTest",
-    "AutoCompletionTest-CSS",
-    "AutoCompletionTest-HTML",
-    "AutoCompletionTest-TypeScript",
-    "Editor.ExternalCommandLineTest",
-    "Editor.BufferModifiedState",
-    "Editor.TabModifiedState",
-    "LargeFileTest",
-    "MarkdownPreviewTest",
-    "PaintPerformanceTest",
-    "QuickOpenTest",
-    "StatusBar-Mode",
-    "Neovim.InvalidInitVimHandlingTest",
-    "NoInstalledNeovim",
-    "Sidebar.ToggleSplitTest",
-    "WindowManager.ErrorBoundary",
-    "Workspace.ConfigurationTest",
-    // Regression Tests
-    "Regression.1251.NoAdditionalProcessesOnStartup",
-    "Regression.1296.SettingColorsTest",
-    "Regression.1295.UnfocusedWindowTest",
-    "TextmateHighlighting.ScopesOnEnterTest",
-]
+const CiTests = ["Editor.OpenFile.PathWithSpacesTest"]
+
+// const CiTests = [
+//     // Core functionality tests
+//     "Api.Buffer.AddLayer",
+//     "Api.Overlays.AddRemoveTest",
+//     "AutoClosingPairsTest",
+//     "AutoCompletionTest-CSS",
+//     "AutoCompletionTest-HTML",
+//     "AutoCompletionTest-TypeScript",
+//     "Editor.ExternalCommandLineTest",
+//     "Editor.BufferModifiedState",
+//     "Editor.TabModifiedState",
+//     "LargeFileTest",
+//     "MarkdownPreviewTest",
+//     "PaintPerformanceTest",
+//     "QuickOpenTest",
+//     "StatusBar-Mode",
+//     "Neovim.InvalidInitVimHandlingTest",
+//     "NoInstalledNeovim",
+//     "Sidebar.ToggleSplitTest",
+//     "WindowManager.ErrorBoundary",
+//     "Workspace.ConfigurationTest",
+//     // Regression Tests
+//     "Regression.1251.NoAdditionalProcessesOnStartup",
+//     "Regression.1296.SettingColorsTest",
+//     "Regression.1295.UnfocusedWindowTest",
+//     "TextmateHighlighting.ScopesOnEnterTest",
+// ]
 
 const WindowsOnlyTests = [
     // For some reason, the `beginFrameSubscription` call doesn't seem to work on OSX,

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -9,35 +9,34 @@ import { IFailedTest, Oni, runInProcTest } from "./common"
 
 const LongTimeout = 5000
 
-const CiTests = ["Editor.OpenFile.PathWithSpacesTest"]
-
-// const CiTests = [
-//     // Core functionality tests
-//     "Api.Buffer.AddLayer",
-//     "Api.Overlays.AddRemoveTest",
-//     "AutoClosingPairsTest",
-//     "AutoCompletionTest-CSS",
-//     "AutoCompletionTest-HTML",
-//     "AutoCompletionTest-TypeScript",
-//     "Editor.ExternalCommandLineTest",
-//     "Editor.BufferModifiedState",
-//     "Editor.TabModifiedState",
-//     "LargeFileTest",
-//     "MarkdownPreviewTest",
-//     "PaintPerformanceTest",
-//     "QuickOpenTest",
-//     "StatusBar-Mode",
-//     "Neovim.InvalidInitVimHandlingTest",
-//     "NoInstalledNeovim",
-//     "Sidebar.ToggleSplitTest",
-//     "WindowManager.ErrorBoundary",
-//     "Workspace.ConfigurationTest",
-//     // Regression Tests
-//     "Regression.1251.NoAdditionalProcessesOnStartup",
-//     "Regression.1296.SettingColorsTest",
-//     "Regression.1295.UnfocusedWindowTest",
-//     "TextmateHighlighting.ScopesOnEnterTest",
-// ]
+const CiTests = [
+    // Core functionality tests
+    "Api.Buffer.AddLayer",
+    "Api.Overlays.AddRemoveTest",
+    "AutoClosingPairsTest",
+    "AutoCompletionTest-CSS",
+    "AutoCompletionTest-HTML",
+    "AutoCompletionTest-TypeScript",
+    "Editor.ExternalCommandLineTest",
+    "Editor.BufferModifiedState",
+    "Editor.OpenFile.PathWithSpacesTest",
+    "Editor.TabModifiedState",
+    "LargeFileTest",
+    "MarkdownPreviewTest",
+    "PaintPerformanceTest",
+    "QuickOpenTest",
+    "StatusBar-Mode",
+    "Neovim.InvalidInitVimHandlingTest",
+    "NoInstalledNeovim",
+    "Sidebar.ToggleSplitTest",
+    "WindowManager.ErrorBoundary",
+    "Workspace.ConfigurationTest",
+    // Regression Tests
+    "Regression.1251.NoAdditionalProcessesOnStartup",
+    "Regression.1296.SettingColorsTest",
+    "Regression.1295.UnfocusedWindowTest",
+    "TextmateHighlighting.ScopesOnEnterTest",
+]
 
 const WindowsOnlyTests = [
     // For some reason, the `beginFrameSubscription` call doesn't seem to work on OSX,

--- a/test/ci/Editor.OpenFile.PathWithSpacesTest.ts
+++ b/test/ci/Editor.OpenFile.PathWithSpacesTest.ts
@@ -5,12 +5,12 @@
  */
 
 import * as assert from "assert"
-import * as os from "os"
 import * as fs from "fs"
+import * as os from "os"
 import * as path from "path"
 
-import * as Oni from "oni-api"
 import * as mkdirp from "mkdirp"
+import * as Oni from "oni-api"
 
 const folderName = "folder with spaces"
 const fileName = "file with spaces.txt"

--- a/test/ci/Editor.OpenFile.PathWithSpacesTest.ts
+++ b/test/ci/Editor.OpenFile.PathWithSpacesTest.ts
@@ -1,0 +1,39 @@
+/**
+ * Test script to validate opening a path with spaces works as expected.
+ *
+ * Regression test for #1681
+ */
+
+import * as assert from "assert"
+import * as os from "os"
+import * as fs from "fs"
+import * as path from "path"
+
+import * as Oni from "oni-api"
+import * as mkdirp from "mkdirp"
+
+const folderName = "folder with spaces"
+const fileName = "file with spaces.txt"
+const createTestFile = (): string => {
+    const fileFullPath = path.join(
+        os.tmpdir(),
+        new Date().getTime().toString(),
+        folderName,
+        fileName,
+    )
+    mkdirp.sync(path.dirname(fileFullPath))
+    fs.writeFileSync(fileFullPath, "test contents")
+    return fileFullPath
+}
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    const file = createTestFile()
+
+    await oni.editors.activeEditor.openFile(file, { openMode: Oni.FileOpenMode.Edit })
+
+    const openFiles = oni.editors.activeEditor.getBuffers()
+    assert.strictEqual(openFiles.length, 1, "Validate a single buffer was opened")
+    assert.strictEqual(openFiles[0].filePath, file, "Validate the filepath was correct")
+}

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -131,7 +131,7 @@ augroup OniEventListeners
     autocmd! BufWritePost * :call OniNotifyEvent("BufWritePost")
     autocmd! BufEnter * :call OniNotifyWithBuffers("BufEnter")
     autocmd! BufRead * :call OniNotifyWithBuffers("BufRead")
-    autocmd! BufWinEnter * :call OniNotifyEvent("BufWinEnter")
+    autocmd! BufWinEnter * :call OniNotifyWithBuffers("BufWinEnter")
     autocmd! ColorScheme * :call OniNotifyEvent("ColorScheme")
     autocmd! FileType * :call OniNotifyEvent("FileType")
     autocmd! WinEnter * :call OniNotifyEvent("WinEnter")


### PR DESCRIPTION
Looks like the move to change the way we open files caused a regression in paths with spaces - thanks @CrossR for catching it!

This fixes the issue by escaping spaces when we send the vim command for opening files, and adds a ci test to verify that we don't break this functionality down the road.

In addition, there was another problem - we weren't getting information on the buffer loaded via `tab drop` (which made it hard to verify in the test!), so this required a change to `init.vim` to make sure we're listening to the proper event (`BufWinEnter`).