### PR TITLE
Fix case where image layer was added to files w/o extension

### DIFF
--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -335,8 +335,9 @@ export class LanguageManager {
             const languages = this._pluginManager.getAllContributionsOfType<
                 Capabilities.ILanguageContribution
             >(contributes => contributes.languages)
-            const matchingLanguages = languages.filter(l =>
-                l.extensions.indexOf(path.extname(filePath)),
+            const extension = path.extname(filePath)
+            const matchingLanguages = languages.filter(
+                l => l.extensions.indexOf(extension) && extension.length > 0,
             )
             if (matchingLanguages.length > 0) {
                 Log.info(

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -337,7 +337,7 @@ export class LanguageManager {
             >(contributes => contributes.languages)
             const extension = path.extname(filePath)
             const matchingLanguages = languages.filter(
-                l => l.extensions.indexOf(extension) && extension.length > 0,
+                l => l.extensions.indexOf(extension) && extension && extension.length > 0,
             )
             if (matchingLanguages.length > 0) {
                 Log.info(


### PR DESCRIPTION
__Issue:__ Our image layers were being added to files without an extension

__Defect:__ Our 'language contribution' was overly aggressive, and would assign any file without an extension that first 'contributed' language it could find.

__Fix:__ Only apply these contributions to files with extensions