### PR TITLE
Fix #1465: Add configuration for browser default landing page

### DIFF
--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -62,6 +62,8 @@ export const activate = (
 
     const openUrl = async (url: string, openMode: Oni.FileOpenMode = Oni.FileOpenMode.NewTab) => {
         if (configuration.getValue("experimental.browser.enabled")) {
+            url = url || configuration.getValue("browser.defaultUrl")
+
             count++
             const buffer: Oni.Buffer = await editorManager.activeEditor.openFile(
                 "Browser" + count.toString(),
@@ -81,15 +83,14 @@ export const activate = (
             command: "browser.openUrl.verticalSplit",
             name: "Browser: Open in Vertical Split",
             detail: "Open a browser window",
-            execute: () => openUrl("https://github.com/onivim/oni", Oni.FileOpenMode.VerticalSplit),
+            execute: (url?: string) => openUrl(url, Oni.FileOpenMode.VerticalSplit),
         })
 
         commandManager.registerCommand({
             command: "browser.openUrl.horizontalSplit",
             name: "Browser: Open in Horizontal Split",
             detail: "Open a browser window",
-            execute: () =>
-                openUrl("https://github.com/onivim/oni", Oni.FileOpenMode.HorizontalSplit),
+            execute: (url?: string) => openUrl(url, Oni.FileOpenMode.HorizontalSplit),
         })
     }
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -33,6 +33,9 @@ const BaseConfiguration: IConfigurationValues = {
     deactivate: noop,
 
     "autoUpdate.enabled": false,
+
+    "browser.defaultUrl": "https://duckduckgo.com",
+
     "configuration.editor": "javascript",
 
     "debug.fixedSize": null,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -30,6 +30,8 @@ export interface IConfigurationValues {
     "debug.detailedSessionLogging": boolean
     "debug.showTypingPrediction": boolean
 
+    "browser.defaultUrl": string
+
     // Simulate slow language server, for debugging
     "debug.fakeLag.languageServer": number | null
     "debug.fakeLag.neovimInput": number | null


### PR DESCRIPTION
Add `browser.defaultUrl` to set the default browser page if none specified. Fixes #1465 