### PR TITLE
Automation: OSX Reliability

### DIFF
--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -21,7 +21,6 @@ const CiTests = [
     "Editor.BufferModifiedState",
     "Editor.OpenFile.PathWithSpacesTest",
     "Editor.TabModifiedState",
-    "LargeFileTest",
     "MarkdownPreviewTest",
     "PaintPerformanceTest",
     "QuickOpenTest",
@@ -36,6 +35,9 @@ const CiTests = [
     "Regression.1296.SettingColorsTest",
     "Regression.1295.UnfocusedWindowTest",
     "TextmateHighlighting.ScopesOnEnterTest",
+
+    // This test occasionally hangs and breaks tests after - trying to move it later...
+    "LargeFileTest",
 ]
 
 const WindowsOnlyTests = [

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -102,7 +102,7 @@ const ensureOniNotRunning = async () => {
         const chromeDriverProcessGone = await tryToKillProcess("chromedriver")
         const oniProcessGone = await tryToKillProcess("oni")
 
-        if (nvimProcessGone && chromeDriverProcessGone && orientation) {
+        if (nvimProcessGone && chromeDriverProcessGone && oniProcessGone) {
             console.log("All processes gone!")
             return
         }
@@ -111,7 +111,7 @@ const ensureOniNotRunning = async () => {
     }
 }
 
-const tryToKillProcess = async (name: string): boolean => {
+const tryToKillProcess = async (name: string): Promise<boolean> => {
     const oniProcesses = await findProcess("name", "oni")
     oniProcesses.forEach(processInfo => {
         console.log(` - Name: ${processInfo.name} PID: ${processInfo.pid}`)

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -92,38 +92,52 @@ const logWithTimeStamp = (message: string) => {
 // when starting the test. It will fail if there is an existing instance
 // running, so we need to make sure to finish it.
 const ensureOniNotRunning = async () => {
-    let attempts = 0
+    let attempts = 1
     const maxAttempts = 5
 
     while (attempts < maxAttempts) {
-        const oniProcesses = await findProcess("name", "oni")
         console.log(`${attempts}/${maxAttempts} Active Processes:`)
-        oniProcesses.forEach(processInfo => {
-            console.log(` - Name: ${processInfo.name} PID: ${processInfo.pid}`)
-        })
-        const isOniProcess = processInfo =>
-            processInfo.name.toLowerCase().indexOf("oni") >= 0 ||
-            processInfo.name.toLowerCase().indexOf("chromedriver") >= 0
-        const filteredProcesses = oniProcesses.filter(isOniProcess)
 
-        if (filteredProcesses.length === 0) {
-            console.log("No Oni processes found - leaving.")
+        const nvimProcessGone = await tryToKillProcess("nvim")
+        const chromeDriverProcessGone = await tryToKillProcess("chromedriver")
+        const oniProcessGone = await tryToKillProcess("oni")
+
+        if (nvimProcessGone && chromeDriverProcessGone && orientation) {
+            console.log("All processes gone!")
             return
         }
 
-        filteredProcesses.forEach(processInfo => {
-            console.log("Attemping to kill pid: " + processInfo.pid)
-            // Sometimes, there can be a race condition here. For example,
-            // the process may have closed between when we queried above
-            // and when we try to kill it. So we'll wrap it in a try/catch.
-            try {
-                process.kill(processInfo.pid)
-            } catch (ex) {
-                console.warn(ex)
-            }
-        })
         attempts++
     }
+}
+
+const tryToKillProcess = async (name: string): boolean => {
+    const oniProcesses = await findProcess("name", "oni")
+    oniProcesses.forEach(processInfo => {
+        console.log(` - Name: ${processInfo.name} PID: ${processInfo.pid}`)
+    })
+    const isOniProcess = processInfo => processInfo.name.toLowerCase().indexOf(name) >= 0
+    const filteredProcesses = oniProcesses.filter(isOniProcess)
+    console.log(`- Found ${filteredProcesses.length} processes with name:  ${name}`)
+
+    if (filteredProcesses.length === 0) {
+        console.log("No Oni processes found - leaving.")
+        return true
+    }
+
+    filteredProcesses.forEach(processInfo => {
+        console.log("Attemping to kill pid: " + processInfo.pid)
+        // Sometimes, there can be a race condition here. For example,
+        // the process may have closed between when we queried above
+        // and when we try to kill it. So we'll wrap it in a try/catch.
+        try {
+            process.kill(processInfo.pid)
+        } catch (ex) {
+            console.warn(ex)
+        }
+    })
+
+    return false
 }
 
 export const runInProcTest = (


### PR DESCRIPTION
Experimenting with a few other ideas. It seems at least some 'stalls' on OSX happen after the 'LargeFileTest'. Trying a couple of things to validate that:
- Kill `nvim` explicitly
- Move `LargeFileTest` to the end of the test suite - does that change the behavior?