### PR TITLE
Bugfix/ incorrect use of dom purify which was breaking <Components />

### DIFF
--- a/browser/src/Editor/NeovimEditor/markdown.ts
+++ b/browser/src/Editor/NeovimEditor/markdown.ts
@@ -170,19 +170,27 @@ export const convertMarkdown = ({ markdown, tokens, type = "title" }: IConversio
     switch (type) {
         case "documentation":
             renderer.html = htmlString => DOMPurify.sanitize(htmlString, purifyConfig)
-            renderer.paragraph = text => createContainer("p", text)
+            renderer.paragraph = text =>
+                createContainer("p", DOMPurify.sanitize(text, purifyConfig))
 
             break
         case "title":
         default:
             renderer.html = htmlString => DOMPurify.sanitize(htmlString, purifyConfig)
-            renderer.paragraph = text => renderWithClasses({ text, tokens })
-            renderer.blockquote = text => renderWithClasses({ text, tokens, container: "pre" })
+            renderer.paragraph = text => {
+                const stringWithClasses = renderWithClasses({ text, tokens })
+                return DOMPurify.sanitize(stringWithClasses, purifyConfig)
+            }
+            renderer.blockquote = text => {
+                const stringWithClasses = renderWithClasses({
+                    text,
+                    tokens,
+                    container: "pre",
+                })
+                return DOMPurify.sanitize(stringWithClasses, purifyConfig)
+            }
     }
 
-    const impure = marked(markdown)
-    const purified = DOMPurify.sanitize(unescape(impure), purifyConfig)
-
-    const html = purified
+    const html = marked(markdown)
     return html
 }

--- a/browser/src/Editor/NeovimEditor/markdown.ts
+++ b/browser/src/Editor/NeovimEditor/markdown.ts
@@ -169,7 +169,7 @@ export const convertMarkdown = ({ markdown, tokens, type = "title" }: IConversio
 
     switch (type) {
         case "documentation":
-            renderer.html = htmlString => DOMPurify.sanitize(htmlString, purifyConfig)
+            renderer.html = text => DOMPurify.sanitize(text, purifyConfig)
             renderer.paragraph = text =>
                 createContainer("p", DOMPurify.sanitize(text, purifyConfig))
 

--- a/browser/src/Editor/NeovimEditor/markdown.ts
+++ b/browser/src/Editor/NeovimEditor/markdown.ts
@@ -143,7 +143,7 @@ interface IConversionArgs {
     type?: string
 }
 
-const purifyConfig = {
+const config = {
     FORBID_TAGS: ["img", "script"],
 }
 
@@ -169,17 +169,16 @@ export const convertMarkdown = ({ markdown, tokens, type = "title" }: IConversio
 
     switch (type) {
         case "documentation":
-            renderer.html = text => DOMPurify.sanitize(text, purifyConfig)
-            renderer.paragraph = text =>
-                createContainer("p", DOMPurify.sanitize(text, purifyConfig))
+            renderer.html = htmlString => DOMPurify.sanitize(htmlString, config)
+            renderer.paragraph = text => createContainer("p", DOMPurify.sanitize(text, config))
 
             break
         case "title":
         default:
-            renderer.html = htmlString => DOMPurify.sanitize(htmlString, purifyConfig)
+            renderer.html = htmlString => DOMPurify.sanitize(htmlString, config)
             renderer.paragraph = text => {
                 const stringWithClasses = renderWithClasses({ text, tokens })
-                return DOMPurify.sanitize(stringWithClasses, purifyConfig)
+                return DOMPurify.sanitize(stringWithClasses, config)
             }
             renderer.blockquote = text => {
                 const stringWithClasses = renderWithClasses({
@@ -187,7 +186,7 @@ export const convertMarkdown = ({ markdown, tokens, type = "title" }: IConversio
                     tokens,
                     container: "pre",
                 })
-                return DOMPurify.sanitize(stringWithClasses, purifyConfig)
+                return DOMPurify.sanitize(stringWithClasses, config)
             }
     }
 

--- a/browser/test/MarkdownTests.ts
+++ b/browser/test/MarkdownTests.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert"
+import { unescape } from "lodash"
 import { StackElement } from "vscode-textmate"
 import * as markdown from "./../../browser/src/Editor/NeovimEditor/markdown"
 
@@ -87,5 +88,19 @@ describe("Markdown Conversion Functions", () => {
             .trim()
 
         assert.ok(tag.replace("\n", "").trim() === expected)
+    })
+
+    it("should render safe jsx untouched ", () => {
+        const md = `### A title
+            <AReactComponent />`
+        const result = markdown.convertMarkdown({ markdown: md, tokens: null })
+        assert.ok(unescape(result).includes(`<AReactComponent />`))
+    })
+
+    it("should render safe html untouched ", () => {
+        const md = `### Another Title
+            <div></div>`
+        const result = markdown.convertMarkdown({ markdown: md, tokens: null })
+        assert.ok(unescape(result).includes(`<div></div>`))
     })
 })


### PR DESCRIPTION
Whilst adding syntax highlighting I added in `DOMPurify` for another measure of safety on top of `marked's` inbuilt sanitization. The implementation however causes safe `html/xml/jsx` to be omitted from documention blocks resulting in docs with empty codeblocks and completely remove all titles from `vue` files hover info.

I've tweaked the way `DOMPurify` is called to preserve non-offensive html-esque syntax. 

Note: for future reference I've discovered an issue on *one* occasion with what the `lsp` sends, whilst the `lsp` dictates that documentation should be sent as markup/markdown in the case of `Observable` documentation html is sent, marked does not convert this to markdown so the whilst it sanitizes it and then in our cases it also passes through dom purify it is left in the hover docs, a potential solution would be to run a check for html after purification and run an html to markdown parser but I think this would only be worth while if it occurs often as I believe the documentation writers for `Observable` are ?in error?

EDIT: checked the same documentation in `vscode` and it also renders the raw html, which makes me think that the `Observable` docs arent written according to spec