### PR TITLE
feature/switch typescript language server to theia-ide

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -187,6 +187,8 @@ const BaseConfiguration: IConfigurationValues = {
     "language.ocaml.languageServer.arguments": ["--stdio"],
     "language.ocaml.languageServer.configuration": ocamlAndReasonConfiguration,
 
+    "language.typescript.languageServer.command": "typescript-language-server",
+    "language.typescript.languageServer.arguments": ["--stdio"],
     "language.typescript.completionTriggerCharacters": [".", "/", "\\"],
     "language.typescript.textMateGrammar": {
         ".ts": path.join(

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
         "shelljs": "0.7.7",
         "styled-components": "^2.3.0",
         "typescript": "2.7.1",
+        "typescript-language-server": "^0.1.9",
         "vscode-css-languageserver-bin": "^1.2.1",
         "vscode-html-languageserver-bin": "^1.1.0",
         "vscode-jsonrpc": "3.5.0",
@@ -225,10 +226,6 @@
         "vscode-textmate": "3.2.0"
     },
     "devDependencies": {
-        "@types/marked": "^0.3.0",
-        "@types/react-dnd": "^2.0.34",
-        "@types/react-dnd-html5-backend": "^2.1.8",
-        "@types/redux-batched-subscribe": "^0.1.2",
         "@types/classnames": "0.0.32",
         "@types/color": "2.0.0",
         "@types/detect-indent": "^5.0.0",
@@ -245,6 +242,8 @@
         "@types/mocha": "2.2.33",
         "@types/msgpack-lite": "0.1.4",
         "@types/node": "8.0.53",
+        "@types/react-dnd": "^2.0.34",
+        "@types/react-dnd-html5-backend": "^2.1.8",
         "@types/react-dom": "16.0.3",
         "@types/react-motion": "0.0.23",
         "@types/react-redux": "5.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,6 +1469,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.2.tgz#12819c64faf95446ec0ae07fe6cafb6eb3708b22"
+
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -6749,6 +6753,15 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript-language-server@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.1.9.tgz#a0b1d7b1a1956abac8ffca5256d6eebcef659a3d"
+  dependencies:
+    command-exists "^1.2.2"
+    commander "^2.11.0"
+    vscode-languageserver "^3.4.3"
+    vscode-uri "^1.0.1"
+
 typescript@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
@@ -6987,6 +7000,13 @@ vscode-languageserver-protocol@3.5.0, vscode-languageserver-protocol@^3.5.0:
     vscode-jsonrpc "^3.5.0"
     vscode-languageserver-types "^3.5.0"
 
+vscode-languageserver-protocol@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz#5144a3a9eeccbd83fe2745bd4ed75fad6cc45f0d"
+  dependencies:
+    vscode-jsonrpc "3.5.0"
+    vscode-languageserver-types "3.5.0"
+
 vscode-languageserver-types@3.5.0, vscode-languageserver-types@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz#e48d79962f0b8e02de955e3f524908e2b19c0374"
@@ -6996,6 +7016,13 @@ vscode-languageserver@3.5.0, vscode-languageserver@^3.5.0:
   resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz#d28099bc6ddda8c1dd16b707e454e1b1ddae0dba"
   dependencies:
     vscode-languageserver-protocol "^3.5.0"
+    vscode-uri "^1.0.1"
+
+vscode-languageserver@^3.4.3:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-3.5.1.tgz#e0044b7df4d2447ce12632dfc98f1ab0afacbdff"
+  dependencies:
+    vscode-languageserver-protocol "3.5.1"
     vscode-uri "^1.0.1"
 
 vscode-nls@^2.0.1, vscode-nls@^2.0.2:


### PR DESCRIPTION
Following discussion with @bryphe in #1593 this PR switches the default `lsp` for typescript to [`theia-ide/typescript-language-server`](https://github.com/theia-ide/typescript-language-server), more details re. reasoning behind the switch can be found in the linked issue.

@bryphe I've essentially replicated the steps I took to setup the LSP and haven't touched Oni's ts lsp.

**Note**:
* Currently there are issues with how oni handles `rename` functionality which are exacerbated with integrating this LSP as I believe Oni might need to make some changes to align with the LSP implementation