### PR TITLE
Fix #1715 - Snippet crashes occasionally on insert

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -19,6 +19,8 @@ export interface NeovimBufferLayersViewProps {
     activeWindowId: number
     windows: State.IWindow[]
     layers: State.Layers
+    fontPixelWidth: number
+    fontPixelHeight: number
 }
 
 const InnerLayerStyle: React.CSSProperties = {
@@ -41,6 +43,8 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
                 isActive: windowState.windowId === this.props.activeWindowId,
                 windowId: windowState.windowId,
 
+                fontPixelWidth: this.props.fontPixelWidth,
+                fontPixelHeight: this.props.fontPixelHeight,
                 bufferToScreen: windowState.bufferToScreen,
                 screenToPixel: windowState.screenToPixel,
                 dimensions: windowState.dimensions,
@@ -106,13 +110,17 @@ const getWindowPixelDimensions = (win: State.IWindow) => {
     }
 }
 
+const EmptyState: NeovimBufferLayersViewProps = {
+    activeWindowId: -1,
+    layers: {},
+    windows: [],
+    fontPixelHeight: -1,
+    fontPixelWidth: -1,
+}
+
 const mapStateToProps = (state: State.IState): NeovimBufferLayersViewProps => {
     if (!state.activeVimTabPage) {
-        return {
-            activeWindowId: -1,
-            layers: {},
-            windows: [],
-        }
+        return EmptyState
     }
 
     const windows = state.activeVimTabPage.windowIds.map(windowId => {
@@ -125,6 +133,8 @@ const mapStateToProps = (state: State.IState): NeovimBufferLayersViewProps => {
         activeWindowId: state.windowState.activeWindow,
         windows: wins,
         layers: state.layers,
+        fontPixelWidth: state.fontPixelWidth,
+        fontPixelHeight: state.fontPixelHeight,
     }
 }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -529,10 +529,23 @@ export const setWindowState = (
 ) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
     const { fontPixelWidth, fontPixelHeight } = getState()
 
-    const screenToPixel = (screenSpace: Oni.Coordinates.ScreenSpacePoint) => ({
-        pixelX: screenSpace.screenX * fontPixelWidth,
-        pixelY: screenSpace.screenY * fontPixelHeight,
-    })
+    const screenToPixel = (screenSpace: Oni.Coordinates.ScreenSpacePoint) => {
+        if (
+            !screenSpace ||
+            typeof screenSpace.screenX !== "number" ||
+            typeof screenSpace.screenY !== "number"
+        ) {
+            return {
+                pixelX: NaN,
+                pixelY: NaN,
+            }
+        }
+
+        return {
+            pixelX: screenSpace.screenX * fontPixelWidth,
+            pixelY: screenSpace.screenY * fontPixelHeight,
+        }
+    }
 
     dispatch({
         type: "SET_WINDOW_STATE",

--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -158,9 +158,7 @@ export class SnippetBufferLayerView extends React.PureComponent<
         const cursors = this.state.cursors.map(c => {
             const pos = this.props.context.screenToPixel(this.props.context.bufferToScreen(c.start))
 
-            const size = this.props.context.screenToPixel(
-                this.props.context.bufferToScreen(types.Position.create(1, c.end.character)),
-            )
+            const size = this.props.context.screenToPixel(this.props.context.bufferToScreen(c.end))
 
             const style: React.CSSProperties = {
                 top: pos.pixelY.toString() + "px",
@@ -170,7 +168,8 @@ export class SnippetBufferLayerView extends React.PureComponent<
                         ? (size.pixelX - pos.pixelX).toString() + "px"
                         : "2px",
                 opacity: this.state.mode === "visual" ? 0.2 : 0.8,
-                height: size.pixelY.toString() + "px",
+                // TODO: Add 'fontPixelWidth' and 'fontPixelHeight' as API methods
+                height: (this.props.context as any).fontPixelHeight.toString() + "px",
             }
 
             return <CursorWrapper style={style} />


### PR DESCRIPTION
__Issue:__ Frequently when inserting snippets, the whole screen goes red with an error message... this is a horrible experience because it means that some edits may be lost 😦 

__Defect:__ There were a couple of issues contributing. First, the `BufferLayer` infrastructure isn't robust when we try and ask about _pixel positions_ for cells that are off the screen - that's where we get the `screenX` error. In the snippet case, we were measuring a position at row `1` to use as the height value, but if we were scrolled past that... we'd hit this error.

__Fix:__ Make the measurement routines more robust - if we don't have the position, at least pass `NaN` so that the computations later don't crash. In addition, plumb an alternative way to get the height of a cell - this is something that would be useful in general for buffer layers, so we should extend our API to support this.

__Future Work__: 
- Extend the `BufferLayerRenderContext` to include `fontPixelWidth` and `fontPixelHeight` properties