### PR TITLE
Fix #1719 - Add 'snippets.enabled' configuration option

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -237,6 +237,8 @@ const BaseConfiguration: IConfigurationValues = {
     "sidebar.marks.enabled": false,
     "sidebar.plugins.enabled": false,
 
+    "snippets.enabled": true,
+
     "statusbar.enabled": true,
     "statusbar.fontSize": "0.9em",
     "statusbar.priority": {

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -217,6 +217,8 @@ export interface IConfigurationValues {
     "sidebar.marks.enabled": boolean
     "sidebar.plugins.enabled": boolean
 
+    "snippets.enabled": boolean
+
     "statusbar.enabled": boolean
     "statusbar.fontSize": string
 

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -11,6 +11,7 @@ import * as Log from "./../../Log"
 import "rxjs/add/operator/auditTime"
 import { Subject } from "rxjs/Subject"
 
+import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 
 import { SnippetBufferLayer } from "./SnippetBufferLayer"
@@ -27,8 +28,8 @@ export class SnippetManager {
     private _snippetProvider: CompositeSnippetProvider
     private _synchronizeSnippetObservable: Subject<void> = new Subject<void>()
 
-    constructor(private _editorManager: EditorManager) {
-        this._snippetProvider = new CompositeSnippetProvider()
+    constructor(private _configuration: Configuration, private _editorManager: EditorManager) {
+        this._snippetProvider = new CompositeSnippetProvider(this._configuration)
 
         this._synchronizeSnippetObservable.auditTime(50).subscribe(() => {
             const activeEditor = this._editorManager.activeEditor as any

--- a/browser/src/Services/Snippets/SnippetProvider.ts
+++ b/browser/src/Services/Snippets/SnippetProvider.ts
@@ -9,6 +9,8 @@ import * as os from "os"
 
 import { PluginManager } from "./../../Plugins/PluginManager"
 
+import { Configuration } from "./../Configuration"
+
 import * as Log from "./../../Log"
 import { flatMap } from "./../../Utility"
 
@@ -21,11 +23,17 @@ export interface ISnippetProvider {
 export class CompositeSnippetProvider implements ISnippetProvider {
     private _providers: ISnippetProvider[] = []
 
+    constructor(private _configuration: Configuration) {}
+
     public registerProvider(provider: ISnippetProvider): void {
         this._providers.push(provider)
     }
 
     public async getSnippets(language: string): Promise<ISnippet[]> {
+        if (!this._configuration.getValue("snippets.enabled")) {
+            return []
+        }
+
         const snippets = this._providers.map(p => p.getSnippets(language))
 
         const allSnippets = await Promise.all(snippets)

--- a/browser/src/Services/Snippets/index.ts
+++ b/browser/src/Services/Snippets/index.ts
@@ -7,6 +7,7 @@ import { PluginManager } from "./../../Plugins/PluginManager"
 
 import { CommandManager } from "./../CommandManager"
 import { CompletionProviders } from "./../Completion"
+import { Configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
 
 import { SnippetCompletionProvider } from "./SnippetCompletionProvider"
@@ -15,8 +16,8 @@ import { PluginSnippetProvider } from "./SnippetProvider"
 
 let _snippetManager: SnippetManager
 
-export const activate = (commandManager: CommandManager) => {
-    _snippetManager = new SnippetManager(editorManager)
+export const activate = (commandManager: CommandManager, configuration: Configuration) => {
+    _snippetManager = new SnippetManager(configuration, editorManager)
 
     commandManager.registerCommand({
         command: "snippet.nextPlaceholder",

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -170,7 +170,7 @@ const start = async (args: string[]): Promise<void> => {
     CSS.activate()
 
     const Snippets = await snippetPromise
-    Snippets.activate(commandManager)
+    Snippets.activate(commandManager, configuration)
 
     Shell.Actions.setLoadingComplete()
 

--- a/browser/test/Services/Completion/CompletionUtilityTests.ts
+++ b/browser/test/Services/Completion/CompletionUtilityTests.ts
@@ -9,10 +9,11 @@ import { SnippetManager } from "./../../../src/Services/Snippets"
 const DefaultCursorMatchRegEx = /[a-z]/i
 const DefaultTriggerCharacters = ["."]
 
-import { MockBuffer, MockEditor } from "./../../Mocks"
+import { MockBuffer, MockConfiguration, MockEditor } from "./../../Mocks"
 
 describe("CompletionUtility", () => {
     describe("commitCompletion", () => {
+        let mockConfiguration: MockConfiguration
         let editorManager: EditorManager
         let mockEditor: MockEditor
         let snippetManager: SnippetManager
@@ -21,7 +22,8 @@ describe("CompletionUtility", () => {
             editorManager = new EditorManager()
             mockEditor = new MockEditor()
             editorManager.setActiveEditor(mockEditor)
-            snippetManager = new SnippetManager(editorManager)
+            mockConfiguration = new MockConfiguration({})
+            snippetManager = new SnippetManager(mockConfiguration as any, editorManager)
         })
 
         it("handles basic completion", async () => {


### PR DESCRIPTION
Fix #1719 - provide an option to disable snippets.

This adds the `snippets.enabled` configuration (defaults to  `true`).