### PR TITLE
Snippets - Bug Fix: Takes two 'esc' key presses to get out of snippet+insert mode

### DIFF
--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -103,9 +103,11 @@ export class SnippetManager {
         return !!this._activeSession
     }
 
-    public cancel(): void {
+    public async cancel(): Promise<void> {
         if (this._activeSession) {
             this._cleanupAfterSession()
+            await (this._editorManager.activeEditor as any).clearSelection()
+            await this._editorManager.activeEditor.neovim.command("stopinsert")
         }
 
         if (this._currentLayer) {

--- a/browser/src/Services/Snippets/SnippetManager.ts
+++ b/browser/src/Services/Snippets/SnippetManager.ts
@@ -107,6 +107,8 @@ export class SnippetManager {
         if (this._activeSession) {
             this._cleanupAfterSession()
             await (this._editorManager.activeEditor as any).clearSelection()
+
+            // TODO: Add 'stopInsert' and 'startInsert' methods on editor
             await this._editorManager.activeEditor.neovim.command("stopinsert")
         }
 


### PR DESCRIPTION
__Issue:__ It takes two `esc` key presses to get out of snippet + insert mode.

__Defect:__ First `esc` cancels the snippet, but you still in insert mode.

__Fix:__ When a snippet is complete, call `stopinsert` explicitly to leave insert mode