### PR TITLE
Bug fix - Textmate Highlighting: Flicker on insert mode

### DIFF
--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightSelectors.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightSelectors.ts
@@ -35,14 +35,16 @@ export const getLineFromBuffer = (
     state: IBufferSyntaxHighlightState,
     lineNumber: number,
 ): ISyntaxHighlightLineInfo => {
+    const currentLine = state.lines[lineNumber]
+
     if (
         state.insertModeLine &&
         state.insertModeLine.info &&
-        state.insertModeLine.version > state.version &&
+        state.insertModeLine.version > currentLine.version &&
         state.insertModeLine.lineNumber === lineNumber
     ) {
         return state.insertModeLine.info
     }
 
-    return state.lines[lineNumber]
+    return currentLine
 }

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingPeriodicJob.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingPeriodicJob.ts
@@ -99,6 +99,7 @@ export class SyntaxHighlightingPeriodicJob implements IPeriodicJob {
                 lineNumber: index,
                 tokens,
                 ruleStack,
+                version: state.version,
             })
 
             return true

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
@@ -113,6 +113,7 @@ export const linesReducer: Reducer<SyntaxHighlightLines> = (
                 dirty: false,
                 tokens: action.tokens,
                 ruleStack: action.ruleStack,
+                version: action.version,
             }
 
             const nextLine = newState[action.lineNumber + 1]

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
@@ -93,6 +93,7 @@ export type ISyntaxHighlightAction =
           lineNumber: number
           tokens: ISyntaxHighlightTokenInfo[]
           ruleStack: StackElement
+          version: number
       }
     | {
           type: "SYNTAX_UPDATE_TOKENS_FOR_LINE_INSERT_MODE"

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingStore.ts
@@ -30,6 +30,9 @@ export interface ISyntaxHighlightLineInfo {
     ruleStack: StackElement
     tokens: ISyntaxHighlightTokenInfo[]
     dirty: boolean
+
+    // The last version of the line that was 'tokenized'
+    version?: number
 }
 
 export interface SyntaxHighlightLines {

--- a/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReconcilerTests.ts
+++ b/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReconcilerTests.ts
@@ -50,6 +50,7 @@ describe("SyntaxHighlightReconciler", () => {
             ruleStack: null,
             tokens: tokenInfo,
             dirty: false,
+            version: 1,
         }
 
         const lines = {

--- a/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReconcilerTests.ts
+++ b/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReconcilerTests.ts
@@ -171,6 +171,58 @@ describe("SyntaxHighlightReconciler", () => {
         )
     })
 
+    it("doesn't use insert mode line if version is earlier than latest tokenized version", () => {
+        // Simulate an empty state to start
+        const testState = createHighlightState(0, null, [])
+
+        syntaxHighlightReconciler.update(testState)
+
+        // And then we'll throw in an insert mode edit
+        const tokenInfo = {
+            scopes: ["scope.test"],
+            range: types.Range.create(0, 0, 0, 5),
+        }
+
+        const currentBufferInfo = testState.bufferToHighlights[mockBuffer.id]
+
+        // Bump version past the insert mode line
+        currentBufferInfo.lines[0].version = 3
+
+        const bufferInfoWithInsertUpdates = {
+            ...currentBufferInfo,
+            insertModeLine: {
+                lineNumber: 0,
+                version: 2,
+                info: {
+                    line: "token",
+                    ruleStack: null as any,
+                    tokens: [tokenInfo],
+                    dirty: false,
+                },
+            },
+        }
+
+        const updatedState: ISyntaxHighlightState = {
+            ...testState,
+            bufferToHighlights: {
+                ...testState.bufferToHighlights,
+                [mockBuffer.id]: bufferInfoWithInsertUpdates,
+            },
+        }
+
+        syntaxHighlightReconciler.update(updatedState)
+
+        const highlights = mockBuffer.mockHighlights.getHighlightsForLine(0)
+
+        const expectedHighlights: HighlightInfo[] = []
+
+        assert.deepEqual(
+            highlights,
+            expectedHighlights,
+            "Validate tokens set in insert mode are correct",
+        )
+    })
+
     it("clears tokens", () => {
         const tokenInfo = {
             scopes: ["scope.test"],


### PR DESCRIPTION
__Issue:__ When pressing `enter` in insert mode, there is a brief flash-of-unstyled-content where the highlights are removed and then reapplied.

__Defect:__ The highlight tokens in insert mode are evaluated with a lightweight strategy, and then re-evaluated with the full strategy when switching to normal mode. The delta between this time was resulting in the flash.

__Fix:__ Only re-evaluate the highlight once it is fully tokenized