### PR TITLE
Fix regression in devtools

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -105,7 +105,7 @@ if (!isDevelopment && !isDebug && !isAutomation) {
     // initialization and is ready to create browser windows.
     // Some APIs can only be used after this event occurs.
     app.on("ready", async () => {
-        if (isAutomation) {
+        if (!isAutomation) {
             await addDevExtensions()
         }
         loadFileFromArguments(process.platform, argsToUse, process.env.ONI_CWD || process.cwd())


### PR DESCRIPTION
There was a flipped conditional in `main.ts` - the intention was not _not_ install dev tools when we run automation, only when the app is run locally - but the opposite was occurring.