### PR TITLE
Test Template File:  Use snippet variable

### DIFF
--- a/.oni/templates/UnitTestTemplate.ts.template
+++ b/.oni/templates/UnitTestTemplate.ts.template
@@ -1,12 +1,13 @@
 /**
- * ${0}.ts
+ * ${TM_FILENAME_BASE}.ts
  */
 
 import * as assert from "assert"
 
-describe("${0}", () => {
+describe("${TM_FILENAME_BASE}", () => {
     it("${1:tests}", async () => {
         ${2:assert.ok(false, "fail")}
+        ${0}
     })
 })
 


### PR DESCRIPTION
This uses the `TM_FILENAME_BASE` variable to pre-populate portions of the unit test template file