### PR TITLE
Terminal: Add convenience commands to open in splits

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -258,6 +258,8 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.showIndex": false,
     "tabs.wrap": false,
 
+    "terminal.shellCommand": os.platform() === "win32" ? "cmd" : "bash",
+
     "ui.animations.enabled": true,
     "ui.colorscheme": "nord",
     "ui.iconTheme": "theme-icons-seti",

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -256,6 +256,8 @@ export interface IConfigurationValues {
     // should be shown in the tab
     "tabs.showFileIcon": boolean
 
+    "terminal.shellCommand": string
+
     "ui.animations.enabled": boolean
     "ui.iconTheme": string
     "ui.colorscheme": string

--- a/browser/src/Services/Terminal.ts
+++ b/browser/src/Services/Terminal.ts
@@ -1,0 +1,40 @@
+/**
+ * Terminal.ts
+ *
+ * Helper / convenience commands for Neovim's integrated terminal experience
+ */
+
+import * as Oni from "oni-api"
+
+import { CommandManager } from "./CommandManager"
+import { Configuration } from "./Configuration"
+import { EditorManager } from "./EditorManager"
+
+export const activate = (
+    commandManager: CommandManager,
+    configuration: Configuration,
+    editorManager: EditorManager,
+) => {
+    const getTerminalCommand = () => {
+        const terminalCommand = configuration.getValue("terminal.shellCommand", "")
+        return `term://${terminalCommand}`
+    }
+
+    const openTerminal = (openMode: Oni.FileOpenMode) => {
+        editorManager.activeEditor.openFile(getTerminalCommand(), { openMode })
+    }
+
+    commandManager.registerCommand({
+        command: "terminal.openInVerticalSplit",
+        name: "Terminal: Open Vertical",
+        detail: "Open a terminal emulator in a vertical split",
+        execute: () => openTerminal(Oni.FileOpenMode.VerticalSplit),
+    })
+
+    commandManager.registerCommand({
+        command: "terminal.openInHorizontalSplit",
+        name: "Terminal: Open Horizontal",
+        detail: "Open a terminal emulator in a horizontal split",
+        execute: () => openTerminal(Oni.FileOpenMode.HorizontalSplit),
+    })
+}

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -49,6 +49,7 @@ const start = async (args: string[]): Promise<void> => {
     const keyDisplayerPromise = import("./Services/KeyDisplayer")
     const quickOpenPromise = import("./Services/QuickOpen")
     const taksPromise = import("./Services/Tasks")
+    const terminalPromise = import("./Services/Terminal")
     const workspacePromise = import("./Services/Workspace")
     const workspaceCommandsPromise = import("./Services/Workspace/WorkspaceCommands")
 
@@ -271,6 +272,9 @@ const start = async (args: string[]): Promise<void> => {
 
     const PluginsSidebarPane = await import("./Plugins/PluginSidebarPane")
     PluginsSidebarPane.activate(configuration, pluginManager, sidebarManager)
+
+    const Terminal = await terminalPromise
+    Terminal.activate(commandManager, configuration, editorManager)
 
     Performance.endMeasure("Oni.Start.Activate")
 


### PR DESCRIPTION
This change adds some convenience commands to open a terminal in a horizontal / vertical split - helps for discoverability to show it in the command palette.