### PR TITLE
Automation - QuickOpen Test: Add wait for menu.close to be available

### DIFF
--- a/test/ci/QuickOpenTest.ts
+++ b/test/ci/QuickOpenTest.ts
@@ -14,6 +14,8 @@ export const test = async (oni: any) => {
 
     await oni.automation.sleep(500)
 
+    await waitForCommand("menu.close", oni)
+
     oni.commands.executeCommand("menu.close")
     await oni.automation.waitFor(() => !oni.menu.isMenuOpen())
 }


### PR DESCRIPTION
- Stabilize the quick open CI test by adding an explicit wait for the menu.close command to be available