### PR TITLE
Fix #685 - Enable autocompletion and quickinfo for config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,14 @@
             "!examples",
             "!lib_test",
             "!test",
+            "!node_modules/oni-api",
             "!node_modules/typescript"
         ],
         "extraResources": [
+            {
+                "from": "node_modules/oni-api",
+                "to": "app/node_modules/oni-api"
+            },
             {
                 "from": "node_modules/typescript",
                 "to": "app/node_modules/typescript"

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -20,7 +20,7 @@ const CiTests = [
 
     "Configuration.JavaScriptEditorTest",
     "Configuration.TypeScriptEditor.NewConfigurationTest",
-    "Configuration.TypeScriptEditor.CompletionTest"
+    "Configuration.TypeScriptEditor.CompletionTest",
 
     "Editor.ExternalCommandLineTest",
     "Editor.BufferModifiedState",

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -20,6 +20,7 @@ const CiTests = [
 
     "Configuration.JavaScriptEditorTest",
     "Configuration.TypeScriptEditor.NewConfigurationTest",
+    "Configuration.TypeScriptEditor.CompletionTest"
 
     "Editor.ExternalCommandLineTest",
     "Editor.BufferModifiedState",

--- a/test/ci/AutoCompletionTest-TypeScript.ts
+++ b/test/ci/AutoCompletionTest-TypeScript.ts
@@ -13,7 +13,8 @@ export const test = async (oni: Oni.Plugin.Api) => {
 
     await createNewFile("ts", oni)
 
-    oni.automation.sendKeys("i")
+    oni.automation.sendKeys(":7")
+    oni.automation.sendKeys(":7")
     await oni.automation.sleep(500)
     oni.automation.sendKeys("window.a")
 

--- a/test/ci/AutoCompletionTest-TypeScript.ts
+++ b/test/ci/AutoCompletionTest-TypeScript.ts
@@ -13,8 +13,7 @@ export const test = async (oni: Oni.Plugin.Api) => {
 
     await createNewFile("ts", oni)
 
-    oni.automation.sendKeys(":7")
-    oni.automation.sendKeys(":7")
+    oni.automation.sendKeys("i")
     await oni.automation.sleep(500)
     oni.automation.sendKeys("window.a")
 

--- a/test/ci/Configuration.TypeScriptEditor.CompletionTest.ts
+++ b/test/ci/Configuration.TypeScriptEditor.CompletionTest.ts
@@ -1,0 +1,54 @@
+/**
+ * Test script for the TypeScript Configuration Editor
+ *
+ * Validate that appropriate typings are coming in -
+ * in particular, we should be getting typing info
+ * for the `oni-api` surface.
+ */
+
+import * as React from "react"
+
+import * as assert from "assert"
+import * as os from "os"
+import * as path from "path"
+
+import * as Oni from "oni-api"
+
+import { createNewFile, getCompletionElement, getTemporaryFolder, waitForCommand } from "./Common"
+
+const emptyConfigPath = path.join(getTemporaryFolder(), "config.js")
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    await waitForCommand("oni.config.openUserConfig", oni)
+    oni.commands.executeCommand("oni.config.openUserConfig")
+
+    await oni.automation.waitFor(() => {
+        return oni.editors.activeEditor.activeBuffer.language === "typescript"
+    }, 10000)
+
+    await oni.automation.waitFor(() => {
+        return oni.editors.activeEditor.activeBuffer.lineCount > 0
+    })
+
+    // Put cursor after 'activate' line
+    oni.automation.sendKeys(":7")
+    oni.automation.sendKeys("<cr>")
+    oni.automation.sendKeys("i")
+
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "insert")
+
+    oni.automation.sendKeys("oni.a")
+
+    const hasCompletionElement = () =>
+        getCompletionElement() && getCompletionElement().textContent.indexOf("automation") >= 0
+
+    await oni.automation.waitFor(hasCompletionElement)
+
+    assert.ok(hasCompletionElement(), "Got completion element!")
+}
+
+export const settings = {
+    configPath: emptyConfigPath,
+}


### PR DESCRIPTION
This is the remaining work to enable autocompletion / quick info in the config.js (which is now a `config.tsx`).

This moves the _default_ configuration strategy to use TypeScript, which allows us to bring the full capabilities of the language service + the oni api typings with configuration, resulting in a much better experience:
![image](https://user-images.githubusercontent.com/13532591/37119549-99ce7f82-220c-11e8-99c3-7238076ea408.png)

![image](https://user-images.githubusercontent.com/13532591/37119574-ae298242-220c-11e8-8c0b-8957dbdb942a.png)

This fixes a bug in the distribution build where we don't supply typings properly for `oni-api`, and adds a CiTest to validate it build-over-build
