### PR TITLE
Fix command line icons config option.

### DIFF
--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -154,7 +154,7 @@ class CommandLine extends React.PureComponent<ICommandLineRendererProps, State> 
 const mapStateToProps = ({ commandLine, configuration }: State.IState) => {
     const { visible, position, content, firstchar, level, prompt } = commandLine
     return {
-        showIcons: configuration["experimental.commandline.icons"],
+        showIcons: configuration["commandline.icons"],
         visible,
         content,
         firstchar,


### PR DESCRIPTION
I've still got an old config on my dev VM, and realised I was getting externalised icons there, and not on my actual PC.

@Akin909, I'm assuming that we want this enabled by default? The default config option was updated at least, so I am assuming it should be!

