### PR TITLE
Snippets - Bugfix: Make snippet loader more robust against parse failures

### DIFF
--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -61,9 +61,9 @@ export class SidebarManager {
         this._store = createStore()
 
         if (_windowManager) {
-            this._iconSplit = this._windowManager.createSplit("right", new SidebarSplit(this))
+            this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
             this._contentSplit = this._windowManager.createSplit(
-                "right",
+                "left",
                 new SidebarContentSplit(this),
             )
         }

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -61,9 +61,9 @@ export class SidebarManager {
         this._store = createStore()
 
         if (_windowManager) {
-            this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
+            this._iconSplit = this._windowManager.createSplit("right", new SidebarSplit(this))
             this._contentSplit = this._windowManager.createSplit(
-                "left",
+                "right",
                 new SidebarContentSplit(this),
             )
         }

--- a/browser/src/Services/Snippets/SnippetProvider.ts
+++ b/browser/src/Services/Snippets/SnippetProvider.ts
@@ -87,6 +87,7 @@ export class PluginSnippetProvider implements Oni.Snippets.SnippetProvider {
 export const loadSnippetsFromFile = async (
     snippetFilePath: string,
 ): Promise<Oni.Snippets.Snippet[]> => {
+    Log.verbose("[loadSnippetsFromFile] Trying to load snippets from: " + snippetFilePath)
     const contents = await new Promise<string>((resolve, reject) => {
         fs.readFile(snippetFilePath, "utf8", (err, data) => {
             if (err) {
@@ -98,7 +99,14 @@ export const loadSnippetsFromFile = async (
         })
     })
 
-    const snippets = Object.values(JSON.parse(contents)) as ISnippetPluginContribution[]
+    let snippets: ISnippetPluginContribution[] = []
+    try {
+        snippets = Object.values(JSON.parse(contents)) as ISnippetPluginContribution[]
+    } catch (ex) {
+        Log.error(ex)
+        snippets = []
+    }
+
     Log.verbose(
         `[loadSnippetsFromFile] - Loaded ${snippets.length} snippets from ${snippetFilePath}`,
     )

--- a/browser/src/Services/Snippets/UserSnippetProvider.ts
+++ b/browser/src/Services/Snippets/UserSnippetProvider.ts
@@ -30,7 +30,7 @@ const SnippetTemplate = [
     '         "}"',
     "       ],",
     '       "description": "For Loop"',
-    "   },",
+    "   }",
     "}",
 ]
 


### PR DESCRIPTION
__Issue:__ If there is a problem with the JSON format of the snippets, it just quietly bails with an exception, which causes downstream failures.

Also, there was an error with our default template, where we had an extra `,`, which would cause the parsing to fail 😦 

__Fix:__ Wrap the `JSON.parse` in a try...catch and log the error. Potentially we should show a notification to the user that we were unable to load the snippet file.