### PR TITLE
Bugfix - Snippets: Don't show snippets in property/member completion

### DIFF
--- a/browser/src/Services/Completion/CompletionStore.ts
+++ b/browser/src/Services/Completion/CompletionStore.ts
@@ -324,6 +324,7 @@ const createGetCompletionsEpic = (
                     filePath: state.bufferInfo.filePath,
                     line: action.currentMeet.meetLine,
                     column: action.currentMeet.queryPosition,
+                    meetCharacter: action.currentMeet.meetBase,
                     textMateScopes: action.currentMeet.textMateScopes,
                 })
                 const completions = results || []

--- a/browser/src/Services/Completion/CompletionsRequestor.ts
+++ b/browser/src/Services/Completion/CompletionsRequestor.ts
@@ -16,6 +16,7 @@ export interface CompletionsRequestContext {
     filePath: string
     line: number
     column: number
+    meetCharacter: string
     textMateScopes: string[]
 }
 

--- a/browser/src/Services/Snippets/SnippetCompletionProvider.ts
+++ b/browser/src/Services/Snippets/SnippetCompletionProvider.ts
@@ -32,6 +32,10 @@ export class SnippetCompletionProvider implements ICompletionsRequestor {
     ): Promise<types.CompletionItem[]> {
         Log.verbose("[SnippetCompletionProvider::getCompletions] Starting...")
 
+        if (!context.meetCharacter) {
+            return []
+        }
+
         const commentsOrQuotedStrings = context.textMateScopes.filter(
             f => f.indexOf("comment.") === 0 || f.indexOf("string.quoted.") === 0,
         )

--- a/browser/test/Services/Completion/CompletionProvidersTests.ts
+++ b/browser/test/Services/Completion/CompletionProvidersTests.ts
@@ -40,6 +40,7 @@ const createContext = (language: string, filePath: string, line: number, column:
     filePath,
     line,
     column,
+    meetCharacter: "",
     textMateScopes: [] as string[],
 })
 

--- a/browser/test/Services/Snippets/SnippetCompletionProviderTests.ts
+++ b/browser/test/Services/Snippets/SnippetCompletionProviderTests.ts
@@ -1,0 +1,44 @@
+/**
+ * SnippetCompletionProviderTests.ts
+ */
+
+import * as assert from "assert"
+
+import * as Oni from "oni-api"
+
+import { SnippetCompletionProvider } from "./../../../src/Services/Snippets/SnippetCompletionProvider"
+
+export class MockSnippetManager {
+    public get isSnippetActive(): boolean {
+        return false
+    }
+
+    public async getSnippetsForLanguage(language: string): Promise<Oni.Snippets.Snippet[]> {
+        const snippets: Oni.Snippets.Snippet[] = [
+            {
+                prefix: "test",
+                body: "foobar",
+                description: "test snippet",
+            },
+        ]
+        return snippets
+    }
+}
+
+describe("SnippetCompletionProviderTests", () => {
+    it("returns empty array if no meets", async () => {
+        const snippetManager: any = new MockSnippetManager()
+        const snippetCompletionProvider = new SnippetCompletionProvider(snippetManager)
+
+        const snippets = await snippetCompletionProvider.getCompletions({
+            language: "test",
+            filePath: "test",
+            line: 0,
+            column: 0,
+            meetCharacter: "",
+            textMateScopes: [],
+        })
+
+        assert.strictEqual(snippets.length, 0)
+    })
+})


### PR DESCRIPTION
__Issue:__ Snippets were showing up as suggestions for property / method completion, which didn't seem like the expected behavior (and wasn't useful).

__Fix:__ Plumb the `meetCharacter` through to the completion providers, and gate the snippet provider, such that it only provides completions if there is an actual meet. In the case of `window.`, the `meetCharacter` will be an empty string (no base).

