### PR TITLE
Error Notifications: Add configuration setting

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -42,7 +42,7 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.persistOnNeovimExit": false,
     "debug.detailedSessionLogging": false,
     "debug.showTypingPrediction": false,
-    "debug.showNotificationOnError": process.env["NODE_ENV"] !== "production",
+    "debug.showNotificationOnError": process.env.NODE_ENV !== "production",
 
     "debug.fakeLag.languageServer": null,
     "debug.fakeLag.neovimInput": null,

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -42,6 +42,7 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.persistOnNeovimExit": false,
     "debug.detailedSessionLogging": false,
     "debug.showTypingPrediction": false,
+    "debug.showNotificationOnError": process.env["NODE_ENV"] !== "production",
 
     "debug.fakeLag.languageServer": null,
     "debug.fakeLag.neovimInput": null,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -38,6 +38,8 @@ export interface IConfigurationValues {
     "debug.fakeLag.languageServer": number | null
     "debug.fakeLag.neovimInput": number | null
 
+    "debug.showNotificationOnError": boolean
+
     "editor.split.mode": string
 
     "configuration.editor": string

--- a/browser/src/Services/UnhandledErrorMonitor.ts
+++ b/browser/src/Services/UnhandledErrorMonitor.ts
@@ -6,7 +6,10 @@
 
 import { Event, IEvent } from "oni-types"
 
+import { Configuration } from "./Configuration"
 import { Notifications } from "./Notifications"
+
+import * as Log from "./../Log"
 
 export class UnhandledErrorMonitor {
     private _onUnhandledErrorEvent = new Event<Error>()
@@ -68,8 +71,13 @@ export const activate = () => {
 
 import { remote } from "electron"
 
-export const start = (notifications: Notifications) => {
+export const start = (configuration: Configuration, notifications: Notifications) => {
     const showError = (title: string, errorText: string) => {
+        if (!configuration.getValue("debug.showNotificationOnError")) {
+            Log.error("Received notification for: " + errorText)
+            return
+        }
+
         const notification = notifications.createItem()
 
         notification.onClick.subscribe(() => {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -153,7 +153,7 @@ const start = async (args: string[]): Promise<void> => {
         notification.show()
     })
 
-    UnhandledErrorMonitor.start(Notifications.getInstance())
+    UnhandledErrorMonitor.start(configuration, Notifications.getInstance())
 
     const Tasks = await taksPromise
     Tasks.activate(menuManager)


### PR DESCRIPTION
__Issue:__ Our error notifications are still a bit aggressive - unfortunately we haven't been able to fix all the issues (yet). Ideally, we would always have them one, so that the issues are front-and-center, but there are also cases where they don't cause a tangible end user issue.

This is the same behavior as we had in `0.3.0` and all prior releases - if we don't make this change, it will seem that the quality bar has dipped (unnecessarily), even though the set of errors hasn't actually changed.

__Fix:__ Add a `debug.showNotificationOnError` setting. This defaults to `false` in production builds, and `true` in debug and webpack dev builds. 

I'd like to get to the point where we can _always_ have this set to `true` - but need to fix some more of these bugs first! 

In any case, the errors will always show in the console.

For developers working on Oni, I recommend setting `debug.showNotificationOnError` to `true` in your config, and helping me fix these issues 😉 