### PR TITLE
Snippets - Bugfix: Exception when inserting a snippet without placeholders

### DIFF
--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -123,6 +123,14 @@ export class SnippetSession {
         )
         this._snippet = new OniSnippet(normalizedSnippet, new SnippetVariableResolver(this._buffer))
 
+        // If there are no placeholders, add an implicit one at the end
+        if (this._snippet.getPlaceholders().length === 0) {
+            this._snippet = new OniSnippet(
+                normalizedSnippet + "${0}",
+                new SnippetVariableResolver(this._buffer),
+            ) // tslint:disable-line
+        }
+
         const cursorPosition = await this._buffer.getCursorPosition()
         const [currentLine] = await this._buffer.getLines(
             cursorPosition.line,
@@ -263,6 +271,10 @@ export class SnippetSession {
     public async synchronizeUpdatedPlaceholders(): Promise<void> {
         // Get current cursor position
         const cursorPosition = await this._buffer.getCursorPosition()
+
+        if (!this._currentPlaceholder) {
+            return
+        }
 
         const bounds = this._getBoundsForPlaceholder()
 

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -126,9 +126,10 @@ export class SnippetSession {
         // If there are no placeholders, add an implicit one at the end
         if (this._snippet.getPlaceholders().length === 0) {
             this._snippet = new OniSnippet(
+                // tslint:disable-next-line
                 normalizedSnippet + "${0}",
                 new SnippetVariableResolver(this._buffer),
-            ) // tslint:disable-line
+            )
         }
 
         const cursorPosition = await this._buffer.getCursorPosition()

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -9,41 +9,43 @@ import { IFailedTest, Oni, runInProcTest } from "./common"
 
 const LongTimeout = 5000
 
-const CiTests = [
-    // Core functionality tests
-    "Api.Buffer.AddLayer",
-    "Api.Overlays.AddRemoveTest",
-    "AutoClosingPairsTest",
-    "AutoCompletionTest-CSS",
-    "AutoCompletionTest-HTML",
-    "AutoCompletionTest-TypeScript",
+const CiTests = ["Snippets.BasicInsertTest"]
 
-    "Configuration.JavaScriptEditorTest",
-    "Configuration.TypeScriptEditor.NewConfigurationTest",
-    "Configuration.TypeScriptEditor.CompletionTest",
+// const CiTests = [
+//     // Core functionality tests
+//     "Api.Buffer.AddLayer",
+//     "Api.Overlays.AddRemoveTest",
+//     "AutoClosingPairsTest",
+//     "AutoCompletionTest-CSS",
+//     "AutoCompletionTest-HTML",
+//     "AutoCompletionTest-TypeScript",
 
-    "Editor.ExternalCommandLineTest",
-    "Editor.BufferModifiedState",
-    "Editor.OpenFile.PathWithSpacesTest",
-    "Editor.TabModifiedState",
-    "MarkdownPreviewTest",
-    "PaintPerformanceTest",
-    "QuickOpenTest",
-    "StatusBar-Mode",
-    "Neovim.InvalidInitVimHandlingTest",
-    "NoInstalledNeovim",
-    "Sidebar.ToggleSplitTest",
-    "WindowManager.ErrorBoundary",
-    "Workspace.ConfigurationTest",
-    // Regression Tests
-    "Regression.1251.NoAdditionalProcessesOnStartup",
-    "Regression.1296.SettingColorsTest",
-    "Regression.1295.UnfocusedWindowTest",
-    "TextmateHighlighting.ScopesOnEnterTest",
+//     "Configuration.JavaScriptEditorTest",
+//     "Configuration.TypeScriptEditor.NewConfigurationTest",
+//     "Configuration.TypeScriptEditor.CompletionTest",
 
-    // This test occasionally hangs and breaks tests after - trying to move it later...
-    "LargeFileTest",
-]
+//     "Editor.ExternalCommandLineTest",
+//     "Editor.BufferModifiedState",
+//     "Editor.OpenFile.PathWithSpacesTest",
+//     "Editor.TabModifiedState",
+//     "MarkdownPreviewTest",
+//     "PaintPerformanceTest",
+//     "QuickOpenTest",
+//     "StatusBar-Mode",
+//     "Neovim.InvalidInitVimHandlingTest",
+//     "NoInstalledNeovim",
+//     "Sidebar.ToggleSplitTest",
+//     "WindowManager.ErrorBoundary",
+//     "Workspace.ConfigurationTest",
+//     // Regression Tests
+//     "Regression.1251.NoAdditionalProcessesOnStartup",
+//     "Regression.1296.SettingColorsTest",
+//     "Regression.1295.UnfocusedWindowTest",
+//     "TextmateHighlighting.ScopesOnEnterTest",
+
+//     // This test occasionally hangs and breaks tests after - trying to move it later...
+//     "LargeFileTest",
+// ]
 
 const WindowsOnlyTests = [
     // For some reason, the `beginFrameSubscription` call doesn't seem to work on OSX,

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -9,43 +9,44 @@ import { IFailedTest, Oni, runInProcTest } from "./common"
 
 const LongTimeout = 5000
 
-const CiTests = ["Snippets.BasicInsertTest"]
+const CiTests = [
+    // Core functionality tests
+    "Api.Buffer.AddLayer",
+    "Api.Overlays.AddRemoveTest",
+    "AutoClosingPairsTest",
+    "AutoCompletionTest-CSS",
+    "AutoCompletionTest-HTML",
+    "AutoCompletionTest-TypeScript",
 
-// const CiTests = [
-//     // Core functionality tests
-//     "Api.Buffer.AddLayer",
-//     "Api.Overlays.AddRemoveTest",
-//     "AutoClosingPairsTest",
-//     "AutoCompletionTest-CSS",
-//     "AutoCompletionTest-HTML",
-//     "AutoCompletionTest-TypeScript",
+    "Configuration.JavaScriptEditorTest",
+    "Configuration.TypeScriptEditor.NewConfigurationTest",
+    "Configuration.TypeScriptEditor.CompletionTest",
 
-//     "Configuration.JavaScriptEditorTest",
-//     "Configuration.TypeScriptEditor.NewConfigurationTest",
-//     "Configuration.TypeScriptEditor.CompletionTest",
+    "Editor.ExternalCommandLineTest",
+    "Editor.BufferModifiedState",
+    "Editor.OpenFile.PathWithSpacesTest",
+    "Editor.TabModifiedState",
+    "MarkdownPreviewTest",
+    "PaintPerformanceTest",
+    "QuickOpenTest",
+    "StatusBar-Mode",
+    "Neovim.InvalidInitVimHandlingTest",
+    "NoInstalledNeovim",
+    "Sidebar.ToggleSplitTest",
 
-//     "Editor.ExternalCommandLineTest",
-//     "Editor.BufferModifiedState",
-//     "Editor.OpenFile.PathWithSpacesTest",
-//     "Editor.TabModifiedState",
-//     "MarkdownPreviewTest",
-//     "PaintPerformanceTest",
-//     "QuickOpenTest",
-//     "StatusBar-Mode",
-//     "Neovim.InvalidInitVimHandlingTest",
-//     "NoInstalledNeovim",
-//     "Sidebar.ToggleSplitTest",
-//     "WindowManager.ErrorBoundary",
-//     "Workspace.ConfigurationTest",
-//     // Regression Tests
-//     "Regression.1251.NoAdditionalProcessesOnStartup",
-//     "Regression.1296.SettingColorsTest",
-//     "Regression.1295.UnfocusedWindowTest",
-//     "TextmateHighlighting.ScopesOnEnterTest",
+    "Snippets.BasicInsertTest",
 
-//     // This test occasionally hangs and breaks tests after - trying to move it later...
-//     "LargeFileTest",
-// ]
+    "WindowManager.ErrorBoundary",
+    "Workspace.ConfigurationTest",
+    // Regression Tests
+    "Regression.1251.NoAdditionalProcessesOnStartup",
+    "Regression.1296.SettingColorsTest",
+    "Regression.1295.UnfocusedWindowTest",
+    "TextmateHighlighting.ScopesOnEnterTest",
+
+    // This test occasionally hangs and breaks tests after - trying to move it later...
+    "LargeFileTest",
+]
 
 const WindowsOnlyTests = [
     // For some reason, the `beginFrameSubscription` call doesn't seem to work on OSX,

--- a/test/ci/Snippets.BasicInsertTest.ts
+++ b/test/ci/Snippets.BasicInsertTest.ts
@@ -1,0 +1,27 @@
+/**
+ * Simple snippet insert test case - validate the buffer is set, and that the cursor position is correct.
+ * This is a very simple case w/o placeholders
+ */
+
+import * as assert from "assert"
+
+import * as Oni from "oni-api"
+
+import { createNewFile } from "./Common"
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    await createNewFile("ts", oni)
+
+    await oni.snippets.insertSnippet("foo")
+
+    const [firstLine] = await oni.editors.activeEditor.activeBuffer.getLines(0, 1)
+
+    assert.strictEqual(firstLine, "foo", "Validate line is set correctly")
+
+    // TODO: getCursorPosition should be added to API
+    const cursorPosition = await (oni.editors.activeEditor.activeBuffer as any).getCursorPosition()
+
+    assert.deepEqual(cursorPosition, { line: 0, character: 3 }, "Validate cursor is at end of line")
+}


### PR DESCRIPTION
__Issue:__ When inserting a snippet without placeholders, like `Oni.snippets.insertSnippet("foo")`, we'd hit an exception that would break the insertion.

__Defect:__ When the cursors moves / buffer changes, we attempt to synchronize the change across placeholders, but we erroneously assume that a placeholder is available.

__Fix:__ If there is no placeholder, we'll add an implicit one at the end so that all snippets behave the same.