### PR TITLE
Dynamic file associations

### DIFF
--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -9,6 +9,7 @@ const _ = require("lodash")
 const shelljs = require("shelljs")
 
 const sourceFile = path.join(__dirname, "setup.template.iss")
+console.log(sourceFile)
 const destFile = path.join(__dirname, "..", "dist", "setup.iss")
 
 shelljs.rm(destFile)
@@ -23,22 +24,13 @@ const prodName = packageMeta.build.productName
 // Replace template variables
 
 const valuesToReplace = {
-    "AppName": prodName,
-    "AppExecutableName": `${prodName}.exe`,
-    "AppSetupExecutableName": `${prodName}-${version}-ia32-win`,
-    "Version": version,
-    "SourcePath": path.join(__dirname, "..", "dist", "win-ia32-unpacked", "*"),
-    "WizardImageFilePath": path.join(__dirname, "setup", "Oni_128.bmp"),
-    "WizardSmallImageFilePath": path.join(__dirname, "setup", "Oni_54.bmp")
-}
-
-const fileExtensions = {
-    ".txt": "Text Files",
-    ".ts": "TypeScript Files",
-    ".js": "JavaScript Files",
-    ".tsx": "TypeScript Files",
-    ".jsx": "JavaScript Files",
-    ".md": "Markdown Files"
+    AppName: prodName,
+    AppExecutableName: `${prodName}.exe`,
+    AppSetupExecutableName: `${prodName}-${version}-ia32-win`,
+    Version: version,
+    SourcePath: path.join(__dirname, "..", "dist", "win-ia32-unpacked", "*"),
+    WizardImageFilePath: path.join(__dirname, "setup", "Oni_128.bmp"),
+    WizardSmallImageFilePath: path.join(__dirname, "setup", "Oni_54.bmp"),
 }
 
 const addToEnv = `
@@ -50,7 +42,6 @@ Root: HKCU; Subkey: "SOFTWARE\\Classes\\*\\shell\\${prodName}\\command"; ValueTy
 `
 
 function getFileRegKey(ext, desc) {
-
     return `
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}${ext}"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
@@ -60,14 +51,14 @@ Root: HKCR; Subkey: "${prodName}${ext}\\shell\\open\\command"; ValueType: string
 `
 }
 
-_.keys(valuesToReplace).forEach((key) => {
+_.keys(valuesToReplace).forEach(key => {
     shelljs.sed("-i", "{{" + key + "}}", valuesToReplace[key], destFile)
 })
 
 let allFilesToAddRegKeysFor = ""
 
-_.keys(fileExtensions).forEach((key) => {
-    allFilesToAddRegKeysFor += getFileRegKey(key, fileExtensions[key])
+packageMeta.build.fileAssociations.forEach(association => {
+    allFilesToAddRegKeysFor += getFileRegKey(`.${association.ext}`, association.name)
 })
 
 allFilesToAddRegKeysFor += addToEnv

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -9,7 +9,6 @@ const _ = require("lodash")
 const shelljs = require("shelljs")
 
 const sourceFile = path.join(__dirname, "setup.template.iss")
-console.log(sourceFile)
 const destFile = path.join(__dirname, "..", "dist", "setup.iss")
 
 shelljs.rm(destFile)

--- a/package.json
+++ b/package.json
@@ -135,6 +135,18 @@
                 "name": "CSS",
                 "role": "Editor",
                 "isPackage": true
+            },
+            {
+                "ext": "txt",
+                "name": "Text",
+                "role": "Editor",
+                "isPackage": true
+            },
+            {
+                "ext": "md",
+                "name": "Markdown",
+                "role": "Editor",
+                "isPackage": true
             }
         ]
     },


### PR DESCRIPTION
This commit removes the hardcoded mappings of fileExtensions from BuildSetupTemplate.js and reuses the mappings in package.json as per #1502.

There's a meaningless empty commit as I didn't realize at first that the change the valuesToReplace to not use strings as keys was done by a precommit hook and thought it was leftover from some earlier fiddling.