### PR TITLE
feature/add truncation to working dir path

### DIFF
--- a/vim/core/oni-core-statusbar/index.js
+++ b/vim/core/oni-core-statusbar/index.js
@@ -91,7 +91,16 @@ const activate = Oni => {
 
         const element = React.createElement(
             "div",
-            { style: { color: "rgb(140, 140, 140)" }, onClick: openFolderCommand },
+            {
+                style: {
+                    color: "rgb(140, 140, 140)",
+                    maxWidth: "25rem",
+                    textOverflow: "ellipsis",
+                    whitespace: "nowrap",
+                    overflow: "hidden",
+                },
+                onClick: openFolderCommand,
+            },
             workingDirectory,
         )
         workingDirectoryItem.setContents(element)


### PR DESCRIPTION
The statusbar item which shows the working directory is not currently limited and can have any length depending on the working dir path. This means it dominates the left hand side of the status bar. This PR adds a limit and a text overflow to truncate it if it is too long.