### PR TITLE
Bugfix: Fix jerkiness on adding new tab

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -138,7 +138,14 @@ export class Tab extends React.Component<ITabPropsWithClick> {
     private _tab: HTMLDivElement
     public componentWillReceiveProps(next: ITabPropsWithClick) {
         if (next.isSelected && this._tab) {
-            this._tab.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" })
+            const anyTab = this._tab as any
+            if (anyTab.scrollIntoViewIfNeeded) {
+                anyTab.scrollIntoViewIfNeeded({
+                    behavior: "smooth",
+                    block: "center",
+                    inline: "center",
+                })
+            }
         }
     }
     public render() {


### PR DESCRIPTION
I noticed while working on the demo video that, when a first tab is opened, the screen 'bounces' - so it feels a little jerky when adding the initial buffer.

The culprit was the `scrollIntoView` on the tab - this would _always_ force a scroll, even if the tab was in view. The fix is to use `scrollIntoViewIfNeeded`, which only runs if the tab is out of the view.

__Before:__
![output](https://user-images.githubusercontent.com/13532591/37319163-39a374b4-262b-11e8-8e49-9d198aae114a.gif)

__After:__
![output](https://user-images.githubusercontent.com/13532591/37319271-b43dda7a-262b-11e8-9394-7e7aeb819cd1.gif)
