### PR TITLE
Refactoring: Refactor blur/focus handling to WindowManager

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -17,7 +17,7 @@ import * as types from "vscode-languageserver-types"
 import { Provider } from "react-redux"
 import { bindActionCreators, Store } from "redux"
 
-import { clipboard, ipcRenderer, remote } from "electron"
+import { clipboard, ipcRenderer } from "electron"
 
 import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -598,23 +598,6 @@ export class NeovimEditor extends Editor implements IEditor {
 
         this._render()
 
-        const browserWindow = remote.getCurrentWindow()
-
-        browserWindow.on("blur", () => {
-            this._neovimInstance.autoCommands.executeAutoCommand("FocusLost")
-        })
-
-        browserWindow.on("focus", () => {
-            this._neovimInstance.autoCommands.executeAutoCommand("FocusGained")
-
-            // If the user has autoread enabled, we should run ":checktime" on
-            // focus, as this is needed to get the file to auto-update.
-            // https://github.com/neovim/neovim/issues/1936
-            if (_configuration.getValue("vim.setting.autoread")) {
-                this._neovimInstance.command(":checktime")
-            }
-        })
-
         this._onConfigChanged(this._configuration.getValues())
         this._configuration.onConfigurationChanged.subscribe(
             (newValues: Partial<IConfigurationValues>) => this._onConfigChanged(newValues),
@@ -693,12 +676,15 @@ export class NeovimEditor extends Editor implements IEditor {
         this._onEnterEvent.dispatch()
         this._actions.setHasFocus(true)
         this._commands.activate()
+
+        this._neovimInstance.autoCommands.executeAutoCommand("FocusGained")
     }
 
     public leave(): void {
         Log.info("[NeovimEditor::leave]")
         this._actions.setHasFocus(false)
         this._commands.deactivate()
+        this._neovimInstance.autoCommands.executeAutoCommand("FocusLost")
     }
 
     public async clearSelection(): Promise<void> {

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -8,6 +8,8 @@
  * to the active editor, and managing transitions between editors.
  */
 
+import { remote } from "electron"
+
 import { Store } from "redux"
 
 import * as Oni from "oni-api"
@@ -143,6 +145,20 @@ export class WindowManager {
 
     constructor() {
         this._rootNavigator = new RelationalSplitNavigator()
+
+        const browserWindow = remote.getCurrentWindow()
+
+        browserWindow.on("blur", () => {
+            if (this.activeSplit) {
+                this.activeSplit.leave()
+            }
+        })
+
+        browserWindow.on("focus", () => {
+            if (this.activeSplit) {
+                this.activeSplit.enter()
+            }
+        })
 
         this._store = createStore()
         this._leftDock = new WindowDockNavigator(() => leftDockSelector(this._store.getState()))


### PR DESCRIPTION
__Issue:__ With editor multiplexing, and closing editors, the current strategy for handling focus doesn't scale. When an editor is disposed, it still tries to send events to its `NeovimInstance`

__Fix:__ Push the blur/focus handling to `WindowManager`, which is alive for the entire lifecycle of the app, and already delegates to `enter`/`leave` events to windows anyway.