### PR TITLE
Refactoring: Refactor 'menu-item-click' to command

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -620,14 +620,6 @@ export class NeovimEditor extends Editor implements IEditor {
             (newValues: Partial<IConfigurationValues>) => this._onConfigChanged(newValues),
         )
 
-        ipcRenderer.on("menu-item-click", (_evt: any, message: string) => {
-            if (message.startsWith(":")) {
-                this._neovimInstance.command('exec "' + message + '"')
-            } else {
-                this._neovimInstance.command('exec ":normal! ' + message + '"')
-            }
-        })
-
         ipcRenderer.on("open-files", (_evt: any, message: string, files: string[]) => {
             this._openFiles(files, message)
         })

--- a/browser/src/Services/Commands/GlobalCommands.ts
+++ b/browser/src/Services/Commands/GlobalCommands.ts
@@ -9,6 +9,7 @@ import { remote } from "electron"
 
 import * as Oni from "oni-api"
 
+import { EditorManager } from "./../../Services/EditorManager"
 import { MenuManager } from "./../../Services/Menu"
 import { showAboutMessage } from "./../../Services/Metadata"
 import { multiProcess } from "./../../Services/MultiProcess"
@@ -23,6 +24,7 @@ import * as Platform from "./../../Platform"
 
 export const activate = (
     commandManager: CommandManager,
+    editorManager: EditorManager,
     menuManager: MenuManager,
     tasks: Tasks,
 ) => {
@@ -42,6 +44,14 @@ export const activate = (
     const popupMenuSelect = popupMenuCommand(() => menuManager.selectMenuItem())
 
     const commands = [
+        new CallbackCommand("editor.executeVimCommand", null, null, (message: string) => {
+            const neovim = editorManager.activeEditor.neovim
+            if (message.startsWith(":")) {
+                neovim.command('exec "' + message + '"')
+            } else {
+                neovim.command('exec ":normal! ' + message + '"')
+            }
+        }),
         new CallbackCommand("oni.about", null, null, () => showAboutMessage()),
 
         new CallbackCommand("oni.quit", null, null, () => remote.app.quit()),

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -251,7 +251,7 @@ const start = async (args: string[]): Promise<void> => {
     AutoClosingPairs.activate(configuration, editorManager, inputManager, languageManager)
 
     const GlobalCommands = await globalCommandsPromise
-    GlobalCommands.activate(commandManager, menuManager, tasks)
+    GlobalCommands.activate(commandManager, editorManager, menuManager, tasks)
 
     const WorkspaceCommands = await workspaceCommandsPromise
     WorkspaceCommands.activateCommands(

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -32,7 +32,10 @@ export const buildMenu = (mainWindow, loadInit) => {
     const normalizePath = fileName => fileName.split("\\").join("/")
 
     const executeVimCommand = (browserWindow: BrowserWindow, command: string) => {
-        executeMenuAction(browserWindow, { evt: "menu-item-click", cmd: [command] })
+        executeMenuAction(browserWindow, {
+            evt: "execute-command",
+            cmd: ["editor.executeVimCommand", command],
+        })
     }
 
     const executeVimCommandForMultipleFiles = (


### PR DESCRIPTION
Right now, if we have multiple editors, they all try and handle the `menu-item-click` ipc call.

This refactors the call to be a command, which is directed towards the `activeEditor`, so that it is handled correctly in the multiplexing case.