### PR TITLE
Bugfix: Snippet placeholder highlighting not rendering on initial insertion

### DIFF
--- a/browser/src/Services/Snippets/SnippetBufferLayer.tsx
+++ b/browser/src/Services/Snippets/SnippetBufferLayer.tsx
@@ -85,9 +85,10 @@ export class SnippetBufferLayerView extends React.PureComponent<
     constructor(props: ISnippetBufferLayerViewProps) {
         super(props)
 
+        const latestCursorState = props.snippetSession.getLatestCursors()
         this.state = {
-            mode: null,
-            cursors: [],
+            mode: latestCursorState.mode,
+            cursors: latestCursorState.cursors,
         }
     }
 

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -91,6 +91,11 @@ export class SnippetSession {
 
     private _currentPlaceholder: OniSnippetPlaceholder = null
 
+    private _lastCursorMovedEvent: IMirrorCursorUpdateEvent = {
+        mode: null,
+        cursors: [],
+    }
+
     public get buffer(): IBuffer {
         return this._buffer
     }
@@ -161,6 +166,7 @@ export class SnippetSession {
         }
 
         await this.nextPlaceholder()
+        await this.updateCursorPosition()
     }
 
     public async nextPlaceholder(): Promise<void> {
@@ -261,10 +267,16 @@ export class SnippetSession {
             }
         })
 
-        this._onCursorMovedEvent.dispatch({
+        this._lastCursorMovedEvent = {
             mode,
             cursors: cursorPositions,
-        })
+        }
+
+        this._onCursorMovedEvent.dispatch(this._lastCursorMovedEvent)
+    }
+
+    public getLatestCursors(): IMirrorCursorUpdateEvent {
+        return this._lastCursorMovedEvent
     }
 
     // Helper method to query the value of the current placeholder,

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -5,7 +5,10 @@
 import * as assert from "assert"
 import * as types from "vscode-languageserver-types"
 
-import { SnippetSession } from "./../../../src/Services/Snippets/SnippetSession"
+import {
+    IMirrorCursorUpdateEvent,
+    SnippetSession,
+} from "./../../../src/Services/Snippets/SnippetSession"
 
 import * as Mocks from "./../../Mocks"
 
@@ -77,6 +80,24 @@ describe("SnippetSession", () => {
 
             const [firstLine] = await mockBuffer.getLines(0, 1)
             assert.strictEqual(firstLine, "\t\tfoo")
+        })
+
+        it("mirrors cursor placeholders on insert", async () => {
+            snippetSession = new SnippetSession(mockEditor as any, "${1:test} ${1}") // tslint:idsable-line
+
+            let lastEvent: IMirrorCursorUpdateEvent = null
+            snippetSession.onCursorMoved.subscribe(evt => {
+                lastEvent = evt
+            })
+
+            await snippetSession.start()
+
+            assert.ok(lastEvent !== null, "Verify 'onCursorMoved' event was fired")
+
+            const firstCursor = types.Range.create(0, 0, 0, 3)
+            const secondCursor = types.Range.create(0, 5, 0, 8)
+
+            assert.deepEqual(lastEvent.cursors, [firstCursor, secondCursor], "Validate cursors")
         })
     })
 

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -83,21 +83,24 @@ describe("SnippetSession", () => {
         })
 
         it("mirrors cursor placeholders on insert", async () => {
-            snippetSession = new SnippetSession(mockEditor as any, "${1:test} ${1}") // tslint:idsable-line
+            snippetSession = new SnippetSession(mockEditor as any, "${1:test} ${1} ${1}") // tslint:idsable-line
 
             let lastEvent: IMirrorCursorUpdateEvent = null
             snippetSession.onCursorMoved.subscribe(evt => {
                 lastEvent = evt
             })
 
+            // Set visual mode so that the range is blockwise
+            mockEditor.simulateModeChange("visual")
+
             await snippetSession.start()
 
             assert.ok(lastEvent !== null, "Verify 'onCursorMoved' event was fired")
 
-            const firstCursor = types.Range.create(0, 0, 0, 3)
-            const secondCursor = types.Range.create(0, 5, 0, 8)
+            const secondCursor = types.Range.create(0, 5, 0, 9)
+            const thirdCursor = types.Range.create(0, 10, 0, 14)
 
-            assert.deepEqual(lastEvent.cursors, [firstCursor, secondCursor], "Validate cursors")
+            assert.deepEqual(lastEvent.cursors, [secondCursor, thirdCursor], "Validate cursors")
         })
     })
 


### PR DESCRIPTION
__Issue:__ The highlighting for placeholders doesn't show up on additional insert. You have to tab, and then shift-tab back, to see the change.

__Defect:__ The placeholder info was only being pushed out on cursor moved, and not on initial insert.

__Fix:__ Update cursors on starting the snippet, and ensure that the `SnippetBufferLayer` has the correct starting state.