### PR TITLE
Use xdg compliant path for config.js/config.tsx files

### DIFF
--- a/browser/src/Services/Configuration/UserConfiguration.ts
+++ b/browser/src/Services/Configuration/UserConfiguration.ts
@@ -36,5 +36,5 @@ export const getUserConfigFolderPath = (): string => {
 
     return Platform.isWindows()
         ? path.join(Platform.getUserHome(), "oni")
-        : path.join(Platform.getUserHome(), ".oni")
+        : path.join(Platform.getUserHome(), ".config/oni") // XDG-compliant
 }


### PR DESCRIPTION
This PR attempts to move the config folder to an XDG-compliant path: `~/.config/oni` as discussed in https://github.com/onivim/oni/issues/1478

:information_source: This change should probably be mentioned in a changelog/documentation so that users are not confused as to where their config went
