### PR TITLE
Configuration: Use 'regex' as the default filter strategy

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -105,7 +105,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.linePadding": 2,
 
     "editor.quickOpen.execCommand": null,
-    "editor.quickOpen.filterStrategy": "fuse",
+    "editor.quickOpen.filterStrategy": "regex",
 
     "editor.split.mode": "native",
 


### PR DESCRIPTION
The 'regex' strategy for quick-open is more predictable and easier to explain - and more usable than ever thanks to @CrossR 's work on the refine option in #1727 (which I'm already hooked on! 💯 )

I'd like to try out switching the default to use the `regex` strategy for our 0.3.2 release - especially given the refinement behavior we have.