### PR TITLE
Edit user config in a VSCode-like split view

### DIFF
--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -14,6 +14,7 @@ import * as Log from "./../../Log"
 import { EditorManager } from "./../EditorManager"
 
 import { Configuration } from "./Configuration"
+import { DefaultConfiguration } from "./DefaultConfiguration"
 
 // For configuring Oni, JavaScript is the de-facto language, and the configuration
 // today will _always_ happen through `config.js`
@@ -106,9 +107,24 @@ export class ConfigurationEditManager {
             }
         }
 
-        this._editorManager.activeEditor.openFile(normalizedEditFile, {
+        // Create the buffer with the list of all the available options
+        await this._createReadonlyReferenceBuffer()
+
+        // Open the actual configuration file
+        await this._editorManager.activeEditor.openFile(normalizedEditFile, {
+            openMode: Oni.FileOpenMode.VerticalSplit,
+        })
+    }
+
+    private async _createReadonlyReferenceBuffer() {
+        const referenceBuffer = await this._editorManager.activeEditor.openFile("", {
             openMode: Oni.FileOpenMode.NewTab,
         })
+
+        // Format the default configuration values as a pretty JSON object, then
+        // set it as the reference buffer content
+        const referenceContent = JSON.stringify(DefaultConfiguration, null, "  ")
+        await referenceBuffer.setLines(0, 1, referenceContent.split("\n"))
     }
 
     private async _transpileConfiguration(


### PR DESCRIPTION
This PR attempts to modify the way the "user config" is currently edited so that:
- It is shown side-by-side with a reference file showing all the possible options
- The reference file is annotated/commented and not just a raw JSON file
- The reference file is readonly

### What is actually implemented
- The split view is displayed with the default configuration values

### What needs to be done
- The reference file needs to be annotated/commented. This might have to wait for the new *Config API* to be implemented
- The reference file needs to be readonly