### PR TITLE
Bugfix: Hide commandline overlay when editor is disposed

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -648,6 +648,11 @@ export class NeovimEditor extends Editor implements IEditor {
             this._completion = null
         }
 
+        if (this._externalMenuOverlay) {
+            this._externalMenuOverlay.hide()
+            this._externalMenuOverlay = null
+        }
+
         // TODO: Implement full disposal logic
         this._popupMenu.dispose()
         this._popupMenu = null


### PR DESCRIPTION
When `editor.split.mode` is `'oni'`, and you close a file in a split, the command line stays open. This change explicitly hides it. We'll also need to look at properly `disposing` it (ensuring that it doesn't stick around the DOM).