### PR TITLE
Refactoring: Tighten up editor disposal

### DIFF
--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -9,6 +9,8 @@ import { Event, IEvent } from "oni-types"
 
 import * as types from "vscode-languageserver-types"
 
+import { Disposable } from "./../Utility"
+
 export interface IEditor extends Oni.Editor {
     // Methods
     init(filesToOpen: string[]): void
@@ -20,7 +22,7 @@ export interface IEditor extends Oni.Editor {
 /**
  * Base class for Editor implementations
  */
-export class Editor implements Oni.Editor {
+export class Editor extends Disposable implements Oni.Editor {
     private _currentMode: string
     private _onBufferEnterEvent = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferLeaveEvent = new Event<Oni.EditorBufferEventArgs>()

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -15,6 +15,8 @@ import * as reduce from "lodash/reduce"
 import { Observable } from "rxjs/Observable"
 import { Subject } from "rxjs/Subject"
 
+import { IDisposable } from "oni-types"
+
 import * as types from "vscode-languageserver-types"
 
 /**
@@ -23,6 +25,25 @@ import * as types from "vscode-languageserver-types"
  * into the module. For most modules, we want the webpack behavior,
  * but for some (like node modules), we want to explicitly require them.
  */
+
+export class Disposable implements IDisposable {
+    private _disposables: IDisposable[] = []
+
+    public get isDisposed(): boolean {
+        return !!this._disposables
+    }
+
+    protected trackDisposable(disposable: IDisposable) {
+        this._disposables.push(disposable)
+    }
+
+    public dispose(): void {
+        if (!this.isDisposed) {
+            this._disposables.forEach(disposable => disposable.dispose())
+            this._disposables = null
+        }
+    }
+}
 
 export function nodeRequire(moduleName: string): any {
     return window["require"](moduleName) // tslint:disable-line

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -19,22 +19,11 @@ import { IDisposable } from "oni-types"
 
 import * as types from "vscode-languageserver-types"
 
-/**
- * Use a `node` require instead of a `webpack` require
- * The difference is that `webpack` require will bake the javascript
- * into the module. For most modules, we want the webpack behavior,
- * but for some (like node modules), we want to explicitly require them.
- */
-
 export class Disposable implements IDisposable {
     private _disposables: IDisposable[] = []
 
     public get isDisposed(): boolean {
         return !!this._disposables
-    }
-
-    protected trackDisposable(disposable: IDisposable) {
-        this._disposables.push(disposable)
     }
 
     public dispose(): void {
@@ -43,7 +32,18 @@ export class Disposable implements IDisposable {
             this._disposables = null
         }
     }
+
+    protected trackDisposable(disposable: IDisposable) {
+        this._disposables.push(disposable)
+    }
 }
+
+/**
+ * Use a `node` require instead of a `webpack` require
+ * The difference is that `webpack` require will bake the javascript
+ * into the module. For most modules, we want the webpack behavior,
+ * but for some (like node modules), we want to explicitly require them.
+ */
 
 export function nodeRequire(moduleName: string): any {
     return window["require"](moduleName) // tslint:disable-line


### PR DESCRIPTION
__Issue:__ With `Editor` instances opening / closing in the multiplexed world (`editor.split.mode` === `'oni'`), the disposal logic needs to be improved. 

__Defect:__ Today, after an editor window is closed, it still continues to listen to events (and isn't garbage collected, due to hanging references - leaking memory as editors are added and closing). This is different than today where there is a single `Editor` that has the same lifetime as the app.

__Fix:__ This is an initial step to unhook some of the event handlers on dispose. There's still more work to fully clean up all the hanging object references. Eventually, it'd be nice to have a CiTest that creates / closes a bunch of splits, forces a GC, and verifies that the memory isn't increasing.