### PR TITLE
Refactoring: Move flip animation to separate component

### DIFF
--- a/browser/src/Services/Learning/Achievements/AchievementNotificationRenderer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementNotificationRenderer.tsx
@@ -10,8 +10,8 @@ import * as React from "react"
 import { CSSTransition, TransitionGroup } from "react-transition-group"
 import styled, { keyframes } from "styled-components"
 
-import { FlipCard } from "./../../../UI/components/FlipCard"
 import { boxShadow, withProps } from "./../../../UI/components/common"
+import { FlipCard } from "./../../../UI/components/FlipCard"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
 export class AchievementNotificationRenderer {

--- a/browser/src/Services/Learning/Achievements/AchievementNotificationRenderer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementNotificationRenderer.tsx
@@ -10,6 +10,7 @@ import * as React from "react"
 import { CSSTransition, TransitionGroup } from "react-transition-group"
 import styled, { keyframes } from "styled-components"
 
+import { FlipCard } from "./../../../UI/components/FlipCard"
 import { boxShadow, withProps } from "./../../../UI/components/common"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
@@ -89,30 +90,11 @@ const AchievementWrapper = withProps<{}>(styled.div)`
     }
 `
 
-const AchievementImageWrapper = styled.div`
+const FlipCardWrapper = styled.div`
     width: 48px;
     height: 48px;
     margin: 8px;
-    position: relative;
     flex: 0 0 auto;
-    transform-style: preserve-3d;
-
-    & .front,
-    & .back {
-        margin: 0;
-        display: block;
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        backface-visibility: hidden;
-    }
-
-    & .back {
-        transform: rotateY(180deg);
-    }
-
-    transition-duration: 1s;
-    transition-property: transform;
 `
 
 const AchievementIconWrapper = withProps<{}>(styled.div)`
@@ -168,23 +150,22 @@ export class AchievementView extends React.PureComponent<IAchievement, Achieveme
         return (
             <CSSTransition {...this.props} timeout={2500} classNames="animate" appear={true}>
                 <AchievementWrapper className="achievement" key={this.props.title}>
-                    <AchievementImageWrapper
-                        style={{
-                            transform: this.state.flipCard ? "rotateY(180deg)" : "rotateY(0deg)",
-                        }}
-                    >
-                        <div className="front">
-                            <img
-                                src="images/256x256.png"
-                                style={{ width: "100%", height: "100%" }}
-                            />
-                        </div>
-                        <div className="back">
-                            <AchievementIconWrapper>
-                                <Icon name="trophy" size={IconSize.TwoX} />
-                            </AchievementIconWrapper>
-                        </div>
-                    </AchievementImageWrapper>
+                    <FlipCardWrapper>
+                        <FlipCard
+                            isFlipped={this.state.flipCard}
+                            front={
+                                <img
+                                    src="images/256x256.png"
+                                    style={{ width: "100%", height: "100%" }}
+                                />
+                            }
+                            back={
+                                <AchievementIconWrapper>
+                                    <Icon name="trophy" size={IconSize.TwoX} />
+                                </AchievementIconWrapper>
+                            }
+                        />
+                    </FlipCardWrapper>
                     <div className="container vertical full" style={{ padding: "0em 1em" }}>
                         <div style={{ fontWeight: "bold", paddingBottom: "0.25em" }}>
                             Achievement Unlocked

--- a/browser/src/UI/components/FlipCard.tsx
+++ b/browser/src/UI/components/FlipCard.tsx
@@ -1,0 +1,53 @@
+/**
+ * FlipCard.tsx
+ *
+ * Component that flips between a 'front' and a 'back'
+ */
+
+import * as React from "react"
+
+import styled from "styled-components"
+
+export interface IFlipCardProps {
+    front: JSX.Element
+    back: JSX.Element
+
+    isFlipped: boolean
+}
+
+const FlipCardWrapper = styled.div`
+    position: relative;
+    transform-style: preserve-3d;
+    width: 100%;
+    height: 100%;
+
+    & .front,
+    & .back {
+        margin: 0;
+        display: block;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        backface-visibility: hidden;
+    }
+
+    & .back {
+        transform: rotateY(180deg);
+    }
+
+    transition-duration: 1s;
+    transition-property: transform;
+`
+
+export const FlipCard = (props: IFlipCardProps): JSX.Element => {
+    const style: React.CSSProperties = {
+        transform: props.isFlipped ? "rotateY(180deg)" : "rotateY(0deg)",
+    }
+
+    return (
+        <FlipCardWrapper style={style}>
+            <div className="front">{props.front}</div>
+            <div className="back">{props.back}</div>
+        </FlipCardWrapper>
+    )
+}


### PR DESCRIPTION
I'd like to reuse the 'flip' animation in some other components, so this factors out that into a reusable component, and updates the achievement UI to use the new component.