### PR TITLE
Achievements: Add 'Trophy Case' buffer layer

### DIFF
--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -1,0 +1,32 @@
+/**
+ * AchievementsBufferLayer.tsx
+ *
+ * This is an implementation of a buffer layer to show the
+ * achievements in a 'trophy-case' style view
+ */
+
+import * as React from "react"
+
+// import styled, { keyframes } from "styled-components"
+
+// import { inputManager, InputManager } from "./../../Services/InputManager"
+
+import * as Oni from "oni-api"
+
+import { AchievementsManager } from "./AchievementsManager"
+
+export class AchievementsBufferLayer implements Oni.BufferLayer {
+    public get id(): string {
+        return "oni.layer.achievements"
+    }
+
+    public get friendlyName(): string {
+        return "Achievements"
+    }
+
+    constructor(private _achievements: AchievementsManager) {}
+
+    public render(context: Oni.BufferLayerRenderContext): JSX.Element {
+        return <div>{JSON.stringify(this._achievements.getAchievements())}</div>
+    }
+}

--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -11,9 +11,9 @@ import styled from "styled-components"
 
 // import { inputManager, InputManager } from "./../../Services/InputManager"
 
+import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
 import { boxShadow, withProps } from "./../../../UI/components/common"
 import { Icon, IconSize } from "./../../../UI/Icon"
-import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
 
 import * as Oni from "oni-api"
 
@@ -45,8 +45,8 @@ export const Container = withProps<ContainerProps>(styled.div)`
 `
 
 export const TrophyCaseViewWrapper = withProps<{}>(styled.div)`
-    background-color: ${p => p.theme["background"]};
-    color: ${p => p.theme["foreground"]};
+    background-color: ${p => p.theme.background};
+    color: ${p => p.theme.foreground};
     width: 100%;
     height: 100%;
 

--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -12,6 +12,8 @@ import styled from "styled-components"
 // import { inputManager, InputManager } from "./../../Services/InputManager"
 
 import { boxShadow, withProps } from "./../../../UI/components/common"
+import { Icon, IconSize } from "./../../../UI/Icon"
+import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
 
 import * as Oni from "oni-api"
 
@@ -44,35 +46,79 @@ export const Container = withProps<ContainerProps>(styled.div)`
 
 export const TrophyCaseViewWrapper = withProps<{}>(styled.div)`
     background-color: ${p => p.theme["background"]};
+    color: ${p => p.theme["foreground"]};
     width: 100%;
     height: 100%;
 
     display: flex;
     flex-direction: column;
 
-    justify-content: center;
+    justify-content: flex-start;
 `
 
 export const TrophyCaseItemViewWrapper = withProps<{}>(styled.div)`
     ${boxShadow}
     background-color: ${p => p.theme["editor.background"]};
     margin: 1em;
-    padding: 1em;
-
+    position: relative;
 
     display: flex;
     flex-direction: horizontal;
+`
+
+export const TrophyCaseBackground = styled.div`
+    position: absolute;
+    color: black;
+    opacity: 0.1;
+    width: 100%;
+    height: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`
+
+export const TrophyItemIcon = styled.div`
+    width: 48px;
+    height: 48px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    padding: 1em;
+    margin: 0.5em;
+    background-color: rgba(0, 0, 0, 0.2);
+    color: rgba(255, 255, 255, 0.5);
+`
+
+export const TitleText = styled.div`
+    padding-bottom: 0.25em;
+    font-weight: bold;
+    opacity: 0.9;
+`
+
+export const DescriptionText = styled.div`
+    font-size: 0.9em;
 `
 
 export const TrophyCaseItemView = (props: { achievementInfo: AchievementWithProgressInfo }) => {
     return (
         <TrophyCaseItemViewWrapper>
             <Fixed>
-                <div>HI</div>
+                <TrophyItemIcon>
+                    <Icon name="trophy" size={IconSize.ThreeX} />
+                </TrophyItemIcon>
             </Fixed>
-            <Full>
-                <div>{props.achievementInfo.achievement.name}</div>
-                <div>{props.achievementInfo.achievement.description}</div>
+            <Full
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    padding: "1em",
+                }}
+            >
+                <TitleText>{props.achievementInfo.achievement.name}</TitleText>
+                <DescriptionText>{props.achievementInfo.achievement.description}</DescriptionText>
             </Full>
         </TrophyCaseItemViewWrapper>
     )
@@ -94,7 +140,20 @@ export class TrophyCaseView extends React.PureComponent<
         const items = this.state.progressInfo.map(item => (
             <TrophyCaseItemView achievementInfo={item} />
         ))
-        return <TrophyCaseViewWrapper>{items}</TrophyCaseViewWrapper>
+        return (
+            <TrophyCaseViewWrapper>
+                <TrophyCaseBackground>
+                    <Icon name="trophy" size={IconSize.FiveX} style={{ fontSize: "20em" }} />
+                </TrophyCaseBackground>
+                <Fixed>
+                    <BufferLayerHeader
+                        title="Achievements"
+                        description="Discover new functionality by unlocking achievements"
+                    />
+                </Fixed>
+                <Full>{items}</Full>
+            </TrophyCaseViewWrapper>
+        )
     }
 }
 

--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -7,13 +7,96 @@
 
 import * as React from "react"
 
-// import styled, { keyframes } from "styled-components"
+import styled from "styled-components"
 
 // import { inputManager, InputManager } from "./../../Services/InputManager"
 
+import { boxShadow, withProps } from "./../../../UI/components/common"
+
 import * as Oni from "oni-api"
 
-import { AchievementsManager } from "./AchievementsManager"
+import { AchievementsManager, AchievementWithProgressInfo } from "./AchievementsManager"
+
+export interface ITrophyCaseViewProps {
+    achievements: AchievementsManager
+}
+
+export interface ITrophyCaseViewState {
+    progressInfo: AchievementWithProgressInfo[]
+}
+
+export interface ContainerProps {
+    direction: "horizontal" | "vertical"
+}
+
+export const Fixed = styled.div`
+    flex: 0 0 auto;
+`
+
+export const Full = styled.div`
+    flex: 1 1 auto;
+`
+
+export const Container = withProps<ContainerProps>(styled.div)`
+    display: flex;
+    flex-direction: ${p => (p.direction === "vertical" ? "column" : "row")};
+`
+
+export const TrophyCaseViewWrapper = withProps<{}>(styled.div)`
+    background-color: ${p => p.theme["background"]};
+    width: 100%;
+    height: 100%;
+
+    display: flex;
+    flex-direction: column;
+
+    justify-content: center;
+`
+
+export const TrophyCaseItemViewWrapper = withProps<{}>(styled.div)`
+    ${boxShadow}
+    background-color: ${p => p.theme["editor.background"]};
+    margin: 1em;
+    padding: 1em;
+
+
+    display: flex;
+    flex-direction: horizontal;
+`
+
+export const TrophyCaseItemView = (props: { achievementInfo: AchievementWithProgressInfo }) => {
+    return (
+        <TrophyCaseItemViewWrapper>
+            <Fixed>
+                <div>HI</div>
+            </Fixed>
+            <Full>
+                <div>{props.achievementInfo.achievement.name}</div>
+                <div>{props.achievementInfo.achievement.description}</div>
+            </Full>
+        </TrophyCaseItemViewWrapper>
+    )
+}
+
+export class TrophyCaseView extends React.PureComponent<
+    ITrophyCaseViewProps,
+    ITrophyCaseViewState
+> {
+    constructor(props: ITrophyCaseViewProps) {
+        super(props)
+
+        this.state = {
+            progressInfo: props.achievements.getAchievements(),
+        }
+    }
+
+    public render(): JSX.Element {
+        const items = this.state.progressInfo.map(item => (
+            <TrophyCaseItemView achievementInfo={item} />
+        ))
+        return <TrophyCaseViewWrapper>{items}</TrophyCaseViewWrapper>
+    }
+}
 
 export class AchievementsBufferLayer implements Oni.BufferLayer {
     public get id(): string {
@@ -27,6 +110,6 @@ export class AchievementsBufferLayer implements Oni.BufferLayer {
     constructor(private _achievements: AchievementsManager) {}
 
     public render(context: Oni.BufferLayerRenderContext): JSX.Element {
-        return <div>{JSON.stringify(this._achievements.getAchievements())}</div>
+        return <TrophyCaseView achievements={this._achievements} />
     }
 }

--- a/browser/src/Services/Learning/Achievements/AchievementsManager.ts
+++ b/browser/src/Services/Learning/Achievements/AchievementsManager.ts
@@ -24,6 +24,11 @@ export interface AchievementGoalDefinition {
     count: number
 }
 
+export interface AchievementWithProgressInfo {
+    achievement: AchievementDefinition
+    completed: boolean
+}
+
 export class AchievementsManager {
     private _goalState: IPersistedAchievementState
     private _achievements: { [achievementId: string]: AchievementDefinition } = {}
@@ -64,6 +69,19 @@ export class AchievementsManager {
         Object.values(this._achievements).forEach(achievement => {
             this._checkIfShouldTrackAchievement(achievement)
             this._checkVictoryCondition(achievement)
+        })
+    }
+
+    public getAchievements(): AchievementWithProgressInfo[] {
+        const allAchievements = Object.values(this._achievements)
+
+        return allAchievements.map(achievement => {
+            const completed = this._goalState.achievedIds.indexOf(achievement.uniqueId) >= 0
+
+            return {
+                achievement,
+                completed,
+            }
         })
     }
 

--- a/browser/src/Services/Learning/Achievements/index.tsx
+++ b/browser/src/Services/Learning/Achievements/index.tsx
@@ -14,9 +14,9 @@ import { EditorManager } from "./../../EditorManager"
 
 export * from "./AchievementsManager"
 
+import { AchievementNotificationRenderer } from "./AchievementNotificationRenderer"
 import { AchievementsBufferLayer } from "./AchievementsBufferLayer"
 import { AchievementsManager, IPersistedAchievementState } from "./AchievementsManager"
-import { AchievementNotificationRenderer } from "./AchievementNotificationRenderer"
 
 let _achievements: AchievementsManager = null
 

--- a/browser/src/Services/Learning/Achievements/index.tsx
+++ b/browser/src/Services/Learning/Achievements/index.tsx
@@ -7,19 +7,23 @@
 import { Configuration } from "./../../Configuration"
 import { OverlayManager } from "./../../Overlay"
 
-import { AchievementNotificationRenderer } from "./AchievementNotificationRenderer"
-
-import { AchievementsManager, IPersistedAchievementState } from "./AchievementsManager"
-
 import { getStore, IStore } from "./../../../Store"
 
+import { CommandManager } from "./../../CommandManager"
+import { EditorManager } from "./../../EditorManager"
+
 export * from "./AchievementsManager"
+
+import { AchievementsBufferLayer } from "./AchievementsBufferLayer"
+import { AchievementsManager, IPersistedAchievementState } from "./AchievementsManager"
+import { AchievementNotificationRenderer } from "./AchievementNotificationRenderer"
 
 let _achievements: AchievementsManager = null
 
 export const activate = (
+    commandManager: CommandManager,
     configuration: Configuration,
-    // editorManager: EditorManager,
+    editorManager: EditorManager,
     // sidebarManager: SidebarManager,
     overlays: OverlayManager,
 ) => {
@@ -74,6 +78,18 @@ export const activate = (
 
     manager.start().then(() => {
         manager.notifyGoal("oni.goal.launch")
+    })
+
+    const showAchievements = async () => {
+        const buf = await editorManager.activeEditor.openFile("ACHIEVEMENTS.oni")
+        buf.addLayer(new AchievementsBufferLayer(manager))
+    }
+
+    commandManager.registerCommand({
+        command: "achievements.show",
+        name: "Achievements: Open Trophy Case",
+        detail: "Show accomplished and in-progress achievements",
+        execute: () => showAchievements(),
     })
 }
 

--- a/browser/src/Services/Learning/index.ts
+++ b/browser/src/Services/Learning/index.ts
@@ -22,7 +22,7 @@ export const activate = (
 ) => {
     const learningEnabled = configuration.getValue("experimental.learning.enabled")
 
-    Achievements.activate(configuration, overlayManager)
+    Achievements.activate(commandManager, configuration, editorManager, overlayManager)
 
     if (!learningEnabled) {
         return

--- a/browser/src/UI/Icon.tsx
+++ b/browser/src/UI/Icon.tsx
@@ -6,6 +6,7 @@ export const TwoX = "fa-2x"
 export const ThreeX = "fa-3x"
 export const FourX = "fa-4x"
 export const FiveX = "fa-5x"
+export const NineX = "fa-9x"
 
 export enum IconSize {
     Default = 0,
@@ -14,20 +15,24 @@ export enum IconSize {
     ThreeX,
     FourX,
     FiveX,
+    NineX,
 }
 
 export interface IconProps {
     name: string
     size?: IconSize
     className?: string
+    style?: React.CSSProperties
 }
+const EmptyStyle: React.CSSProperties = {}
 
 export class Icon extends React.PureComponent<IconProps, {}> {
     public render(): JSX.Element {
+        const style = this.props.style || EmptyStyle
         const className =
             "fa fa-" + this.props.name + " " + this._getClassForIconSize(this.props.size as any) // FIXME: undefined
         const additionalClass = this.props.className || ""
-        return <i className={className + additionalClass} aria-hidden="true" />
+        return <i className={className + additionalClass} style={style} aria-hidden="true" />
     }
 
     private _getClassForIconSize(size: IconSize): string {
@@ -44,6 +49,8 @@ export class Icon extends React.PureComponent<IconProps, {}> {
                 return FourX
             case IconSize.FiveX:
                 return FiveX
+            case IconSize.NineX:
+                return NineX
             default:
                 return Default
         }

--- a/browser/src/UI/components/BufferLayerHeader.tsx
+++ b/browser/src/UI/components/BufferLayerHeader.tsx
@@ -1,0 +1,36 @@
+/**
+ * BufferLayerHeader.tsx
+ *
+ * Common header used by several buffer layers
+ */
+
+import * as React from "react"
+
+import styled from "styled-components"
+
+const HeaderWrapper = styled.div`
+    padding: 1em;
+`
+
+const PrimaryHeader = styled.div`
+    font-size: 2em;
+    font-weight: bold;
+`
+
+const SubHeader = styled.div`
+    font-size: 1.2em;
+`
+
+export interface BufferLayerHeaderProps {
+    title: string
+    description: string
+}
+
+export const BufferLayerHeader = (props: BufferLayerHeaderProps) => {
+    return (
+        <HeaderWrapper>
+            <PrimaryHeader>{props.title}</PrimaryHeader>
+            <SubHeader>{props.description}</SubHeader>
+        </HeaderWrapper>
+    )
+}


### PR DESCRIPTION
This adds a special buffer layer / view for showing completed achievements, and discovering new achievements:

![image](https://user-images.githubusercontent.com/13532591/37488608-7c12576a-2852-11e8-8607-1174784e2683.png)

This is an initial PR to add the buffer layer and render the set of achievements.

Some improvements to come later:
- Synchronize the cursor position with the achievements (so that they are keyboard accessible)
- Show completion state (a checkmark for completed achievements)
- Add entry point in the learning pane (a button for opening the `Achievements` pane)

This is gated by the `experimental.learning.enabled` and `experimental.achievements.enabled` flags, and is accessible by running `Oni.commands.executeCommand("achievements.show")`