### PR TITLE
Tidy up and remove options from default vim config.

### DIFF
--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -5,12 +5,6 @@ set smartcase
 set splitright
 set splitbelow
 
-" Default tab settings
-set tabstop=4
-set shiftwidth=4
-set softtabstop=4
-set expandtab
-
 " Turn off statusbar, because it is externalized
 set noshowmode
 set noruler
@@ -20,18 +14,14 @@ set noshowcmd
 " Enable GUI mouse behavior
 set mouse=a
 
-set list
-set listchars=trail:·
+" All config settings after this point 
+" can be removed, once an Oni config option is added.
 
-" Helpers for command mode
-" %% for current buffer file name
-" :: for current buffer file path
-cnoremap %% <C-R>=fnameescape(expand('%'))<CR>
-cnoremap :: <C-R>=fnameescape(expand('%:p:h'))<CR>/
-
-" Make Control+nav keys functionality in insert mode
-inoremap <expr> <C-a> pumvisible() ? "<Esc>A" : "<C-o>A"
-inoremap <expr> <C-b> pumvisible() ? "<Esc>bi" : "<C-o>b"
-inoremap <expr> <C-l> pumvisible() ? "<Esc>la" : "<C-o>a"
-
+" Use ESC to exit insert mode in :term
 tnoremap <Esc> <C-\><C-n>
+
+" Default tab settings
+set tabstop=4
+set shiftwidth=4
+set softtabstop=4
+set expandtab


### PR DESCRIPTION
I've not moved any of the other values to the core conf just yet, so as to minimise the changes that the default and core config go through.

Eventually, is the plan to remove all options from the default config? Seems like we could achieve everything there in the Oni layer, which makes it more front and central from a customisation point of view.