### PR TITLE
Remove annoying underline & color menu highlightings

### DIFF
--- a/browser/src/Services/Menu/Menu.less
+++ b/browser/src/Services/Menu/Menu.less
@@ -61,22 +61,12 @@
             .label {
                 margin: 4px;
                 padding-right: 8px;
-
-                .highlight {
-                    font-weight: bold;
-                    text-decoration: underline;
-                }
             }
 
             .detail {
                 font-size: @font-size-small;
                 color: @text-color-detail;
                 flex: 1 1 auto;
-
-                .highlight {
-                    font-weight: bold;
-                    text-decoration: underline;
-                }
             }
         }
     }

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -225,6 +225,16 @@ const MenuItemWrapper = withProps<IMenuItemWrapperProps>(styled.div)`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    & .label .highlight {
+        font-weight: bold;
+        color: ${props => props.theme["highlight.mode.normal.background"]};
+    }
+
+    & .detail .highlight {
+        font-weight: bold;
+        color: #757575;
+    }
 `
 
 export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {


### PR DESCRIPTION
Quick fix for #1767.

It would now look like this:
![capture d ecran 2018-03-16 a 14 23 35](https://user-images.githubusercontent.com/793402/37522885-a402a760-2925-11e8-850c-dd49af1bf0ca.png)

It uses the `highlight.mode.normal.background` theme color
