### PR TITLE
Fix menu empty item selection

### DIFF
--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -191,6 +191,10 @@ export class QuickOpen {
         selectedOption: Oni.Menu.MenuOption,
         openInSplit: Oni.FileOpenMode = Oni.FileOpenMode.Edit,
     ): Promise<void> {
+        if (!selectedOption) {
+            return
+        }
+
         const arg = selectedOption
 
         if (arg.icon === QuickOpenItem.convertTypeToIcon(QuickOpenType.bookmarkHelp)) {

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -66,6 +66,10 @@ export class Tasks {
     }
 
     private async _onItemSelected(selectedOption: Oni.Menu.MenuOption): Promise<void> {
+        if (!selectedOption) {
+            return
+        }
+
         const { label, detail } = selectedOption
 
         const selectedTask = find(this._lastTasks, t => t.name === label && t.detail === detail)


### PR DESCRIPTION
Nice tiny PR to stop an error occurring if you select an empty item from either the QuickOpen or Command Menu.

Noticed I was getting an error when I was typing quickly and badly so there were no results to select.