### PR TITLE
Re-added autoread work around

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -753,6 +753,19 @@ export class NeovimEditor extends Editor implements IEditor {
         this._commands.activate()
 
         this._neovimInstance.autoCommands.executeAutoCommand("FocusGained")
+        this.checkAutoRead()
+    }
+
+    public checkAutoRead(): void {
+        // If the user has autoread enabled, we should run ":checktime" on
+        // focus, as this is needed to get the file to auto-update.
+        // https://github.com/neovim/neovim/issues/1936
+        if (
+            this._neovimInstance.isInitialized &&
+            this._configuration.getValue("vim.setting.autoread")
+        ) {
+            this._neovimInstance.command(":checktime")
+        }
     }
 
     public leave(): void {


### PR DESCRIPTION
This is just to bring back in the work-around for autoread that was seemingly removed before.

If this was intentional, then feel free to close this PR!

There is a linked Github issue to why this is used, since it does look a bit odd. Ideally it would be updated  in core, but until then this seems to be the best/common way of doing it.