### PR TITLE
Automation: Add regression test for autoread functionality

### DIFF
--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -44,6 +44,7 @@ const CiTests = [
     "Regression.1296.SettingColorsTest",
     "Regression.1295.UnfocusedWindowTest",
     "Regression.1799.MacroApplicationTest",
+    "Regression.1819.AutoReadCheckTimeTest",
 
     "TextmateHighlighting.DebugScopesTest",
     "TextmateHighlighting.ScopesOnEnterTest",

--- a/test/ci/Regression.1819.AutoReadCheckTimeTest.ts
+++ b/test/ci/Regression.1819.AutoReadCheckTimeTest.ts
@@ -5,8 +5,8 @@
  */
 
 import * as assert from "assert"
-import * as path from "path"
 import * as fs from "fs"
+import * as path from "path"
 
 import { remote } from "electron"
 

--- a/test/ci/Regression.1819.AutoReadCheckTimeTest.ts
+++ b/test/ci/Regression.1819.AutoReadCheckTimeTest.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test for #1819
+ *
+ * Validate our `vim.setting.autoread` behaves as intended
+ */
+
+import * as assert from "assert"
+import * as path from "path"
+import * as fs from "fs"
+
+import { remote } from "electron"
+
+import * as Oni from "oni-api"
+import { getTemporaryFilePath, navigateToFile } from "./Common"
+
+const fileName = getTemporaryFilePath("txt")
+const writeInitialFile = () => {
+    fs.writeFileSync(fileName, "Hello World")
+}
+
+const writeRevision = () => {
+    fs.writeFileSync(fileName, "Hello Again")
+}
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    writeInitialFile()
+
+    await navigateToFile(fileName, oni)
+
+    const win = remote.getCurrentWindow()
+
+    win.blur()
+
+    writeRevision()
+
+    await oni.automation.sleep(500)
+
+    win.focus()
+
+    const activeEditor = oni.editors.activeEditor
+
+    let attempts = 0
+    let editAccomplished = false
+    while (attempts < 5) {
+        const [firstLine] = await activeEditor.activeBuffer.getLines(0, 1)
+
+        if (firstLine.indexOf("Hello Again") === 0) {
+            editAccomplished = true
+            break
+        }
+
+        await oni.automation.sleep(1000)
+        attempts++
+    }
+
+    assert.ok(editAccomplished, "Validate the change was picked up")
+}
+//
+// Bring in custom config.
+export const settings = {
+    config: {
+        "vim.setting.autoread": true,
+    },
+}

--- a/test/ci/Regression.1819.AutoReadCheckTimeTest.ts
+++ b/test/ci/Regression.1819.AutoReadCheckTimeTest.ts
@@ -10,6 +10,8 @@ import * as path from "path"
 
 import { remote } from "electron"
 
+import * as ShellJS from "shelljs"
+
 import * as Oni from "oni-api"
 import { getTemporaryFilePath, navigateToFile } from "./Common"
 
@@ -29,15 +31,17 @@ export const test = async (oni: Oni.Plugin.Api) => {
 
     await navigateToFile(fileName, oni)
 
-    const win = remote.getCurrentWindow()
-
-    win.blur()
-
-    writeRevision()
+    const windowsAsAny = oni.windows as any
+    windowsAsAny.activeSplit.leave()
 
     await oni.automation.sleep(500)
 
-    win.focus()
+    writeRevision()
+    ShellJS.touch(fileName)
+
+    await oni.automation.sleep(500)
+
+    windowsAsAny.activeSplit.enter()
 
     const activeEditor = oni.editors.activeEditor
 


### PR DESCRIPTION
Tighten up our safety net around the `autoread` functionality - I don't test this often so it'd be great to have it validated build over build.