### PR TITLE
Achievements: Add achievements button in learning pane

### DIFF
--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -12,7 +12,7 @@ import styled from "styled-components"
 // import { inputManager, InputManager } from "./../../Services/InputManager"
 
 import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
-import { boxShadow, withProps, Fixed, Full } from "./../../../UI/components/common"
+import { boxShadow, Fixed, Full, withProps } from "./../../../UI/components/common"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
 import * as Oni from "oni-api"

--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -12,7 +12,7 @@ import styled from "styled-components"
 // import { inputManager, InputManager } from "./../../Services/InputManager"
 
 import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
-import { boxShadow, withProps } from "./../../../UI/components/common"
+import { boxShadow, withProps, Fixed, Full } from "./../../../UI/components/common"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
 import * as Oni from "oni-api"
@@ -26,23 +26,6 @@ export interface ITrophyCaseViewProps {
 export interface ITrophyCaseViewState {
     progressInfo: AchievementWithProgressInfo[]
 }
-
-export interface ContainerProps {
-    direction: "horizontal" | "vertical"
-}
-
-export const Fixed = styled.div`
-    flex: 0 0 auto;
-`
-
-export const Full = styled.div`
-    flex: 1 1 auto;
-`
-
-export const Container = withProps<ContainerProps>(styled.div)`
-    display: flex;
-    flex-direction: ${p => (p.direction === "vertical" ? "column" : "row")};
-`
 
 export const TrophyCaseViewWrapper = withProps<{}>(styled.div)`
     background-color: ${p => p.theme.background};

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -15,6 +15,7 @@ import { SidebarContainerView, SidebarItemView } from "./../../UI/components/Sid
 import { SidebarButton } from "./../../UI/components/SidebarButton"
 import { VimNavigator } from "./../../UI/components/VimNavigator"
 
+import { Icon, IconSize } from "./../../UI/Icon"
 import { Container, Full, Fixed } from "./../../UI/components/common"
 import { SidebarPane } from "./../Sidebar"
 
@@ -110,6 +111,30 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
                 />
             ))
 
+        const InnerTrophyButton: JSX.Element = (
+            <Container
+                direction="horizontal"
+                style={{ justifyContent: "center", alignItems: "center" }}
+            >
+                <Fixed>
+                    <Icon name="trophy" size={IconSize.Large} />
+                </Fixed>
+                <Full>
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "center",
+                            alignItems: "center",
+                            width: "100%",
+                            height: "100%",
+                        }}
+                    >
+                        <div style={{ paddingLeft: "8px" }}>Achievements</div>
+                    </div>
+                </Full>
+            </Container>
+        )
+
         return (
             <VimNavigator
                 ids={ids}
@@ -144,7 +169,7 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
                             <Fixed>
                                 <div style={{ marginBottom: "2em", marginTop: "2em" }}>
                                     <SidebarButton
-                                        text={"Trophy Case"}
+                                        text={InnerTrophyButton}
                                         focused={selectedId === "trophy_case"}
                                         onClick={() => this._onSelect("trophy_case")}
                                     />

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -11,12 +11,12 @@ import { Event, IEvent } from "oni-types"
 import { CommandManager } from "./../CommandManager"
 
 import { PureComponentWithDisposeTracking } from "./../../UI/components/PureComponentWithDisposeTracking"
-import { SidebarContainerView, SidebarItemView } from "./../../UI/components/SidebarItemView"
 import { SidebarButton } from "./../../UI/components/SidebarButton"
+import { SidebarContainerView, SidebarItemView } from "./../../UI/components/SidebarItemView"
 import { VimNavigator } from "./../../UI/components/VimNavigator"
 
+import { Container, Fixed, Full } from "./../../UI/components/common"
 import { Icon, IconSize } from "./../../UI/Icon"
-import { Container, Full, Fixed } from "./../../UI/components/common"
 import { SidebarPane } from "./../Sidebar"
 
 import { ITutorialMetadataWithProgress, TutorialManager } from "./Tutorial/TutorialManager"

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -8,11 +8,14 @@ import * as React from "react"
 
 import { Event, IEvent } from "oni-types"
 
+import { CommandManager } from "./../CommandManager"
+
 import { PureComponentWithDisposeTracking } from "./../../UI/components/PureComponentWithDisposeTracking"
 import { SidebarContainerView, SidebarItemView } from "./../../UI/components/SidebarItemView"
 import { SidebarButton } from "./../../UI/components/SidebarButton"
 import { VimNavigator } from "./../../UI/components/VimNavigator"
 
+import { Container, Full, Fixed } from "./../../UI/components/common"
 import { SidebarPane } from "./../Sidebar"
 
 import { ITutorialMetadataWithProgress, TutorialManager } from "./Tutorial/TutorialManager"
@@ -21,7 +24,10 @@ export class LearningPane implements SidebarPane {
     private _onEnter = new Event<void>()
     private _onLeave = new Event<void>()
 
-    constructor(private _tutorialManager: TutorialManager) {}
+    constructor(
+        private _tutorialManager: TutorialManager,
+        private _commandManager: CommandManager,
+    ) {}
 
     public get id(): string {
         return "oni.sidebar.learning"
@@ -47,7 +53,7 @@ export class LearningPane implements SidebarPane {
                 onLeave={this._onLeave}
                 tutorialManager={this._tutorialManager}
                 onStartTutorial={id => this._tutorialManager.startTutorial(id)}
-                onOpenAchievements={() => alert("open achievements")}
+                onOpenAchievements={() => this._commandManager.executeCommand("achievements.show")}
             />
         )
     }
@@ -112,22 +118,39 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
                 render={selectedId => {
                     const items = tutorialItems(selectedId)
                     return (
-                        <div>
-                            <SidebarContainerView
-                                indentationLevel={0}
-                                isFocused={selectedId === "tutorial_container"}
-                                text={"Tutorials"}
-                                isContainer={true}
-                                isExpanded={true}
-                            >
-                                {items}
-                            </SidebarContainerView>
-                            <SidebarButton
-                                text={"Trophy Case"}
-                                focused={selectedId === "trophy_case"}
-                                onClick={() => this._onSelect("trophy_case")}
-                            />
-                        </div>
+                        <Container
+                            fullHeight={true}
+                            fullWidth={true}
+                            direction="vertical"
+                            style={{
+                                position: "absolute",
+                                top: "0px",
+                                left: "0px",
+                                right: "0px",
+                                bottom: "0px",
+                            }}
+                        >
+                            <Full style={{ height: "100%" }}>
+                                <SidebarContainerView
+                                    indentationLevel={0}
+                                    isFocused={selectedId === "tutorial_container"}
+                                    text={"Tutorials"}
+                                    isContainer={true}
+                                    isExpanded={true}
+                                >
+                                    {items}
+                                </SidebarContainerView>
+                            </Full>
+                            <Fixed>
+                                <div style={{ marginBottom: "2em", marginTop: "2em" }}>
+                                    <SidebarButton
+                                        text={"Trophy Case"}
+                                        focused={selectedId === "trophy_case"}
+                                        onClick={() => this._onSelect("trophy_case")}
+                                    />
+                                </div>
+                            </Fixed>
+                        </Container>
                     )
                 }}
             />

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -10,6 +10,7 @@ import { Event, IEvent } from "oni-types"
 
 import { PureComponentWithDisposeTracking } from "./../../UI/components/PureComponentWithDisposeTracking"
 import { SidebarContainerView, SidebarItemView } from "./../../UI/components/SidebarItemView"
+import { SidebarButton } from "./../../UI/components/SidebarButton"
 import { VimNavigator } from "./../../UI/components/VimNavigator"
 
 import { SidebarPane } from "./../Sidebar"
@@ -45,6 +46,8 @@ export class LearningPane implements SidebarPane {
                 onEnter={this._onEnter}
                 onLeave={this._onLeave}
                 tutorialManager={this._tutorialManager}
+                onStartTutorial={id => this._tutorialManager.startTutorial(id)}
+                onOpenAchievements={() => alert("open achievements")}
             />
         )
     }
@@ -54,6 +57,9 @@ export interface ILearningPaneViewProps {
     onEnter: IEvent<void>
     onLeave: IEvent<void>
     tutorialManager: TutorialManager
+
+    onStartTutorial: (tutorialId: string) => void
+    onOpenAchievements: () => void
 }
 
 export interface ILearningPaneViewState {
@@ -87,7 +93,7 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
 
     public render(): JSX.Element {
         const tutorialIds = this.state.tutorialInfo.map(t => t.tutorialInfo.id)
-        const ids = ["tutorial_container", ...tutorialIds]
+        const ids = ["tutorial_container", ...tutorialIds, "trophy_case"]
 
         const tutorialItems = (selectedId: string) =>
             this.state.tutorialInfo.map(t => (
@@ -102,21 +108,39 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
             <VimNavigator
                 ids={ids}
                 active={this.state.isActive}
+                onSelected={id => this._onSelect(id)}
                 render={selectedId => {
                     const items = tutorialItems(selectedId)
                     return (
-                        <SidebarContainerView
-                            indentationLevel={0}
-                            isFocused={selectedId === "tutorial_container"}
-                            text={"Tutorials"}
-                            isContainer={true}
-                            isExpanded={true}
-                        >
-                            {items}
-                        </SidebarContainerView>
+                        <div>
+                            <SidebarContainerView
+                                indentationLevel={0}
+                                isFocused={selectedId === "tutorial_container"}
+                                text={"Tutorials"}
+                                isContainer={true}
+                                isExpanded={true}
+                            >
+                                {items}
+                            </SidebarContainerView>
+                            <SidebarButton
+                                text={"Trophy Case"}
+                                focused={selectedId === "trophy_case"}
+                                onClick={() => this._onSelect("trophy_case")}
+                            />
+                        </div>
                     )
                 }}
             />
         )
+    }
+
+    private _onSelect(selectedId: string) {
+        if (selectedId === "tutorial_container") {
+            // TODO: Handle expansion
+        } else if (selectedId === "trophy_case") {
+            this.props.onOpenAchievements()
+        } else {
+            this.props.onStartTutorial(selectedId)
+        }
     }
 }

--- a/browser/src/Services/Learning/index.ts
+++ b/browser/src/Services/Learning/index.ts
@@ -31,7 +31,7 @@ export const activate = (
     }
 
     const tutorialManager = new TutorialManager(editorManager)
-    sidebarManager.add("trophy", new LearningPane(tutorialManager))
+    sidebarManager.add("trophy", new LearningPane(tutorialManager, commandManager))
 
     AllTutorials.forEach((tut: ITutorial) => tutorialManager.registerTutorial(tut))
 

--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -127,6 +127,7 @@ export class SidebarHeaderView extends React.PureComponent<ISidebarHeaderProps, 
 export const SidebarInnerPaneWrapper = withProps<{}>(styled.div)`
     flex: 1 1 auto;
     overflow-y: auto;
+    position: relative;
 `
 
 export class SidebarContentView extends React.PureComponent<

--- a/browser/src/UI/components/RedErrorScreen.tsx
+++ b/browser/src/UI/components/RedErrorScreen.tsx
@@ -55,7 +55,7 @@ const ButtonsWrapper = styled.div`
     margin-top: 4em;
 `
 
-import { OniButton } from "./SidebarEmptyPaneView"
+import { SidebarButton } from "./SidebarButton"
 
 import { remote } from "electron"
 
@@ -84,8 +84,8 @@ export class RedErrorScreenView extends React.PureComponent<RedErrorScreenViewPr
                     <ErrorTextWrapper>{additionalStack}</ErrorTextWrapper>
                 </RedScreenContentsWrapper>
                 <ButtonsWrapper>
-                    <OniButton focused={false} text="Open Debugger" onClick={openDebugger} />
-                    <OniButton focused={false} text="Create an Issue" onClick={createIssue} />
+                    <SidebarButton focused={false} text="Open Debugger" onClick={openDebugger} />
+                    <SidebarButton focused={false} text="Create an Issue" onClick={createIssue} />
                 </ButtonsWrapper>
             </RedScreenWrapper>
         )

--- a/browser/src/UI/components/SidebarButton.tsx
+++ b/browser/src/UI/components/SidebarButton.tsx
@@ -1,0 +1,61 @@
+/**
+ * SidebarEmptyPaneView.tsx
+ */
+
+import * as React from "react"
+import styled from "styled-components"
+import { boxShadow, withProps } from "./common"
+
+const ButtonWrapper = styled.button`
+    background-color: ${props => props.theme.background};
+    color: ${props => props.theme.foreground};
+    padding: 1em;
+    border: 2px solid transparent;
+    width: 100%;
+    outline: none;
+    cursor: pointer;
+    transition: all 0.1s ease-in;
+
+    pointer-events: all;
+
+    &:hover {
+        ${boxShadow} transform: translateY(-1px);
+    }
+`
+
+export interface ButtonContainerProps {
+    selected: boolean
+}
+
+const ButtonContainer = withProps<ButtonContainerProps>(styled.div)`
+    padding-left: 32px;
+    padding-right: 32px;
+
+    transition: all 0.1s ease-in;
+
+    background-color: ${props => (props.selected ? "rgba(0, 0, 0, 0.1)" : "transparent")};
+    border-left: 2px solid ${props =>
+        props.selected ? props.theme["highlight.mode.normal.background"] : "transparent"};
+`
+
+import { Sneakable } from "./Sneakable"
+
+export interface ISidebarButtonProps {
+    focused: boolean
+    text: string | JSX.Element
+    onClick: () => void
+}
+
+export class SidebarButton extends React.PureComponent<ISidebarButtonProps, {}> {
+    public render(): JSX.Element {
+        return (
+            <ButtonContainer selected={this.props.focused}>
+                <Sneakable callback={this.props.onClick}>
+                    <ButtonWrapper onClick={this.props.onClick}>
+                        <span>{this.props.text}</span>
+                    </ButtonWrapper>
+                </Sneakable>
+            </ButtonContainer>
+        )
+    }
+}

--- a/browser/src/UI/components/SidebarEmptyPaneView.tsx
+++ b/browser/src/UI/components/SidebarEmptyPaneView.tsx
@@ -20,24 +20,8 @@ const Wrapper = styled.div`
     justify-content: center;
 `
 
-import { boxShadow, withProps } from "./common"
-
-const ButtonWrapper = styled.button`
-    background-color: ${props => props.theme.background};
-    color: ${props => props.theme.foreground};
-    padding: 1em;
-    border: 2px solid transparent;
-    width: 100%;
-    outline: none;
-    cursor: pointer;
-    transition: all 0.1s ease-in;
-
-    pointer-events: all;
-
-    &:hover {
-        ${boxShadow} transform: translateY(-1px);
-    }
-`
+import { SidebarButton } from "./SidebarButton"
+import { VimNavigator } from "./VimNavigator"
 
 const Description = styled.div`
     margin: 32px;
@@ -45,48 +29,10 @@ const Description = styled.div`
     text-align: center;
 `
 
-export interface ButtonContainerProps {
-    selected: boolean
-}
-
-const ButtonContainer = withProps<ButtonContainerProps>(styled.div)`
-    padding-left: 32px;
-    padding-right: 32px;
-
-    transition: all 0.1s ease-in;
-
-    background-color: ${props => (props.selected ? "rgba(0, 0, 0, 0.1)" : "transparent")};
-    border-left: 2px solid ${props =>
-        props.selected ? props.theme["highlight.mode.normal.background"] : "transparent"};
-`
-
-import { Sneakable } from "./Sneakable"
-import { VimNavigator } from "./VimNavigator"
-
-export interface IOniButtonProps {
-    focused: boolean
-    text: string
-    onClick: () => void
-}
-
-export class OniButton extends React.PureComponent<IOniButtonProps, {}> {
-    public render(): JSX.Element {
-        return (
-            <ButtonContainer selected={this.props.focused}>
-                <Sneakable callback={this.props.onClick}>
-                    <ButtonWrapper onClick={this.props.onClick}>
-                        <span>{this.props.text}</span>
-                    </ButtonWrapper>
-                </Sneakable>
-            </ButtonContainer>
-        )
-    }
-}
-
 export class SidebarEmptyPaneView extends React.PureComponent<ISidebarEmptyPaneViewProps, {}> {
     public render(): JSX.Element {
         const button = this.props.actionButtonText ? (
-            <OniButton
+            <SidebarButton
                 focused={this.props.active}
                 text={this.props.actionButtonText}
                 onClick={() => this.props.onClickButton && this.props.onClickButton()}

--- a/browser/src/UI/components/common.ts
+++ b/browser/src/UI/components/common.ts
@@ -16,6 +16,28 @@ const {
     IThemeColors
 >
 
+export interface ContainerProps {
+    direction: "horizontal" | "vertical"
+    fullHeight?: boolean
+    fullWidth?: boolean
+}
+
+export const Fixed = styled.div`
+    flex: 0 0 auto;
+`
+
+export const Full = styled.div`
+    flex: 1 1 auto;
+`
+
+export const Container = withProps<ContainerProps>(styled.div)`
+    display: flex;
+    flex-direction: ${p => (p.direction === "vertical" ? "column" : "row")};
+
+    ${p => (p.fullHeight ? "height: 100%;" : "")}
+    ${p => (p.fullWidth ? "width: 100%;" : "")}
+`
+
 export type StyledFunction<T> = styledComponents.ThemedStyledFunction<T, IThemeColors>
 
 export function withProps<T, U extends HTMLElement = HTMLElement>(


### PR DESCRIPTION
This adds a sneakable entrance to the achievements pane in the learning pane:
![image](https://user-images.githubusercontent.com/13532591/37543239-32030cec-291e-11e8-91ea-43b8e0ab6f75.png)
