### PR TITLE
Automation: Add bail flag to stop tests if one fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
         "dist:win": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
         "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "npm run test:unit && npm run test:integration",
-        "test:integration": "npm run build:test && mocha -t 120000 lib_test/test/CiTests.js",
+        "test:integration": "npm run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:unit": "npm run test:unit:browser && npm run test:unit:main",
         "test:unit:browser": "npm run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
         "test:unit:main": "npm run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",


### PR DESCRIPTION
On OSX, if a test fails, it will cause every subsequent test to timeout - this causes long delays in the OSX build queue.

Once a test fails, we know the Ci run will fail, so there is no point taking time to run other tests. This adds the `--bail` flag to shorten the time in the case an OSX test does fail.