### PR TITLE
Fix highlighting of differently cased words in QuickOpen

### DIFF
--- a/browser/src/Services/QuickOpen/RegExFilter.ts
+++ b/browser/src/Services/QuickOpen/RegExFilter.ts
@@ -48,8 +48,16 @@ export const regexFilter = (
     const ret = filteredOptions.map(fo => {
         const letterCountDictionary = createLetterCountDictionary(searchString)
 
-        const detailHighlights = getHighlightsFromString(fo.detail, letterCountDictionary)
-        const labelHighlights = getHighlightsFromString(fo.label, letterCountDictionary)
+        const detailHighlights = getHighlightsFromString(
+            fo.detail,
+            letterCountDictionary,
+            isCaseSensitive,
+        )
+        const labelHighlights = getHighlightsFromString(
+            fo.label,
+            letterCountDictionary,
+            isCaseSensitive,
+        )
 
         return {
             ...fo,
@@ -82,6 +90,7 @@ export const processSearchTerm = (
 export const getHighlightsFromString = (
     text: string,
     letterCountDictionary: LetterCountDictionary,
+    isCaseSensitive: boolean = false,
 ): number[] => {
     if (!text) {
         return []
@@ -90,7 +99,7 @@ export const getHighlightsFromString = (
     const ret: number[] = []
 
     for (let i = 0; i < text.length; i++) {
-        const letter = text[i]
+        const letter = isCaseSensitive ? text[i] : text[i].toLowerCase()
         const idx = i
         if (letterCountDictionary[letter] && letterCountDictionary[letter] > 0) {
             ret.push(idx)

--- a/browser/test/Services/QuickOpen/RegExFilterTests.ts
+++ b/browser/test/Services/QuickOpen/RegExFilterTests.ts
@@ -3,7 +3,12 @@
  */
 
 import * as assert from "assert"
-import { processSearchTerm, regexFilter } from "./../../../src/Services/QuickOpen/RegExFilter"
+import { createLetterCountDictionary } from "../../../src/UI/components/HighlightText"
+import {
+    getHighlightsFromString,
+    processSearchTerm,
+    regexFilter,
+} from "./../../../src/Services/QuickOpen/RegExFilter"
 
 describe("processSearchTerm", () => {
     it("Correctly matches word.", async () => {
@@ -132,5 +137,38 @@ describe("regexFilter", () => {
         const result = regexFilter(testList, testString)
 
         assert.deepEqual(result, [])
+    })
+})
+
+describe("getHighlightsFromString", () => {
+    it("Correctly highlights a match when case is similar", () => {
+        const match = "foobar"
+        const searchString = "foob"
+
+        const highlights = getHighlightsFromString(match, createLetterCountDictionary(searchString))
+
+        assert.deepEqual([0, 1, 2, 3], highlights)
+    })
+
+    it("Correctly highlights a search match when case is not similar (in case INSENSITIVE mode)", () => {
+        const match = "FooBar"
+        const searchString = "foob"
+
+        const highlights = getHighlightsFromString(match, createLetterCountDictionary(searchString))
+
+        assert.deepEqual([0, 1, 2, 3], highlights)
+    })
+
+    it("Correctly highlights a search match when case is not similar (in case SENSITIVE mode)", () => {
+        const match = "FooBar"
+        const searchString = "foob"
+
+        const highlights = getHighlightsFromString(
+            match,
+            createLetterCountDictionary(searchString),
+            true,
+        )
+
+        assert.deepEqual([1, 2], highlights)
     })
 })


### PR DESCRIPTION
Fixes https://github.com/onivim/oni/issues/1828
It lowercases characters when trying to highlight them in case insensitive mode. The PR also adds tests so that it doesn't happen again.