### PR TITLE
Automation: Update buffers test to use explicit buffer mode

### DIFF
--- a/test/ci/Editor.BufferModifiedState.ts
+++ b/test/ci/Editor.BufferModifiedState.ts
@@ -47,3 +47,10 @@ export const test = async (oni: Oni.Plugin.Api) => {
 
     assert.ok(tabState, "Check buffer still has modified icon after swapping")
 }
+
+// Bring in custom config.
+export const settings = {
+    config: {
+        "tabs.mode": "buffers",
+    },
+}


### PR DESCRIPTION
As the default `tabs.mode` changed from `'buffers'` to `'tabs'`, the test needs to be updated - it's running in the default mode now. This changes the buffer modified state test to explicitly use buffer mode.