### PR TITLE
Highlight text crash fix

### DIFF
--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -43,7 +43,11 @@ export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIn
     public render(): JSX.Element {
         const childNodes: JSX.Element[] = []
         const highlightIndices = this.props.highlightIndices || []
-        const text = this.props.text || ""
+        let text = this.props.text || ""
+
+        if (typeof text !== "string") {
+            text = ""
+        }
 
         text.split("").forEach((c: string, idx: number) => {
             if (shouldHighlightIndex(idx, highlightIndices)) {

--- a/ui-tests/HighlightText.test.tsx
+++ b/ui-tests/HighlightText.test.tsx
@@ -21,21 +21,46 @@ const initialState = {
 }
 
 describe("<HighlightTextByIndex />", () => {
-    const HighlightTextIndexComponent = <HighlightTextByIndex {...initialState} />
-
     it("renders a shallow instance of the component", () => {
-        const wrapper = shallow(<HighlightTextByIndex {...initialState} />)
-        expect(wrapper.length).toEqual(1)
+        const component = shallow(<HighlightTextByIndex {...initialState} />)
+
+        expect(component.length).toEqual(1)
     })
 
-    it("renders the correct text", () => {
-        const wrapper = mount(<HighlightTextByIndex {...initialState} />)
-        expect(wrapper.text()).toContain("highlight text")
-        expect(wrapper.text()).toHaveLength(14)
-        expect(wrapper.find("span")).toHaveLength(15)
+    it("renders the correct text with highlights", () => {
+        const component = mount(<HighlightTextByIndex {...initialState} />)
+
+        // Check the correct text is there
+        expect(component.text()).toContain("highlight text")
+
+        // Check the structure is correct
+        expect(component.text()).toHaveLength(14)
+
+        // Check only 4 chars were highlighed
+        expect(component.find(".highlight-test")).toHaveLength(4)
     })
 
-    it("renders non-string correcttly", () => {
+    it("renders the correct text with no highlights", () => {
+        const testState = {
+            highlightClassName: "highlight-test",
+            highlightIndices: [],
+            text: "no highlight text",
+            className: "test-class",
+        }
+
+        const component = mount(<HighlightTextByIndex {...testState} />)
+
+        // Check the correct text is there
+        expect(component.text()).toContain("no highlight text")
+
+        // Check the structure is correct
+        expect(component.text()).toHaveLength(17)
+
+        // Check only 4 chars were highlighed
+        expect(component.find(".highlight-test")).toHaveLength(0)
+    })
+
+    it("doesn't crash when passed a non-string", () => {
         const testState = {
             highlightClassName: "highlight-test",
             highlightIndices: [0, 1, 3, 4],
@@ -43,7 +68,12 @@ describe("<HighlightTextByIndex />", () => {
             className: "test-class",
         } as any
 
-        const wrapper = shallow(<HighlightTextByIndex {...testState} />)
-        expect(wrapper.find("span")).toHaveLength(1)
+        const component = mount(<HighlightTextByIndex {...testState} />)
+
+        // Should be length one, as only the out span is returned
+        // due to no inner text.
+        expect(component.find("span")).toHaveLength(1)
+        expect(component.text() === "")
+        expect(component.hasClass("highlight-test") === false)
     })
 })

--- a/ui-tests/HighlightText.test.tsx
+++ b/ui-tests/HighlightText.test.tsx
@@ -56,7 +56,7 @@ describe("<HighlightTextByIndex />", () => {
         // Check the structure is correct
         expect(component.text()).toHaveLength(17)
 
-        // Check only 4 chars were highlighed
+        // Check no chars were highlighed
         expect(component.find(".highlight-test")).toHaveLength(0)
     })
 

--- a/ui-tests/HighlightText.test.tsx
+++ b/ui-tests/HighlightText.test.tsx
@@ -1,0 +1,49 @@
+import { mount, shallow } from "enzyme"
+import { shallowToJson } from "enzyme-to-json"
+import * as React from "react"
+
+import * as os from "os"
+
+import { HighlightTextByIndex } from "./../browser/src/UI/components/HighlightText"
+
+interface IHighlightTextByIndexProps {
+    highlightClassName: string
+    highlightIndices: number[]
+    text: string
+    className: string
+}
+
+const initialState = {
+    highlightClassName: "highlight-test",
+    highlightIndices: [0, 1, 3, 4],
+    text: "highlight text",
+    className: "test-class",
+}
+
+describe("<HighlightTextByIndex />", () => {
+    const HighlightTextIndexComponent = <HighlightTextByIndex {...initialState} />
+
+    it("renders a shallow instance of the component", () => {
+        const wrapper = shallow(<HighlightTextByIndex {...initialState} />)
+        expect(wrapper.length).toEqual(1)
+    })
+
+    it("renders the correct text", () => {
+        const wrapper = mount(<HighlightTextByIndex {...initialState} />)
+        expect(wrapper.text()).toContain("highlight text")
+        expect(wrapper.text()).toHaveLength(14)
+        expect(wrapper.find("span")).toHaveLength(15)
+    })
+
+    it("renders non-string correcttly", () => {
+        const testState = {
+            highlightClassName: "highlight-test",
+            highlightIndices: [0, 1, 3, 4],
+            text: 10101,
+            className: "test-class",
+        } as any
+
+        const wrapper = shallow(<HighlightTextByIndex {...testState} />)
+        expect(wrapper.find("span")).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
Partially fixes #1842.

If a string isn't passed in, we set it `""`.
Seems this is the best option since otherwise we would need a messy check I think to check the input, especially when its called in the users' config so we have no control over it.

I've attempted to add some React tests....though I'll be the first to admit I've never used them, so hopefully they look okay!