### PR TITLE
Bugfix: Fix exception when creating a new split after closing a split

### DIFF
--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -280,7 +280,7 @@ export class WindowManager {
             splits: state,
         })
 
-        this._idToSplit[splitId] = null
+        delete this._idToSplit[splitId]
     }
 
     public focusSplit(splitId: string): void {

--- a/browser/test/Services/WindowManager/WindowManagerTests.ts
+++ b/browser/test/Services/WindowManager/WindowManagerTests.ts
@@ -13,6 +13,7 @@ describe("WindowManagerTests", () => {
     beforeEach(() => {
         windowManager = new WindowManager()
     })
+
     it("sends focus to previous split after closing", async () => {
         const split1 = new MockWindowSplit("window1")
         const split2 = new MockWindowSplit("window2")
@@ -33,5 +34,22 @@ describe("WindowManagerTests", () => {
         handle3.close()
 
         assert.strictEqual(windowManager.activeSplit.id, handle1.id)
+    })
+
+    it("can get split after a split is closed", async () => {
+        const split1 = new MockWindowSplit("window1")
+        const split2 = new MockWindowSplit("window2")
+        const split3 = new MockWindowSplit("window3")
+
+        windowManager.createSplit("horizontal", split1)
+        const handle2 = windowManager.createSplit("vertical", split2, split1)
+
+        handle2.close()
+
+        const handle3 = windowManager.createSplit("vertical", split3, split1)
+
+        const handle = windowManager.getSplitHandle(split3)
+
+        assert.strictEqual(handle.id, handle3.id)
     })
 })


### PR DESCRIPTION
__Issue:__ When `editor.split.mode` is `oni`, if you close a split and then create a new split, there will be an exception.

__Fix:__ There was a hanging referencing to a `null` window split in `this._idToSplit`, so delete it instead of setting to to `null`