### PR TITLE
Bugfix: Fix configuration editor to handle reload in 'oni' editor.split.mode

### DIFF
--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -72,7 +72,7 @@ export class ConfigurationEditManager {
     private _fileToEditor: { [filePath: string]: IConfigurationEditInfo } = {}
 
     constructor(private _configuration: Configuration, private _editorManager: EditorManager) {
-        this._editorManager.activeEditor.onBufferSaved.subscribe(evt => {
+        this._editorManager.anyEditor.onBufferSaved.subscribe(evt => {
             const activeEditingSession = this._fileToEditor[evt.filePath]
 
             if (activeEditingSession) {


### PR DESCRIPTION
__Issue:__ When `editor.split.mode` is set to `'oni'`, the configuration editor is not picking up changes.

__Defect:__ The `ConfigurationEditor` was only listening to changes in the `activeEditor` when the command is invoked, but with the change to move the configuration to a split, that happens in a separate editor.

__Fix:__ Replace `activeEditor` with `anyEditor` for listening for buffer updates - this means we'll get the `onBufferSaved` event from any of the editors, no matter which one is currently active.