### PR TITLE
Enhancement(small)/ update title bar background color for one-dark

### DIFF
--- a/extensions/theme-onedark/colors/onedark.json
+++ b/extensions/theme-onedark/colors/onedark.json
@@ -5,7 +5,7 @@
         "background": "#1E2127",
         "foreground": "#ABB2BF",
 
-        "title.background": "#1F1F1F",
+        "title.background": "#1E2127",
         "title.foreground": "#ABB2BF",
 
         "editor.background": "#282C34",


### PR DESCRIPTION
This is I hope a boon to all `onedark` users I've noted that at least on macos where the title bar is set to a color the onedark theme has muddy brown title bar which I think *personally* isn't really in keeping with the theme, or how the title bar is rendered in other editors where I've seen the theme used

### Pics
#### Oni default:
<img width="901" alt="screen shot 2018-03-20 at 10 13 08" src="https://user-images.githubusercontent.com/22454918/37648715-a1eb4c48-2c27-11e8-949d-6218608ca20e.png">

#### Proposed change: 
<img width="927" alt="screen shot 2018-03-20 at 10 12 15" src="https://user-images.githubusercontent.com/22454918/37648720-a5cc3c64-2c27-11e8-8b1a-9127990aad75.png">

#### Vscode: (as an example, in the proposal I opted for a darker title which is what atom does)
<img width="849" alt="screen shot 2018-03-20 at 10 15 55" src="https://user-images.githubusercontent.com/22454918/37648746-b64bd162-2c27-11e8-85c1-26b068efbc18.png">

It's a little hard to see the difference due to the quality of the images but I think if you switch to onedark in one and compare it to atom or vscode the difference is obvious. This is a minor color tweak ive been using locally for months to achieve the same effect. 