### PR TITLE
Build: Increase timeout of dmg packing on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
 - npm run check-cached-binaries
 - ./build/script/install-reason.sh
-- ./build/script/travis-build.sh
+- travis_wait 30 ./build/script/travis-build.sh
 deploy:
     - provider: s3
       access_key_id: AKIAIYMATI2CEFTHPBOQ

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -23,7 +23,7 @@ fi
 npm run build
 npm run test:unit
 npm run lint
-npm run pack
+travis_wait npm run pack
 
 echo Using neovim path: "$ONI_NEOVIM_PATH"
 

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -23,6 +23,7 @@ fi
 npm run build
 npm run test:unit
 npm run lint
+npm run pack
 
 echo Using neovim path: "$ONI_NEOVIM_PATH"
 

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -24,9 +24,6 @@ npm run build
 npm run test:unit
 npm run lint
 
-# Increase the timeout from 10minutes -> 20minutes for packing the dmg
-travis_wait npm run pack
-
 echo Using neovim path: "$ONI_NEOVIM_PATH"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -23,6 +23,8 @@ fi
 npm run build
 npm run test:unit
 npm run lint
+
+# Increase the timeout from 10minutes -> 20minutes for packing the dmg
 travis_wait npm run pack
 
 echo Using neovim path: "$ONI_NEOVIM_PATH"


### PR DESCRIPTION
Travis will quit if it doesn't see any console output for 10min, but I suspect the dmg packing is taking longer on the build machines.

Travis has an option to increase that timeout: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

Using the `travis_wait` command bumps up the timeout to 20min instead of 10min.

