### PR TITLE
Automation: Add flaky bucket

### DIFF
--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -60,6 +60,10 @@ const WindowsOnlyTests = [
 
 const OSXOnlyTests = ["AutoCompletionTest-Reason", "OSX.WindowTitleTest"]
 
+// Flaky tests are tests that fail intermittently, and are not reliable.
+// TODO: We should invest in making these more reliable.
+const FlakyTests = ["Regression.1799.MacroApplicationTest"]
+
 // tslint:disable:no-console
 
 import * as Platform from "./../browser/src/Platform"
@@ -83,7 +87,8 @@ describe("ci tests", function() {
 
     const testFailures: IFailedTest[] = []
     tests.forEach(test => {
-        runInProcTest(path.join(__dirname, "ci"), test, 5000, testFailures)
+        const isFlaky = !!FlakyTests.find(t => test === t)
+        runInProcTest(path.join(__dirname, "ci"), test, 5000, testFailures, isFlaky)
     })
 
     // After all of the tests are completed display failures

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -149,8 +149,17 @@ export const runInProcTest = (
     testName: string,
     timeout: number = 5000,
     failures: IFailedTest[] = null,
+    isFlaky: boolean = false,
 ) => {
-    describe(testName, () => {
+    // tslint:disable-next-line
+    describe(testName, function() {
+        if (isFlaky) {
+            logWithTimeStamp(
+                `${testName} is marked as a FLAKY TEST. Allowing retries for this test.`,
+            )
+            this.retries(2)
+        }
+
         let testCase: ITestCase
         let oni: Oni
 


### PR DESCRIPTION
This adds a 'flaky' bucket for tests. Ideally, we should have __no__ tests that are flaky, but we can put these here while they are being stabilized, so that we can continue getting the coverage while they are being iterated on.