### PR TITLE
Change navigateToProjectRoot to accept folders.

### DIFF
--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -130,16 +130,11 @@ export class Workspace implements IWorkspace {
 
     public navigateToProjectRoot = async (bufferPath: string) => {
         const projectMarkers = this._configuration.getValue("workspace.autoDetectRootFiles")
-        let cwd = ""
 
         // If the supplied path is a folder, we should use that instead of
         // moving up a folder again.
         // Helps when calling Oni from the CLI with "oni ."
-        if (await this.pathIsDir(bufferPath)) {
-            cwd = bufferPath
-        } else {
-            cwd = path.dirname(bufferPath)
-        }
+        const cwd = (await this.pathIsDir(bufferPath)) ? bufferPath : path.dirname(bufferPath)
 
         const filePath = await findup(projectMarkers, { cwd })
         if (filePath) {

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -130,7 +130,17 @@ export class Workspace implements IWorkspace {
 
     public navigateToProjectRoot = async (bufferPath: string) => {
         const projectMarkers = this._configuration.getValue("workspace.autoDetectRootFiles")
-        const cwd = path.dirname(bufferPath)
+        let cwd = ""
+
+        // If the supplied path is a folder, we should use that instead of
+        // moving up a folder again.
+        // Helps when calling Oni from the CLI with "oni ."
+        if (await this.pathIsDir(bufferPath)) {
+            cwd = bufferPath
+        } else {
+            cwd = path.dirname(bufferPath)
+        }
+
         const filePath = await findup(projectMarkers, { cwd })
         if (filePath) {
             const dir = path.dirname(filePath)


### PR DESCRIPTION
Proposed partial fix for #1860.

This would allow `oni .` to load the current folder, whereas currently it needs a file instead.
This means with `"workspace.autoDetectWorkspace": "always",` opening with `oni .` would load the current folder.

Behaviour when `"workspace.autoDetectWorkspace"` is not `"always"` should not be affected.
I could stick some tests around this, but I think due to its interfacing with the file system, they would need to be CI tests.

This would go along side any bigger changes that are needed in #1707.