### PR TITLE
Automation: Longer timeout for stop

### DIFF
--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -114,7 +114,7 @@ export class Oni {
                 let didStop = false
                 const promise1 = this._app.stop().then(
                     () => {
-                        console.log("_app.stop promise completed!")
+                        log("_app.stop promise completed!")
                         didStop = true
                     },
                     err => {

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -111,13 +111,25 @@ export class Oni {
                 }
 
                 log("- Calling _app.stop")
-                this._app.stop()
-                log("- _app.stop call completed")
+                let didStop = false
+                const promise1 = this._app.stop().then(
+                    () => {
+                        console.log("_app.stop promise completed!")
+                        didStop = true
+                    },
+                    err => {
+                        // tslint:disable-next-line
+                        console.error(err)
+                    },
+                )
 
-                log("- Sleeping...")
-                await sleep()
-                log("- Sleep complete")
+                const promise2 = sleep(15000)
 
+                log("- Racing with 15s timer...")
+                const race = Promise.race([promise1, promise2])
+                await race
+
+                log("- Race complete. didStop: " + didStop)
                 attempts++
             }
         }
@@ -125,8 +137,8 @@ export class Oni {
     }
 }
 
-const sleep = () => {
+const sleep = (timeout: number = 1000) => {
     return new Promise(resolve => {
-        setTimeout(resolve, 1000)
+        setTimeout(resolve, timeout)
     })
 }

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -3,6 +3,8 @@ import * as path from "path"
 
 import { Application } from "spectron"
 
+import { ensureProcessNotRunning } from "./ensureProcessNotRunning"
+
 const log = (msg: string) => {
     console.log(msg) // tslint:disable-line no-console
 }
@@ -130,6 +132,13 @@ export class Oni {
                 await race
 
                 log("- Race complete. didStop: " + didStop)
+
+                if (!didStop) {
+                    log("- Attemping to force close processes:")
+                    await ensureProcessNotRunning("nvim")
+                    log("- Force close complete")
+                }
+
                 attempts++
             }
         }

--- a/test/common/ensureProcessNotRunning.ts
+++ b/test/common/ensureProcessNotRunning.ts
@@ -1,0 +1,58 @@
+import * as assert from "assert"
+import * as fs from "fs"
+import * as path from "path"
+
+import { Oni } from "./Oni"
+
+const findProcess = require("find-process") // tslint:disable-line
+
+// Sometimes, on the automation machines, Oni will still be running
+// when starting the test. It will fail if there is an existing instance
+// running, so we need to make sure to finish it.
+export const ensureProcessNotRunning = async (processName: string) => {
+    let attempts = 1
+    const maxAttempts = 5
+
+    while (attempts < maxAttempts) {
+        console.log(`${attempts}/${maxAttempts} Active Processes:`)
+
+        const nvimProcessGone = await tryToKillProcess(processName)
+        const oniProcessGone = await tryToKillProcess(processName)
+
+        if (nvimProcessGone && oniProcessGone) {
+            console.log("All processes gone!")
+            return
+        }
+
+        attempts++
+    }
+}
+
+const tryToKillProcess = async (name: string): Promise<boolean> => {
+    const oniProcesses = await findProcess("name", "oni")
+    oniProcesses.forEach(processInfo => {
+        console.log(` - Name: ${processInfo.name} PID: ${processInfo.pid}`)
+    })
+    const isOniProcess = processInfo => processInfo.name.toLowerCase().indexOf(name) >= 0
+    const filteredProcesses = oniProcesses.filter(isOniProcess)
+    console.log(`- Found ${filteredProcesses.length} processes with name:  ${name}`)
+
+    if (filteredProcesses.length === 0) {
+        console.log("No Oni processes found - leaving.")
+        return true
+    }
+
+    filteredProcesses.forEach(processInfo => {
+        console.log("Attemping to kill pid: " + processInfo.pid)
+        // Sometimes, there can be a race condition here. For example,
+        // the process may have closed between when we queried above
+        // and when we try to kill it. So we'll wrap it in a try/catch.
+        try {
+            process.kill(processInfo.pid)
+        } catch (ex) {
+            console.warn(ex)
+        }
+    })
+
+    return false
+}

--- a/test/common/ensureProcessNotRunning.ts
+++ b/test/common/ensureProcessNotRunning.ts
@@ -3,6 +3,8 @@ import * as fs from "fs"
 import * as path from "path"
 
 import { Oni } from "./Oni"
+//
+// tslint:disable:no-console
 
 const findProcess = require("find-process") // tslint:disable-line
 

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -4,7 +4,7 @@ import * as path from "path"
 
 import { Oni } from "./Oni"
 
-const findProcess = require("find-process") // tslint:disable-line
+import { ensureProcessNotRunning } from "./ensureProcessNotRunning"
 
 // tslint:disable:no-console
 
@@ -92,58 +92,6 @@ const logWithTimeStamp = (message: string) => {
     console.log(`[${deltaInSeconds}] ${message}`)
 }
 
-// Sometimes, on the automation machines, Oni will still be running
-// when starting the test. It will fail if there is an existing instance
-// running, so we need to make sure to finish it.
-const ensureOniNotRunning = async () => {
-    let attempts = 1
-    const maxAttempts = 5
-
-    while (attempts < maxAttempts) {
-        console.log(`${attempts}/${maxAttempts} Active Processes:`)
-
-        const nvimProcessGone = await tryToKillProcess("nvim")
-        const chromeDriverProcessGone = await tryToKillProcess("chromedriver")
-        const oniProcessGone = await tryToKillProcess("oni")
-
-        if (nvimProcessGone && chromeDriverProcessGone && oniProcessGone) {
-            console.log("All processes gone!")
-            return
-        }
-
-        attempts++
-    }
-}
-
-const tryToKillProcess = async (name: string): Promise<boolean> => {
-    const oniProcesses = await findProcess("name", "oni")
-    oniProcesses.forEach(processInfo => {
-        console.log(` - Name: ${processInfo.name} PID: ${processInfo.pid}`)
-    })
-    const isOniProcess = processInfo => processInfo.name.toLowerCase().indexOf(name) >= 0
-    const filteredProcesses = oniProcesses.filter(isOniProcess)
-    console.log(`- Found ${filteredProcesses.length} processes with name:  ${name}`)
-
-    if (filteredProcesses.length === 0) {
-        console.log("No Oni processes found - leaving.")
-        return true
-    }
-
-    filteredProcesses.forEach(processInfo => {
-        console.log("Attemping to kill pid: " + processInfo.pid)
-        // Sometimes, there can be a race condition here. For example,
-        // the process may have closed between when we queried above
-        // and when we try to kill it. So we'll wrap it in a try/catch.
-        try {
-            process.kill(processInfo.pid)
-        } catch (ex) {
-            console.warn(ex)
-        }
-    })
-
-    return false
-}
-
 export const runInProcTest = (
     rootPath: string,
     testName: string,
@@ -160,10 +108,6 @@ export const runInProcTest = (
 
         beforeEach(async () => {
             logWithTimeStamp("BEFORE EACH: " + testName)
-
-            logWithTimeStamp(" - Closing existing instances...")
-            await ensureOniNotRunning()
-            logWithTimeStamp(" - Finished closing")
 
             testCase = loadTest(rootPath, testName)
             const startOptions = {


### PR DESCRIPTION
In attempting to fix cases where `app.stop` hangs, we were aggressively calling `app.stop`. That had its own set of problems. This updates the approach to be a bit more conservative, and give `app.stop` 15 seconds to shutdown.