### PR TITLE
Crop command details in command menu when too long

### DIFF
--- a/browser/src/Services/Menu/Menu.less
+++ b/browser/src/Services/Menu/Menu.less
@@ -67,6 +67,9 @@
                 font-size: @font-size-small;
                 color: @text-color-detail;
                 flex: 1 1 auto;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                padding-right: 8px;
             }
         }
     }


### PR DESCRIPTION
This fixes #1560 by truncating the details and inserting an ellipsis ("...") if the complete information does not fit into the command line width.

I decided against migrating these files from `.less` to `styled-components` as the change was so simple and I wanted to get it out of the way first. I will migrate the `.less` files within another PR. I hope that is okay :)