### PR TITLE
Build: Split travis build steps to improve reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ install:
 script:
 - npm run check-cached-binaries
 - ./build/script/install-reason.sh
-- travis_wait 30 ./build/script/travis-build.sh
+- ./build/script/travis-build.sh
+- travis_wait 30 npm run pack
+- ./build/script/travis-test.sh
 deploy:
     - provider: s3
       access_key_id: AKIAIYMATI2CEFTHPBOQ

--- a/build/script/travis-build.sh
+++ b/build/script/travis-build.sh
@@ -30,24 +30,3 @@ fi
 npm run build
 npm run test:unit
 npm run lint
-npm run pack
-
-echo Using neovim path: "$ONI_NEOVIM_PATH"
-
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-   npm run demo:screenshot
-fi
-
-npm run test:integration
-
-# Upload master bits
-npm run upload:dist
-
-# We'll run code coverage only on Linux, for now
-if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    npm run ccov:instrument
-    npm run ccov:test:browser
-    npm run ccov:remap:browser:lcov
-    npm run ccov:clean
-    npm run ccov:upload
-fi

--- a/build/script/travis-test.sh
+++ b/build/script/travis-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo Travis build - detected OS is: "$TRAVIS_OS_NAME"
+set -e
+
+echo Using neovim path: "$ONI_NEOVIM_PATH"
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+   npm run demo:screenshot
+fi
+
+npm run test:integration
+
+# Upload master bits
+npm run upload:dist
+
+# We'll run code coverage only on Linux, for now
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    npm run ccov:instrument
+    npm run ccov:test:browser
+    npm run ccov:remap:browser:lcov
+    npm run ccov:clean
+    npm run ccov:upload
+fi


### PR DESCRIPTION
The `travis_wait` script seems to have helped improve reliability for the `pack` step, however, when there is a test failure, the log output seems to get mangled.

This change splits up our `travis-build` into 3 steps:
- `travis-build.sh` - do the initial build and unit tests
- `npm run pack` (with `travis_wait` - this generates the packages)
- `travis-test.sh` - this runs the integration tests and code coverage