### PR TITLE
#1055 - Part 1 - Naive implementation of chorded key presses

### DIFF
--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -19,6 +19,8 @@ export interface KeyBindingMap {
     [key: string]: KeyBinding[]
 }
 
+// const MAX_DELAY_BETWEEN_KEY_CHORD = 250 /* milliseconds */
+
 import { KeyboardResolver } from "./../Input/Keyboard/KeyboardResolver"
 
 import {
@@ -27,9 +29,38 @@ import {
     remapResolver,
 } from "./../Input/Keyboard/Resolvers"
 
+export interface KeyPressInfo {
+    keyChord: string
+    time: number
+}
+
+// Helper method to filter a set of key presses such that they are only the potential chords
+export const getRecentKeyPresses = (
+    keys: KeyPressInfo[],
+    maxTimeBetweenKeyPresses: number,
+): KeyPressInfo[] => {
+    return keys.reduce(
+        (prev, curr) => {
+            if (prev.length === 0) {
+                return [curr]
+            }
+
+            const lastItem = prev[prev.length - 1]
+
+            if (curr.time - lastItem.time > maxTimeBetweenKeyPresses) {
+                return [curr]
+            } else {
+                return [...prev, curr]
+            }
+        },
+        [] as KeyPressInfo[],
+    )
+}
+
 export class InputManager implements Oni.Input.InputManager {
     private _boundKeys: KeyBindingMap = {}
     private _resolver: KeyboardResolver
+    // private _keys: KeyPressInfo[] = []
 
     constructor() {
         this._resolver = new KeyboardResolver()

--- a/browser/test/Input/InputManagerTests.ts
+++ b/browser/test/Input/InputManagerTests.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert"
 
-import { InputManager, KeyPressInfo, getRecentKeyPresses } from "./../../src/Services/InputManager"
+import { getRecentKeyPresses, InputManager, KeyPressInfo } from "./../../src/Services/InputManager"
 
 describe("InputManager", () => {
     describe("bind", () => {
@@ -78,6 +78,38 @@ describe("InputManager", () => {
                 const boundKeys = im.getBoundKeys("test.command")
                 assert.deepEqual(boundKeys, [], "Validate no bound keys are returned")
             })
+        })
+    })
+
+    describe("handleKey", () => {
+        it("handles chorded inputs", () => {
+            const im = new InputManager()
+
+            let hitCount: number = 0
+            im.bind("gg", () => {
+                hitCount++
+                return true
+            })
+
+            im.handleKey("g", 1)
+            im.handleKey("g", 2)
+
+            assert.strictEqual(hitCount, 1, "Validate the binding for gg was executed")
+        })
+
+        it("doesn't dispatch action if time expires between key presses", () => {
+            const im = new InputManager()
+
+            let hitCount: number = 0
+            im.bind("gg", () => {
+                hitCount++
+                return true
+            })
+
+            im.handleKey("g", 1)
+            im.handleKey("g", 1000)
+
+            assert.strictEqual(hitCount, 0, "Validate the binding was not executed")
         })
     })
 

--- a/browser/test/Input/InputManagerTests.ts
+++ b/browser/test/Input/InputManagerTests.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert"
 
-import { InputManager } from "./../../src/Services/InputManager"
+import { InputManager, KeyPressInfo, getRecentKeyPresses } from "./../../src/Services/InputManager"
 
 describe("InputManager", () => {
     describe("bind", () => {
@@ -78,6 +78,23 @@ describe("InputManager", () => {
                 const boundKeys = im.getBoundKeys("test.command")
                 assert.deepEqual(boundKeys, [], "Validate no bound keys are returned")
             })
+        })
+    })
+
+    describe("getRecentKeyPresses", () => {
+        const createKeyPressInfo = (keyChord: string, time: number): KeyPressInfo => ({
+            keyChord,
+            time,
+        })
+        it("collapses keypress info per the delay", () => {
+            const key1 = createKeyPressInfo("a", 1)
+            const key2 = createKeyPressInfo("b", 2)
+            const key3 = createKeyPressInfo("c", 103)
+            const key4 = createKeyPressInfo("d", 104)
+
+            const items = getRecentKeyPresses([key1, key2, key3, key4], 100)
+
+            assert.deepEqual(items, [key3, key4], "Validate the correct items remain")
         })
     })
 })


### PR DESCRIPTION
This implements the first part of #1055 - the ability to bind to key chords. 

Although technically it allows you to bind using something like: `Oni.input.bind("jk", () => {...})`, and have an action triggered in response to that binding, it is naive - it will still let the `j` pass through. (This means it isn't usable to have `jk` exit insert mode today - you'll end up with a 'typed' j, and the binding will execute at the `k` key presses). 

We'll need to think about how to handle cases like that for it to be fully baked.