### PR TITLE
Bugfix: Input being swallowed when switching between multiplexed editors

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -757,6 +757,10 @@ export class NeovimEditor extends Editor implements IEditor {
 
         this._neovimInstance.autoCommands.executeAutoCommand("FocusGained")
         this.checkAutoRead()
+
+        if (this.activeBuffer) {
+            this.notifyBufferEnter(this.activeBuffer)
+        }
     }
 
     public checkAutoRead(): void {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -188,9 +188,9 @@ export class OniEditor extends Utility.Disposable implements IEditor {
 
     public enter(): void {
         Log.info("[OniEditor::enter]")
-        this._neovimEditor.enter()
-
         editorManager.setActiveEditor(this)
+
+        this._neovimEditor.enter()
 
         commandManager.registerCommand({
             command: "editor.split.horizontal",

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -162,7 +162,7 @@ export const activate = (
                 subscriptions.push(
                     inputManager.bind(
                         pair.open,
-                        handleOpenCharacter(pair, editorManager.anyEditor, true),
+                        handleOpenCharacter(pair, editorManager.activeEditor, true),
                         insertModeFilter,
                     ),
                 )
@@ -171,14 +171,14 @@ export const activate = (
             subscriptions.push(
                 inputManager.bind(
                     pair.open,
-                    handleOpenCharacter(pair, editorManager.anyEditor, false),
+                    handleOpenCharacter(pair, editorManager.activeEditor, false),
                     insertModeFilter,
                 ),
             )
             subscriptions.push(
                 inputManager.bind(
                     pair.close,
-                    handleCloseCharacter(pair, editorManager.anyEditor),
+                    handleCloseCharacter(pair, editorManager.activeEditor),
                     insertModeFilter,
                 ),
             )
@@ -187,20 +187,20 @@ export const activate = (
         subscriptions.push(
             inputManager.bind(
                 "<bs>",
-                handleBackspaceCharacter(autoClosingPairs, editorManager.anyEditor),
+                handleBackspaceCharacter(autoClosingPairs, editorManager.activeEditor),
                 insertModeFilter,
             ),
         )
         subscriptions.push(
             inputManager.bind(
                 "<enter>",
-                handleEnterCharacter(autoClosingPairs, editorManager.anyEditor),
+                handleEnterCharacter(autoClosingPairs, editorManager.activeEditor),
                 insertModeFilter,
             ),
         )
     }
 
-    editorManager.activeEditor.onBufferEnter.subscribe(onBufferEnter)
+    editorManager.anyEditor.onBufferEnter.subscribe(onBufferEnter)
 
     const activeEditor = editorManager.activeEditor
     if (activeEditor && activeEditor.activeBuffer) {

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -162,7 +162,7 @@ export const activate = (
                 subscriptions.push(
                     inputManager.bind(
                         pair.open,
-                        handleOpenCharacter(pair, editorManager.activeEditor, true),
+                        handleOpenCharacter(pair, editorManager.anyEditor, true),
                         insertModeFilter,
                     ),
                 )
@@ -171,14 +171,14 @@ export const activate = (
             subscriptions.push(
                 inputManager.bind(
                     pair.open,
-                    handleOpenCharacter(pair, editorManager.activeEditor, false),
+                    handleOpenCharacter(pair, editorManager.anyEditor, false),
                     insertModeFilter,
                 ),
             )
             subscriptions.push(
                 inputManager.bind(
                     pair.close,
-                    handleCloseCharacter(pair, editorManager.activeEditor),
+                    handleCloseCharacter(pair, editorManager.anyEditor),
                     insertModeFilter,
                 ),
             )
@@ -187,14 +187,14 @@ export const activate = (
         subscriptions.push(
             inputManager.bind(
                 "<bs>",
-                handleBackspaceCharacter(autoClosingPairs, editorManager.activeEditor),
+                handleBackspaceCharacter(autoClosingPairs, editorManager.anyEditor),
                 insertModeFilter,
             ),
         )
         subscriptions.push(
             inputManager.bind(
                 "<enter>",
-                handleEnterCharacter(autoClosingPairs, editorManager.activeEditor),
+                handleEnterCharacter(autoClosingPairs, editorManager.anyEditor),
                 insertModeFilter,
             ),
         )


### PR DESCRIPTION
__Repro:__
- Set `editor.split.mode` to `'oni'`.
- Restart Oni
- Edit user config
- Try and make changes to the configuration file - specifically, type in characters that would engage autoclosing pairs functionality (`(`, `<enter>`, etc)

__Expected:__ Should function as normally without being in oni split mode
__Actual:__ Some of the input gets sent to the leftmost editor, making it impossible to do anything in the right editor.

This bug only occurs when `editor.split.mode` is set to `'oni'` (so off by default), and is a class of issues - things that are using `activeEditor` will only handle the _original_ editor. 

This is fine and the code is working as designed, in the non-multiplexed world, since we only ever had one editor. The bug is that, in the 'multiplexed' world, we can now have multiple editors, and the feature hasn't been updated to handle it. 

In this case, the `anyEditor` is a convenient proxy that always points to the _currently_ focused editor - so the fix here is to make the `AutoClosingPairs` functionality multiplexed-aware by switching to `anyEditor` vs `activeEditor` in places that are deferring functionality. For example, for input bindings that might get executed later, we should use `anyEditor`, since the actual editor might be different depending on which editor has focus (and the bindings apply across all editors).