### PR TITLE
Configuration: Add configuration setting / metadata API

### DIFF
--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -111,7 +111,7 @@ export class Configuration implements Oni.Configuration {
 
     private _settingMetadata: { [settingName: string]: IConfigurationSettingMetadata<any> } = {}
     private _subscriptions: {
-        [settingName: string]: Event<IConfigurationSettingValueChangedEvent<any>>[]
+        [settingName: string]: Array<Event<IConfigurationSettingValueChangedEvent<any>>>
     } = {}
 
     public get editor(): IConfigurationEditor {
@@ -157,7 +157,7 @@ export class Configuration implements Oni.Configuration {
         }
 
         const newEvent = new Event<IConfigurationSettingValueChangedEvent<any>>()
-        const subs: Event<IConfigurationSettingValueChangedEvent<any>>[] =
+        const subs: Array<Event<IConfigurationSettingValueChangedEvent<any>>> =
             this._subscriptions[name] || []
         this._subscriptions[name] = [...subs, newEvent]
 

--- a/browser/test/Services/Configuration/ConfigurationTests.ts
+++ b/browser/test/Services/Configuration/ConfigurationTests.ts
@@ -120,6 +120,36 @@ describe("Configuration", () => {
         })
     })
 
+    describe("registerConfigurationSetting", () => {
+        it("sets default value", () => {
+            const configuration = new Configuration()
+            configuration.registerSetting("test.setting", {
+                defaultValue: 1,
+            })
+
+            const val = configuration.getValue("test.setting")
+            assert.strictEqual(val, 1, "Validate default value gets set")
+        })
+
+        it("notifies when value is changed", () => {
+            const configuration = new Configuration()
+            const setting = configuration.registerSetting("test.setting", {
+                defaultValue: 1,
+            })
+
+            let val: number = null
+            let oldVal: number = null
+            setting.onValueChanged.subscribe(evt => {
+                val = evt.newValue
+                oldVal = evt.oldValue
+            })
+
+            configuration.setValue("test.setting", 2)
+            assert.strictEqual(val, 2, "Validate new value was populated in event handler")
+            assert.strictEqual(oldVal, 1, "Validate the oldValue was set correctly")
+        })
+    })
+
     describe("persisted configuration", () => {
         let persistedConfiguration: IPersistedConfiguration
 


### PR DESCRIPTION
This change adds a `registerSetting` API to register a configuration setting, along with metadata. The metadata will be used to help populate the configuration helper page we have. It will also help in terms of deciding when we need to reload oni vs can handle the configuration update in the current session, with the `requireReload` property.

I'm picturing additional pieces of metadata being useful in the future, too. One piece in particular (which is stubbed out here, but not implemented) is a _merge strategy_ - when multiple configuration providers specify a value (for example, user config vs workspace config), the current strategy is by default to overwrite. However, depending on the configuration setting, there might be different ways to resolve this - this allows specifying a custom lambda to reconcile the settings.