### PR TITLE
Browser: Add 'browser.zoomFactor' configuration value

### DIFF
--- a/browser/src/Services/Browser/BrowserView.tsx
+++ b/browser/src/Services/Browser/BrowserView.tsx
@@ -109,12 +109,13 @@ export class BrowserView extends React.PureComponent<IBrowserViewProps, IBrowser
 
                 return sneaks.map(s => {
                     const callbackFunction = (id: string) => () => this._triggerSneak(id)
+                    const zoomFactor = this._getZoomFactor()
                     return {
                         rectangle: Oni.Shapes.Rectangle.create(
-                            webviewDimensions.left + s.rectangle.x,
-                            webviewDimensions.top + s.rectangle.y,
-                            s.rectangle.width,
-                            s.rectangle.height,
+                            webviewDimensions.left + s.rectangle.x * zoomFactor,
+                            webviewDimensions.top + s.rectangle.y * zoomFactor,
+                            s.rectangle.width * zoomFactor,
+                            s.rectangle.height * zoomFactor,
                         ),
                         callback: callbackFunction(s.id),
                     }
@@ -212,6 +213,10 @@ export class BrowserView extends React.PureComponent<IBrowserViewProps, IBrowser
         }
     }
 
+    private _getZoomFactor(): number {
+        return this.props.configuration.getValue("browser.zoomFactor", 1.0)
+    }
+
     private _initializeElement(elem: HTMLElement) {
         if (elem && !this._webviewElement) {
             const webviewElement = document.createElement("webview")
@@ -220,9 +225,9 @@ export class BrowserView extends React.PureComponent<IBrowserViewProps, IBrowser
             this._webviewElement = webviewElement
             this._webviewElement.src = this.props.initialUrl
 
-            const zoomFactor = this.props.configuration.getValue("browser.zoomFactor", 1.0)
-
-            this._webviewElement.setZoomFactor(zoomFactor)
+            this._webviewElement.addEventListener("dom-ready", () => {
+                this._webviewElement.setZoomFactor(this._getZoomFactor())
+            })
 
             this._webviewElement.addEventListener("did-navigate", (evt: any) => {
                 this.setState({

--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -22,7 +22,7 @@ export class BrowserLayer implements Oni.BufferLayer {
     private _goForwardEvent = new Event<void>()
     private _reloadEvent = new Event<void>()
 
-    constructor(private _url: string) {}
+    constructor(private _url: string, private _configuration: Configuration) {}
 
     public get id(): string {
         return "oni.browser"
@@ -31,6 +31,7 @@ export class BrowserLayer implements Oni.BufferLayer {
     public render(): JSX.Element {
         return (
             <BrowserView
+                configuration={this._configuration}
                 initialUrl={this._url}
                 goBack={this._goBackEvent}
                 goForward={this._goForwardEvent}
@@ -75,7 +76,7 @@ export const activate = (
                 { openMode },
             )
 
-            const layer = new BrowserLayer(url)
+            const layer = new BrowserLayer(url, configuration)
             buffer.addLayer(layer)
             activeLayers[buffer.id] = layer
         } else {

--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -100,6 +100,13 @@ export const activate = (
         })
     }
 
+    configuration.registerSetting("browser.zoomFactor", {
+        description:
+            "This sets the `zoomFactor` for nested browser windows. A value of `1` means `100%` zoom, a value of 0.5 means `50%` zoom, and a value of `2` means `200%` zoom.",
+        requiresReload: false,
+        defaultValue: 1,
+    })
+
     commandManager.registerCommand({
         command: "browser.openUrl",
         execute: openUrl,


### PR DESCRIPTION
This adds a ` browser.zoomFactor` configuration setting, which is used for the _embedded browser_. When a browser is in a split, I find it convenient to be zoomed out a little (like `0.9`). 