### PR TITLE
Bugfix - Input Regression: Auto-closing pairs are too aggressive

### DIFF
--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -37,6 +37,7 @@ export const activate = (
         editor: Oni.Editor,
         openCharacterSameAsClosed: boolean,
     ) => () => {
+        Log.verbose("[AutoClosingPairs::handleOpenCharacter] " + pair.open)
         const neovim: NeovimInstance = editor.neovim as any
         neovim.blockInput(async (inputFunc: any) => {
             await checkOpenCharacter(inputFunc, pair, editor, openCharacterSameAsClosed)
@@ -46,6 +47,7 @@ export const activate = (
     }
 
     const handleBackspaceCharacter = (pairs: IAutoClosingPair[], editor: Oni.Editor) => () => {
+        Log.verbose("[AutoClosingPairs::handleBackspaceCharacter]")
         const neovim: NeovimInstance = editor.neovim as any
         neovim.blockInput(async (inputFunc: any) => {
             const activeBuffer = editor.activeBuffer
@@ -84,6 +86,7 @@ export const activate = (
     }
 
     const handleEnterCharacter = (pairs: IAutoClosingPair[], editor: Oni.Editor) => () => {
+        Log.verbose("[AutoClosingPairs::handleEnterCharacter]")
         const neovim: NeovimInstance = editor.neovim as any
         editor.blockInput(async (inputFunc: Oni.InputCallbackFunction) => {
             const activeBuffer = editor.activeBuffer
@@ -123,6 +126,7 @@ export const activate = (
     }
 
     const handleCloseCharacter = (pair: IAutoClosingPair, editor: Oni.Editor) => () => {
+        Log.verbose("[AutoClosingPairs::handleCloseCharacter]")
         editor.blockInput(async (inputFunc: Oni.InputCallbackFunction) => {
             const activeBuffer = editor.activeBuffer
             const lines = await activeBuffer.getLines(

--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -150,6 +150,10 @@ export class InputManager implements Oni.Input.InputManager {
     // Returns true if the key was handled and should not continue bubbling,
     // false otherwise.
     public handleKey(keyChord: string, time: number = new Date().getTime()): boolean {
+        if (keyChord === null) {
+            return false
+        }
+
         const newKey: KeyPressInfo = {
             keyChord,
             time,
@@ -164,6 +168,7 @@ export class InputManager implements Oni.Input.InputManager {
             const fullChord = potentialKeys.map(k => k.keyChord).join("")
 
             if (this._handleKeyCore(fullChord)) {
+                this._keys = []
                 return true
             }
 

--- a/browser/test/Input/InputManagerTests.ts
+++ b/browser/test/Input/InputManagerTests.ts
@@ -111,6 +111,23 @@ describe("InputManager", () => {
 
             assert.strictEqual(hitCount, 0, "Validate the binding was not executed")
         })
+
+        it("doesn't re-dispatch if key was null", () => {
+            const im = new InputManager()
+            let hitCount: number = 0
+            im.bind("[", () => {
+                hitCount++
+                return true
+            })
+
+            im.handleKey("[", 1)
+
+            // For control keys like 'shift', we get a null value passed
+            // to the key-chord logic.
+            im.handleKey(null, 2)
+
+            assert.strictEqual(hitCount, 1, "Verify handler was only hit once")
+        })
     })
 
     describe("getRecentKeyPresses", () => {


### PR DESCRIPTION
I noticed while typing in the latest master, like: `Log("[A` would actually result in `Log("[[A` - an extra bracket. And there were a few other cases that felt really broken (and annoying).

It looks like this behavior was a regression from the chorded input work. The sequence of keys we were getting was:
- `[`
- `null` (From the shift key, which doesn't resolve to a character -> this is expected)
- `A`

Because of the way we queued up chords, we'd actually trigger the `[` handler _twice_ - on the initial `[` keystroke, and then on the `shift` key press. 