### PR TITLE
Plugin Management: Add 'plugins' configuration setting

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -341,6 +341,9 @@ export const start = async (args: string[]): Promise<void> => {
     const Particles = await import("./Services/Particles")
     Particles.activate(commandManager, configuration, editorManager, overlayManager)
 
+    const PluginConfigurationSynchronizer = await import("./Plugins/PluginConfigurationSynchronizer")
+    PluginConfigurationSynchronizer.activate(configuration, pluginManager)
+
     Performance.endMeasure("Oni.Start.Activate")
 
     checkForUpdates()

--- a/browser/src/Plugins/PluginConfigurationSynchronizer.ts
+++ b/browser/src/Plugins/PluginConfigurationSynchronizer.ts
@@ -4,6 +4,8 @@
  * Responsible for synchronizing user's `plugin` configuration settings.
  */
 
+import * as Log from "./../Log"
+
 import { Configuration } from "./../Services/Configuration"
 import { PluginManager } from "./PluginManager"
 
@@ -19,16 +21,16 @@ export const activate = (configuration: Configuration, pluginManager: PluginMana
             return
         }
 
+        Log.verbose("[PluginConfigurationSynchronizer - onValueChanged]")
+
         const newPlugins = evt.newValue.filter(plugin => evt.oldValue.indexOf(plugin) === -1)
 
-        console.dir(`'plugins changed' - new value: ${evt.newValue} old value: ${evt.oldValue}`)
-
-        console.dir("new plugins: " + newPlugins)
+        Log.info("[PluginConfigurationSynchronizer] New Plugins: " + newPlugins)
 
         newPlugins.forEach(async plugin => {
-            console.log("Installing plugin: " + plugin)
+            Log.info("[PluginConfigurationSynchronizer] Installing plugin: " + plugin)
             await pluginManager.installer.install(plugin)
-            console.log("Installation complete!")
+            Log.info("[PluginConfigurationSynchronizer] Installation complete!")
         })
     })
 }

--- a/browser/src/Plugins/PluginConfigurationSynchronizer.ts
+++ b/browser/src/Plugins/PluginConfigurationSynchronizer.ts
@@ -15,6 +15,20 @@ export const activate = (configuration: Configuration, pluginManager: PluginMana
     })
 
     setting.onValueChanged.subscribe(evt => {
+        if (!evt.newValue || !evt.newValue.length) {
+            return
+        }
+
+        const newPlugins = evt.newValue.filter(plugin => evt.oldValue.indexOf(plugin) === -1)
+
         console.dir(`'plugins changed' - new value: ${evt.newValue} old value: ${evt.oldValue}`)
+
+        console.dir("new plugins: " + newPlugins)
+
+        newPlugins.forEach(async plugin => {
+            console.log("Installing plugin: " + plugin)
+            await pluginManager.installer.install(plugin)
+            console.log("Installation complete!")
+        })
     })
 }

--- a/browser/src/Plugins/PluginConfigurationSynchronizer.ts
+++ b/browser/src/Plugins/PluginConfigurationSynchronizer.ts
@@ -1,0 +1,20 @@
+/**
+ * PluginConfigurationSynchronizer.ts
+ *
+ * Responsible for synchronizing user's `plugin` configuration settings.
+ */
+
+import { Configuration } from "./../Services/Configuration"
+import { PluginManager } from "./PluginManager"
+
+export const activate = (configuration: Configuration, pluginManager: PluginManager): void => {
+    const setting = configuration.registerSetting<string[]>("plugins", {
+        description:
+            "`plugins` is an array of strings designating plugins that should be installed. Plugins can either be installed from `npm` (for Oni / JS plugins), or from GitHub (usually for Vim plugins). For an `npm` plugin, simply specify the package name - like 'oni-power-mode'. For a GitHub plugin, specify the user + plugin, for example 'tpope/vim-fugitive'",
+        requiresReload: false,
+    })
+
+    setting.onValueChanged.subscribe(evt => {
+        console.dir(`'plugins changed' - new value: ${evt.newValue} old value: ${evt.oldValue}`)
+    })
+}


### PR DESCRIPTION
This adds a `plugins` configuration setting, which is an array of strings, that supports installation from both `npm` and `git` plugins, ie:

```
"plugins": [
   "tpope/vim-fugitive",
   "oni-power-mode", // not ready yet, but this will be an Oni plugin hosted on NPM
]
```

This hooks up a watcher for the configuration setting, such that if a value is added, we will install it using the bundled `yarn` strategy.