### PR TITLE
Achievements: Show 'notification bubble' to guide users to the learning pane

### DIFF
--- a/browser/src/Services/Learning/Achievements/index.tsx
+++ b/browser/src/Services/Learning/Achievements/index.tsx
@@ -11,6 +11,7 @@ import { getPersistentStore, IPersistentStore } from "./../../../PersistentStore
 
 import { CommandManager } from "./../../CommandManager"
 import { EditorManager } from "./../../EditorManager"
+import { SidebarManager } from "./../../Sidebar"
 
 export * from "./AchievementsManager"
 
@@ -24,7 +25,7 @@ export const activate = (
     commandManager: CommandManager,
     configuration: Configuration,
     editorManager: EditorManager,
-    // sidebarManager: SidebarManager,
+    sidebarManager: SidebarManager,
     overlays: OverlayManager,
 ) => {
     const achievementsEnabled = configuration.getValue("experimental.achievements.enabled")
@@ -51,6 +52,8 @@ export const activate = (
             title: achievement.name,
             description: achievement.description,
         })
+
+        sidebarManager.setNotification("oni.sidebar.learning")
     })
 
     manager.registerAchievement({

--- a/browser/src/Services/Learning/index.ts
+++ b/browser/src/Services/Learning/index.ts
@@ -28,7 +28,13 @@ export const activate = (
 ) => {
     const learningEnabled = configuration.getValue("experimental.learning.enabled")
 
-    Achievements.activate(commandManager, configuration, editorManager, overlayManager)
+    Achievements.activate(
+        commandManager,
+        configuration,
+        editorManager,
+        sidebarManager,
+        overlayManager,
+    )
 
     if (!learningEnabled) {
         return

--- a/browser/src/Services/Sidebar/SidebarView.tsx
+++ b/browser/src/Services/Sidebar/SidebarView.tsx
@@ -20,6 +20,7 @@ export interface ISidebarIconProps {
     active: boolean
     focused: boolean
     iconName: string
+    hasNotification: boolean
     onClick: () => void
 }
 
@@ -31,6 +32,7 @@ const EntranceKeyframes = keyframes`
 `
 
 const SidebarIconWrapper = withProps<ISidebarIconProps>(styled.div)`
+    position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -57,6 +59,28 @@ const SidebarIconWrapper = withProps<ISidebarIconProps>(styled.div)`
     }
     `
 
+const NotificationEnterKeyFrames = keyframes`
+    0% { opacity: 0; transform: scale(0.5); translateY(6px); }
+    75% { opacity: 0.75; transform: scale(1.25); translateY(2px); }
+    100% { opacity: 1; transform: scale(1); translateY(0px); }
+`
+
+const SidebarIconNotification = withProps<{}>(styled.div)`
+    animation: ${NotificationEnterKeyFrames} 0.35s linear forwards;
+    animation-delay: 1s;
+
+    opacity: 0;
+
+    position:absolute;
+    top: 10px;
+    right: 10px;
+    width: 0.4rem;
+    height: 0.4rem;
+
+    background-color: ${p => p.theme["highlight.mode.normal.background"]};
+    border-radius: 1rem;
+`
+
 const SidebarIconInner = styled.div`
     margin-top: 16px;
     margin-bottom: 16px;
@@ -64,12 +88,14 @@ const SidebarIconInner = styled.div`
 
 export class SidebarIcon extends React.PureComponent<ISidebarIconProps, {}> {
     public render(): JSX.Element {
+        const notification = this.props.hasNotification ? <SidebarIconNotification /> : null
         return (
             <Sneakable callback={this.props.onClick}>
                 <SidebarIconWrapper {...this.props} tabIndex={0}>
                     <SidebarIconInner>
                         <Icon name={this.props.iconName} size={IconSize.Large} />
                     </SidebarIconInner>
+                    {notification}
                 </SidebarIconWrapper>
             </Sneakable>
         )
@@ -132,6 +158,7 @@ export class SidebarView extends React.PureComponent<ISidebarViewProps, {}> {
                                     iconName={e.icon}
                                     active={isActive}
                                     focused={isFocused}
+                                    hasNotification={e.hasNotification}
                                     onClick={() => this.props.onSelectionChanged(e.id)}
                                 />
                             )


### PR DESCRIPTION
We've got an achievement that shows up on first launch, which is pretty cool... But it might not be clear to users how it's useful or what they can do with it.

I've added a notification bubble that pops up on the sidebar learning pane's icon - so that hopefully it will help bring users over there (and showcase the learning / achievements).

![sidebar-notification](https://user-images.githubusercontent.com/13532591/37849363-9e0605cc-2e94-11e8-8b98-cb9771fd5f0d.gif)

It's pretty subtle but I hope it will help new  users get on-boarded. Will be more useful when we have more content in that pane 😄 