### PR TITLE
Browser: Enable 'sneak mode' for textarea and button tags

### DIFF
--- a/webview_preload/src/index.ts
+++ b/webview_preload/src/index.ts
@@ -60,7 +60,7 @@
                 if (elem && elem.click) {
                     if (elem.tagName === "A") {
                         elem.click()
-                    } else if (elem.tagName === "INPUT") {
+                    } else if (elem.tagName === "INPUT" || elem.tagName === "TEXTAREA") {
                         elem.focus()
                     }
                 }
@@ -78,7 +78,7 @@
             })
         }
 
-        const tagsToCollect = ["a", "input"]
+        const tagsToCollect = ["a", "input", "textarea"]
 
         tagsToCollect.forEach(tag => {
             const elems = document.getElementsByTagName(tag) as NodeListOf<HTMLElement>


### PR DESCRIPTION
This updates our webview integration layer, such that it is aware of a couple missing tags: `<textarea>` and `<button>`.