### PR TITLE
Achievements: Add 'dependent achievements'

### DIFF
--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -10,7 +10,7 @@ import * as React from "react"
 import styled from "styled-components"
 
 import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
-import { boxShadow, Fixed, Full, withProps, Bold } from "./../../../UI/components/common"
+import { Bold, boxShadow, Fixed, Full, withProps } from "./../../../UI/components/common"
 import { FlipCard } from "./../../../UI/components/FlipCard"
 import { Icon, IconSize } from "./../../../UI/Icon"
 

--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -10,7 +10,7 @@ import * as React from "react"
 import styled from "styled-components"
 
 import { BufferLayerHeader } from "./../../../UI/components/BufferLayerHeader"
-import { boxShadow, Fixed, Full, withProps } from "./../../../UI/components/common"
+import { boxShadow, Fixed, Full, withProps, Bold } from "./../../../UI/components/common"
 import { FlipCard } from "./../../../UI/components/FlipCard"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
@@ -97,25 +97,46 @@ export const CenteredIcon = withProps<ICenteredIconProps>(styled.div)`
     ${p => (p.isSuccess ? "color: " + p.theme["highlight.mode.insert.background"] + ";" : "")}
 `
 
-export const TrophyCaseItemView = (props: { achievementInfo: AchievementWithProgressInfo }) => {
+export const TrophyCaseItemView = (props: {
+    achievementInfo: AchievementWithProgressInfo
+    dependentAchieventName?: string
+}) => {
+    const isLocked = !!props.dependentAchieventName
+
+    const icon = (
+        <FlipCard
+            isFlipped={props.achievementInfo.completed}
+            front={
+                <CenteredIcon>
+                    <Icon name="trophy" size={IconSize.ThreeX} />
+                </CenteredIcon>
+            }
+            back={
+                <CenteredIcon isSuccess={true}>
+                    <Icon name="check" size={IconSize.ThreeX} />
+                </CenteredIcon>
+            }
+        />
+    )
+
+    const lockedIcon = (
+        <CenteredIcon>
+            <Icon name="lock" size={IconSize.ThreeX} />
+        </CenteredIcon>
+    )
+
+    const description = isLocked ? (
+        <span>
+            Complete the <Bold>{props.dependentAchieventName}</Bold> achievement to unlock
+        </span>
+    ) : (
+        props.achievementInfo.achievement.description
+    )
+
     return (
         <TrophyCaseItemViewWrapper>
             <Fixed>
-                <TrophyItemIcon>
-                    <FlipCard
-                        isFlipped={props.achievementInfo.completed}
-                        front={
-                            <CenteredIcon>
-                                <Icon name="trophy" size={IconSize.ThreeX} />
-                            </CenteredIcon>
-                        }
-                        back={
-                            <CenteredIcon isSuccess={true}>
-                                <Icon name="check" size={IconSize.ThreeX} />
-                            </CenteredIcon>
-                        }
-                    />
-                </TrophyItemIcon>
+                <TrophyItemIcon>{isLocked ? lockedIcon : icon}</TrophyItemIcon>
             </Fixed>
             <Full
                 style={{
@@ -125,8 +146,8 @@ export const TrophyCaseItemView = (props: { achievementInfo: AchievementWithProg
                     padding: "1em",
                 }}
             >
-                <TitleText>{props.achievementInfo.achievement.name}</TitleText>
-                <DescriptionText>{props.achievementInfo.achievement.description}</DescriptionText>
+                <TitleText>{isLocked ? null : props.achievementInfo.achievement.name}</TitleText>
+                <DescriptionText>{description}</DescriptionText>
             </Full>
         </TrophyCaseItemViewWrapper>
     )
@@ -145,9 +166,25 @@ export class TrophyCaseView extends React.PureComponent<
     }
 
     public render(): JSX.Element {
-        const items = this.state.progressInfo.map(item => (
-            <TrophyCaseItemView achievementInfo={item} />
-        ))
+        const items = this.state.progressInfo.map(item => {
+            let dependentAchievementName = null
+            if (item.locked) {
+                const dependentId = item.achievement.dependsOnId
+                const dependentAchievement = this.state.progressInfo.find(
+                    f => f.achievement.uniqueId === dependentId,
+                )
+                if (dependentAchievement) {
+                    dependentAchievementName = dependentAchievement.achievement.name
+                }
+            }
+
+            return (
+                <TrophyCaseItemView
+                    achievementInfo={item}
+                    dependentAchieventName={dependentAchievementName}
+                />
+            )
+        })
         return (
             <TrophyCaseViewWrapper>
                 <TrophyCaseBackground>

--- a/browser/src/Services/Learning/Achievements/AchievementsManager.ts
+++ b/browser/src/Services/Learning/Achievements/AchievementsManager.ts
@@ -15,6 +15,10 @@ export interface AchievementDefinition {
     name: string
     description: string
 
+    // An achievement 'id' that this achievement
+    // depends on, before it can be tracked or available
+    dependsOnId?: string
+
     goals: AchievementGoalDefinition[]
 }
 
@@ -26,6 +30,7 @@ export interface AchievementGoalDefinition {
 
 export interface AchievementWithProgressInfo {
     achievement: AchievementDefinition
+    locked?: boolean
     completed: boolean
 }
 
@@ -76,11 +81,16 @@ export class AchievementsManager {
         const allAchievements = Object.values(this._achievements)
 
         return allAchievements.map(achievement => {
-            const completed = this._goalState.achievedIds.indexOf(achievement.uniqueId) >= 0
-
+            const isDependentAchievementCompleted =
+                !achievement.dependsOnId ||
+                this._goalState.achievedIds.indexOf(achievement.dependsOnId) >= 0
+            const completed =
+                isDependentAchievementCompleted &&
+                this._goalState.achievedIds.indexOf(achievement.uniqueId) >= 0
             return {
                 achievement,
                 completed,
+                locked: !isDependentAchievementCompleted,
             }
         })
     }

--- a/browser/src/Services/Learning/Achievements/index.tsx
+++ b/browser/src/Services/Learning/Achievements/index.tsx
@@ -61,7 +61,7 @@ export const activate = (
             {
                 name: "Launch Oni",
                 goalId: "oni.goal.launch",
-                count: 2,
+                count: 1,
             },
         ],
     })

--- a/browser/src/Services/Learning/Achievements/index.tsx
+++ b/browser/src/Services/Learning/Achievements/index.tsx
@@ -61,13 +61,14 @@ export const activate = (
             {
                 name: "Launch Oni",
                 goalId: "oni.goal.launch",
-                count: 1,
+                count: 2,
             },
         ],
     })
 
     manager.registerAchievement({
         uniqueId: "oni.achievement.dedication",
+        dependsOnId: "oni.achievement.welcome",
         name: "Dedication",
         description: "Launch Oni 25 times",
         goals: [

--- a/browser/test/Services/Learning/Achievements/AchievementsManagerTests.ts
+++ b/browser/test/Services/Learning/Achievements/AchievementsManagerTests.ts
@@ -6,6 +6,7 @@ import * as assert from "assert"
 
 import {
     AchievementsManager,
+    AchievementDefinition,
     IPersistedAchievementState,
 } from "./../../../../src/Services/Learning/Achievements"
 
@@ -89,5 +90,51 @@ describe("AchievementsManagerTests", () => {
         achievementsManager.registerAchievement(achievement)
 
         assert.strictEqual(hitCount, 1, "Validate that onAchievementsAccomplished was fired")
+    })
+
+    describe("dependent achievements", () => {
+        let achievementsManager: AchievementsManager
+        let coreAchievement: AchievementDefinition
+        let dependentAchievement: AchievementDefinition
+
+        beforeEach(async () => {
+            achievementsManager = new AchievementsManager(mockStore)
+            await achievementsManager.start()
+
+            coreAchievement = createTestAchievement("test.achievement.core", "test.goal")
+            dependentAchievement = createTestAchievement("test.achievement.dependent", "test.goal")
+            dependentAchievement.dependsOnId = "test.achievement.core"
+
+            achievementsManager.registerAchievement(coreAchievement)
+            achievementsManager.registerAchievement(dependentAchievement)
+        })
+
+        it("is locked until dependent achievement is accomplished", () => {
+            const progress = achievementsManager.getAchievements()
+
+            const coreResult = progress.find(
+                a => a.achievement.uniqueId === "test.achievement.core",
+            )
+            const dependentResult = progress.find(
+                a => a.achievement.uniqueId === "test.achievement.dependent",
+            )
+
+            assert.strictEqual(coreResult.locked, false)
+            assert.strictEqual(dependentResult.locked, true)
+
+            achievementsManager.notifyGoal("test.goal")
+
+            const progressAfterFirstGoal = achievementsManager.getAchievements()
+            const coreResultAfter = progressAfterFirstGoal.find(
+                a => a.achievement.uniqueId === "test.achievement.core",
+            )
+            const dependentResultAfter = progressAfterFirstGoal.find(
+                a => a.achievement.uniqueId === "test.achievement.dependent",
+            )
+
+            assert.strictEqual(coreResultAfter.completed, true)
+            // The dependent result should no longer be locked
+            assert.strictEqual(dependentResultAfter.locked, false)
+        })
     })
 })

--- a/browser/test/Services/Learning/Achievements/AchievementsManagerTests.ts
+++ b/browser/test/Services/Learning/Achievements/AchievementsManagerTests.ts
@@ -5,8 +5,8 @@
 import * as assert from "assert"
 
 import {
-    AchievementsManager,
     AchievementDefinition,
+    AchievementsManager,
     IPersistedAchievementState,
 } from "./../../../../src/Services/Learning/Achievements"
 


### PR DESCRIPTION
This adds an ability for an achievement to be 'dependent' on another achievement. If that other achievement isn't accomplished yet, the dependent achievement will show as 'locked' on the achievements screen.