### PR TITLE
Tutorial: Track progress / completion state

### DIFF
--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -102,12 +102,10 @@ export const TutorialItemView = (props: { info: ITutorialMetadataWithProgress })
     const results = isCompleted ? (
         <div style={{ margin: "0.25em" }}>
             <TutorialResultsWrapper>
-                <Bold>Keys:</Bold>
-                {props.info.completionInfo.keyPresses}
+                <Bold>{(props.info.completionInfo.time / 1000).toFixed(2)}</Bold>s
             </TutorialResultsWrapper>
             <TutorialResultsWrapper>
-                <Bold>Time:</Bold>
-                {props.info.completionInfo.time}s
+                <Bold>{props.info.completionInfo.keyPresses}</Bold> keys
             </TutorialResultsWrapper>
         </div>
     ) : (
@@ -155,6 +153,13 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
 
         this.trackDisposable(this.props.onEnter.subscribe(() => this.setState({ isActive: true })))
         this.trackDisposable(this.props.onLeave.subscribe(() => this.setState({ isActive: false })))
+        this.trackDisposable(
+            this.props.tutorialManager.onTutorialCompletedEvent.subscribe(() => {
+                this.setState({
+                    tutorialInfo: this.props.tutorialManager.getTutorialInfo(),
+                })
+            }),
+        )
     }
 
     public render(): JSX.Element {

--- a/browser/src/Services/Learning/Tutorial/CompletionView.tsx
+++ b/browser/src/Services/Learning/Tutorial/CompletionView.tsx
@@ -75,7 +75,7 @@ export const CompletionView = (props: ICompletionViewProps): JSX.Element => {
             <Fixed>
                 <ResultsWrapper>
                     <div>
-                        <Bold>Time:</Bold> {props.time}s
+                        <Bold>Time:</Bold> {(props.time / 1000).toFixed(2)}s
                     </div>
                     <div>
                         <Bold>Keystrokes:</Bold> {props.keyStrokes}

--- a/browser/src/Services/Learning/Tutorial/TutorialManager.ts
+++ b/browser/src/Services/Learning/Tutorial/TutorialManager.ts
@@ -11,7 +11,6 @@ import { IPersistentStore } from "./../../../PersistentStore"
 
 import { ITutorial, ITutorialMetadata } from "./ITutorial"
 import { TutorialBufferLayer } from "./TutorialBufferLayer"
-import * as Tutorials from "./Tutorials"
 
 export interface ITutorialPersistedState {
     completedTutorialIds: string[]
@@ -71,6 +70,10 @@ export class TutorialManager {
         }))
     }
 
+    public getTutorial(id: string): ITutorial {
+        return this._tutorials.find(t => t.metadata.id === id)
+    }
+
     public registerTutorial(tutorial: ITutorial): void {
         this._tutorials.push(tutorial)
     }
@@ -111,9 +114,9 @@ export class TutorialManager {
 
     public async startTutorial(id: string): Promise<void> {
         // const tutorial = this._getTutorialById(id)
-        const buf = await this._editorManager.activeEditor.openFile("Tutorial")
-        const layer = new TutorialBufferLayer()
-        layer.startTutorial(new Tutorials.BasicMovementTutorial())
+        const buf = await this._editorManager.activeEditor.openFile("oni://tutorial")
+        const layer = new TutorialBufferLayer(this)
+        layer.startTutorial(id)
         buf.addLayer(layer)
 
         // Focus the editor
@@ -129,6 +132,6 @@ export class TutorialManager {
     }
 
     private _getCompletionState(id: string): ITutorialCompletionInfo {
-        return this._persistedState[id] || null
+        return this._persistedState.completionInfo[id] || null
     }
 }

--- a/browser/src/Services/Learning/index.ts
+++ b/browser/src/Services/Learning/index.ts
@@ -44,6 +44,7 @@ export const activate = (
         completionInfo: {},
     })
     const tutorialManager = new TutorialManager(editorManager, store, windowManager)
+    tutorialManager.start()
     sidebarManager.add("trophy", new LearningPane(tutorialManager, commandManager))
 
     AllTutorials.forEach((tut: ITutorial) => tutorialManager.registerTutorial(tut))


### PR DESCRIPTION
This wires up the tutorial buffer layer so that it reports the completion status (time to complete / key presses to complete) back to `TutorialManager`, which then persists it. This means that the tutorial state is now persisted and saved between sessions, which is great for jumping back into it:

![image](https://user-images.githubusercontent.com/13532591/37857172-49c44a7e-2eb6-11e8-9b43-8eebd8e24a54.png)

Now we just need more tutorials 😄 
