### PR TITLE
Sneak: Particle effect to improve feel of selected sneak item

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -146,6 +146,7 @@ export const start = async (args: string[]): Promise<void> => {
 
     const Colors = await colorsPromise
     Colors.activate(configuration, Themes.getThemeManagerInstance())
+    const colors = Colors.getInstance()
     Shell.initializeColors(Colors.getInstance())
     Performance.endMeasure("Oni.Start.Themes")
 
@@ -177,7 +178,7 @@ export const start = async (args: string[]): Promise<void> => {
     const sneakPromise = import("./Services/Sneak")
     const { commandManager } = await import("./Services/CommandManager")
     const Sneak = await sneakPromise
-    Sneak.activate(commandManager, overlayManager)
+    Sneak.activate(colors, commandManager, configuration, overlayManager)
 
     const Menu = await menuPromise
     Menu.activate(configuration, overlayManager)

--- a/browser/src/Services/Particles/ParticleSystem.tsx
+++ b/browser/src/Services/Particles/ParticleSystem.tsx
@@ -31,7 +31,23 @@ export interface ParticleSystemDefinition {
     StartOpacity: number
     EndOpacity: number
 
+    Gravity: Vector
+
     Time: number
+}
+
+const ZeroVector = { x: 0, y: 0 }
+
+export const DefaultParticleSystemDefinition: Partial<ParticleSystemDefinition> = {
+    Color: "white",
+    StartOpacity: 1,
+    EndOpacity: 0,
+    Gravity: { x: 0, y: 500 },
+    Time: 1,
+    Position: ZeroVector,
+    Velocity: ZeroVector,
+    PositionVariance: ZeroVector,
+    VelocityVariance: ZeroVector,
 }
 
 export interface Particle {
@@ -41,6 +57,7 @@ export interface Particle {
 
     velocity: Vector
     opacityVelocity: number
+    gravity: Vector
 
     remainingTime: number
 }
@@ -70,8 +87,13 @@ export class ParticleSystem {
         this._enabled = val
     }
 
-    public createParticles(count: number, system: ParticleSystemDefinition): void {
+    public createParticles(count: number, particleSystem: Partial<ParticleSystemDefinition>): void {
         const newParticles: Particle[] = []
+
+        const system = {
+            ...DefaultParticleSystemDefinition,
+            ...particleSystem,
+        }
 
         for (let i = 0; i < count; i++) {
             newParticles.push({
@@ -85,6 +107,7 @@ export class ParticleSystem {
                     x: system.Velocity.x + (Math.random() - 0.5) * system.VelocityVariance.x,
                     y: system.Velocity.y + (Math.random() - 0.5) * system.VelocityVariance.y,
                 },
+                gravity: system.Gravity,
                 opacityVelocity: (system.EndOpacity - system.StartOpacity) / system.Time,
                 remainingTime: system.Time,
             })
@@ -124,8 +147,8 @@ export class ParticleSystem {
                     y: p.position.y + p.velocity.y * deltaTime,
                 },
                 velocity: {
-                    x: p.velocity.x,
-                    y: p.velocity.y + 500 * deltaTime,
+                    x: p.velocity.x + p.gravity.x * deltaTime,
+                    y: p.velocity.y + p.gravity.y * deltaTime,
                 },
                 opacity: p.opacity + p.opacityVelocity * deltaTime,
                 remainingTime: p.remainingTime - deltaTime,

--- a/browser/src/Services/Sneak/index.tsx
+++ b/browser/src/Services/Sneak/index.tsx
@@ -4,12 +4,12 @@
  * Entry point for sneak functionality
  */
 
+import { Colors } from "./../Colors"
 import { CallbackCommand, CommandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
 import { AchievementsManager } from "./../Learning/Achievements"
 import { OverlayManager } from "./../Overlay"
 import { getInstance as getParticlesInstance } from "./../Particles"
-import { Colors } from "./../Colors"
 
 import { Sneak } from "./Sneak"
 

--- a/browser/src/Services/Sneak/index.tsx
+++ b/browser/src/Services/Sneak/index.tsx
@@ -5,8 +5,11 @@
  */
 
 import { CallbackCommand, CommandManager } from "./../CommandManager"
+import { Configuration } from "./../Configuration"
 import { AchievementsManager } from "./../Learning/Achievements"
 import { OverlayManager } from "./../Overlay"
+import { getInstance as getParticlesInstance } from "./../Particles"
+import { Colors } from "./../Colors"
 
 import { Sneak } from "./Sneak"
 
@@ -14,7 +17,12 @@ export * from "./SneakStore"
 
 let _sneak: Sneak
 
-export const activate = (commandManager: CommandManager, overlayManager: OverlayManager) => {
+export const activate = (
+    colors: Colors,
+    commandManager: CommandManager,
+    configuration: Configuration,
+    overlayManager: OverlayManager,
+) => {
     _sneak = new Sneak(overlayManager)
 
     commandManager.registerCommand(
@@ -37,6 +45,8 @@ export const activate = (commandManager: CommandManager, overlayManager: Overlay
             () => _sneak.isActive,
         ),
     )
+
+    initializeParticles(colors, configuration)
 }
 
 export const registerAchievements = (achievements: AchievementsManager) => {
@@ -81,6 +91,32 @@ export const registerAchievements = (achievements: AchievementsManager) => {
 
     _sneak.onSneakCompleted.subscribe(val => {
         achievements.notifyGoal("oni.goal.sneak.complete")
+    })
+}
+
+export const initializeParticles = (colors: Colors, configuration: Configuration) => {
+    const isAnimationEnabled = () => configuration.getValue("ui.animations.enabled")
+    const getVisualColor = () => colors.getColor("highlight.mode.visual.background")
+
+    _sneak.onSneakCompleted.subscribe(sneak => {
+        if (!isAnimationEnabled()) {
+            return
+        }
+        const particles = getParticlesInstance()
+
+        if (!particles) {
+            return
+        }
+
+        particles.createParticles(15, {
+            Position: { x: sneak.rectangle.x, y: sneak.rectangle.y },
+            PositionVariance: { x: 0, y: 0 },
+            Velocity: { x: 0, y: 0 },
+            Gravity: { x: 0, y: 300 },
+            VelocityVariance: { x: 200, y: 200 },
+            Time: 0.2,
+            Color: getVisualColor(),
+        })
     })
 }
 


### PR DESCRIPTION
This leverages the particle system to make the 'sneak' interaction more satisfying.

The sneak interaction today isn't very compelling, because once you press the final key to trigger the selected element, you don't get any sort of immediate visual confirmation of your selection. This subconsciously feels a bit awkward, especially in cases like the browser where it might take a second for a page to load - there is a moment of uncertainty if the system responded properly to your input.

The particle effect provides an immediate visual confirmation of your choice, which feels a bit more satisfying. This is gated by the `ui.animations.enabled` configuration setting, so if animations are off, the particle effect won't be executed.
