### PR TITLE
Feature/highlight config reference

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -42,6 +42,7 @@ import { TokenColor } from "./../Services/TokenColors"
 import { IBufferLayer } from "./NeovimEditor/BufferLayerManager"
 
 export interface IBuffer extends Oni.Buffer {
+    setLanguage(lang: string): Promise<void>
     getCursorPosition(): Promise<types.Position>
     handleInput(key: string): boolean
     detectIndentation(): Promise<BufferIndentationInfo>
@@ -175,11 +176,13 @@ export class Buffer implements IBuffer {
 
     public async setLanguage(language: string): Promise<void> {
         this._language = language
-        await this._neovimInstance.request<any>("nvim_buf_set_option", [
+        console.log("language: ", language)
+        const result = await this._neovimInstance.request<any>("nvim_buf_set_option", [
             parseInt(this._id, 10),
             "filetype",
             language,
         ])
+        console.log("result----------------------------------------------------------: ", result)
     }
 
     public async detectIndentation(): Promise<BufferIndentationInfo> {

--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -46,6 +46,7 @@ export interface IBuffer extends Oni.Buffer {
     getCursorPosition(): Promise<types.Position>
     handleInput(key: string): boolean
     detectIndentation(): Promise<BufferIndentationInfo>
+    setScratchBuffer(): Promise<void>
 }
 
 type NvimError = [1, string]
@@ -176,13 +177,30 @@ export class Buffer implements IBuffer {
 
     public async setLanguage(language: string): Promise<void> {
         this._language = language
-        console.log("language: ", language)
-        const result = await this._neovimInstance.request<any>("nvim_buf_set_option", [
-            parseInt(this._id, 10),
-            "filetype",
-            language,
-        ])
-        console.log("result----------------------------------------------------------: ", result)
+        await this._neovimInstance.command(`setl ft=${language}`)
+    }
+
+    public async setScratchBuffer(): Promise<void> {
+        // set the open buffer to be a readonly throw away buffer, also add scrollbind
+        // may need a config option
+        const calls = [
+            ["nvim_command", ["setlocal buftype=nofile"]],
+            ["nvim_command", ["setlocal bufhidden=hide"]],
+            ["nvim_command", ["setlocal noswapfile"]],
+            ["nvim_command", ["setlocal nobuflisted"]],
+            ["nvim_command", ["setlocal nomodifiable"]],
+            ["nvim_command", ["windo set scrollbind!"]],
+        ]
+
+        const [result, error] = await this._neovimInstance.request<any[] | NvimError>(
+            "nvim_call_atomic",
+            [calls],
+        )
+
+        if (typeof result === "number" && error) {
+            Log.info(`Failed to set scratch buffer due to ${error}`)
+        }
+        this._modified = false
     }
 
     public async detectIndentation(): Promise<BufferIndentationInfo> {

--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -125,6 +125,11 @@ export class ConfigurationEditManager {
         // set it as the reference buffer content
         const referenceContent = JSON.stringify(DefaultConfiguration, null, "  ")
         await referenceBuffer.setLines(0, 1, referenceContent.split("\n"))
+        console.log(
+            "Does set lang exist: ",
+            await (referenceBuffer as any).setLanguage("javascript"),
+        )
+        await (referenceBuffer as any).setLanguage("javascript")
     }
 
     private async _transpileConfiguration(

--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -117,19 +117,19 @@ export class ConfigurationEditManager {
     }
 
     private async _createReadonlyReferenceBuffer() {
-        const referenceBuffer = await this._editorManager.activeEditor.openFile("", {
+        const referenceBuffer = await this._editorManager.activeEditor.openFile("reference", {
             openMode: Oni.FileOpenMode.NewTab,
         })
 
         // Format the default configuration values as a pretty JSON object, then
         // set it as the reference buffer content
         const referenceContent = JSON.stringify(DefaultConfiguration, null, "  ")
-        await referenceBuffer.setLines(0, 1, referenceContent.split("\n"))
-        console.log(
-            "Does set lang exist: ",
-            await (referenceBuffer as any).setLanguage("javascript"),
-        )
-        await (referenceBuffer as any).setLanguage("javascript")
+        await Promise.all([
+            referenceBuffer.setLines(0, 1, referenceContent.split("\n")),
+            // FIXME: needs to be added to the Oni.Buffers API
+            (referenceBuffer as any).setLanguage("json"),
+            (referenceBuffer as any).setScratchBuffer(),
+        ])
     }
 
     private async _transpileConfiguration(


### PR DESCRIPTION
Following on from #1795 I've added a method to set the `reference` split to a scratch buffer and set syntax highlighting to `json` (this is mainly because the lsp throws an error if set to `js` or `ts` for example as the contents of the split aren't valid js or ts).

I've set the buffer to open as `nomodifiable` as well.

The outstanding thing is to add the method `setScratchBuffer` to the `oni-api` also I added a `scrollbind` to the window as I thought it'd be nice to have the reference scroll with the user though I can easily see ppl objecting to this, open to removing it or making it configurable.

Also tweaked the set lang method as after a lot of debugging seems that the command `nvim_buf` was not actually working.

EDIT: opened onivim/oni-api#37 to add new buffer methods

<img width="1455" alt="screen shot 2018-03-26 at 00 03 51" src="https://user-images.githubusercontent.com/22454918/37881022-3ca38da8-3089-11e8-93b8-105a335de5cc.png">
