### PR TITLE
Add an example of binding to an internal command

### DIFF
--- a/configuration/config.default.js
+++ b/configuration/config.default.js
@@ -9,6 +9,7 @@ const activate = oni => {
     //
     // Add input bindings here:
     //
+    oni.input.bind("<f1>", "commands.show")
     oni.input.bind("<c-enter>", () => console.log("Control+Enter was pressed"))
 
     //


### PR DESCRIPTION
I use Ctrl+Shift+P for screenshoting and have no any ability to pass it to Oni.

The shortcuts configuration for internal features is not detailed at all, I think it would be a great addition.

1. Adding the example and keywords to search in the code
2. Reproducing the VS Code behavior