### PR TITLE
Fix #1924 - Part 1 - Make tutorials clickable and sneakable in the sidebar

### DIFF
--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -16,6 +16,8 @@ import { VimNavigator } from "./../UI/components/VimNavigator"
 
 import { PluginManager } from "./../Plugins/PluginManager"
 
+import { noop } from "./../Utility"
+
 export class PluginsSidebarPane implements SidebarPane {
     private _onEnter = new Event<void>()
     private _onLeave = new Event<void>()
@@ -120,7 +122,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             isFocused={p.id === selectedId}
                             isContainer={false}
                             text={p.id}
-                            onClick={() => {}}
+                            onClick={noop}
                         />
                     ))
 
@@ -130,7 +132,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             isFocused={p.id === selectedId}
                             isContainer={false}
                             text={p.id}
-                            onClick={() => {}}
+                            onClick={noop}
                         />
                     ))
 
@@ -140,7 +142,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                                 text={"Default"}
                                 isExpanded={this.state.defaultPluginsExpanded}
                                 isFocused={selectedId === "container.default"}
-                                onClick={() => {}}
+                                onClick={noop}
                             >
                                 {defaultPluginItems}
                             </SidebarContainerView>
@@ -148,7 +150,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                                 text={"User"}
                                 isExpanded={this.state.userPluginsExpanded}
                                 isFocused={selectedId === "container.user"}
-                                onClick={() => {}}
+                                onClick={noop}
                             >
                                 {userPluginItems}
                             </SidebarContainerView>

--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -120,6 +120,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             isFocused={p.id === selectedId}
                             isContainer={false}
                             text={p.id}
+                            onClick={() => {}}
                         />
                     ))
 
@@ -129,6 +130,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             isFocused={p.id === selectedId}
                             isContainer={false}
                             text={p.id}
+                            onClick={() => {}}
                         />
                     ))
 
@@ -138,6 +140,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                                 text={"Default"}
                                 isExpanded={this.state.defaultPluginsExpanded}
                                 isFocused={selectedId === "container.default"}
+                                onClick={() => {}}
                             >
                                 {defaultPluginItems}
                             </SidebarContainerView>
@@ -145,6 +148,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                                 text={"User"}
                                 isExpanded={this.state.userPluginsExpanded}
                                 isFocused={selectedId === "container.user"}
+                                onClick={() => {}}
                             >
                                 {userPluginItems}
                             </SidebarContainerView>

--- a/browser/src/Services/Bookmarks/BookmarksPane.tsx
+++ b/browser/src/Services/Bookmarks/BookmarksPane.tsx
@@ -176,6 +176,7 @@ export class BookmarksPaneView extends React.PureComponent<
                     isFocused={selectedId === bm.id}
                     isContainer={false}
                     indentationLevel={0}
+                    onClick={() => this._onSelected(bm.id)}
                 />
             )
 
@@ -199,6 +200,7 @@ export class BookmarksPaneView extends React.PureComponent<
                                     text="Global Marks"
                                     isExpanded={this.state.isGlobalSectionExpanded}
                                     isFocused={selectedId === "container.global"}
+                                    onClick={() => this._onSelected("container.global")}
                                 >
                                     {globalMarks.map(mapFunc)}
                                 </SidebarContainerView>
@@ -206,6 +208,7 @@ export class BookmarksPaneView extends React.PureComponent<
                                     text="Local Marks"
                                     isExpanded={this.state.isLocalSectionExpanded}
                                     isFocused={selectedId === "container.local"}
+                                    onClick={() => this._onSelected("container.local")}
                                 >
                                     {localMarks.map(mapFunc)}
                                 </SidebarContainerView>

--- a/browser/src/Services/Explorer/ExplorerView.tsx
+++ b/browser/src/Services/Explorer/ExplorerView.tsx
@@ -70,7 +70,6 @@ export class NodeView extends React.PureComponent<INodeViewProps, {}> {
         return (
             <NodeWrapper
                 style={{ cursor: "pointer" }}
-                onClick={() => this.props.onClick()}
                 innerRef={this.props.isSelected ? scrollIntoViewIfNeeded : noop}
             >
                 {this.getElement()}
@@ -96,6 +95,7 @@ export class NodeView extends React.PureComponent<INodeViewProps, {}> {
                                     isOver={isOver && canDrop}
                                     didDrop={didDrop}
                                     canDrop={canDrop}
+                                    onClick={() => this.props.onClick()}
                                     text={node.name}
                                     isFocused={this.props.isSelected}
                                     isContainer={false}
@@ -118,6 +118,7 @@ export class NodeView extends React.PureComponent<INodeViewProps, {}> {
                                     isOver={isOver}
                                     isContainer={true}
                                     isExpanded={node.expanded}
+                                    onClick={() => this.props.onClick()}
                                     text={node.name}
                                     isFocused={this.props.isSelected}
                                 />
@@ -143,6 +144,7 @@ export class NodeView extends React.PureComponent<INodeViewProps, {}> {
                                     text={node.name}
                                     isFocused={this.props.isSelected}
                                     indentationLevel={node.indentationLevel}
+                                    onClick={() => this.props.onClick()}
                                 />
                             )
                         }}
@@ -166,7 +168,6 @@ export interface IExplorerViewProps extends IExplorerViewContainerProps {
 }
 
 import { SidebarEmptyPaneView } from "./../../UI/components/SidebarEmptyPaneView"
-import { Sneakable } from "./../../UI/components/Sneakable"
 
 import { commandManager } from "./../CommandManager"
 
@@ -193,14 +194,12 @@ export class ExplorerView extends React.PureComponent<IExplorerViewProps, {}> {
                 onSelected={id => this.props.onClick(id)}
                 render={(selectedId: string) => {
                     const nodes = this.props.nodes.map(node => (
-                        <Sneakable callback={() => this.props.onClick(node.id)} key={node.id}>
-                            <NodeView
-                                moveFileOrFolder={this.props.moveFileOrFolder}
-                                node={node}
-                                isSelected={node.id === selectedId}
-                                onClick={() => this.props.onClick(node.id)}
-                            />
-                        </Sneakable>
+                        <NodeView
+                            moveFileOrFolder={this.props.moveFileOrFolder}
+                            node={node}
+                            isSelected={node.id === selectedId}
+                            onClick={() => this.props.onClick(node.id)}
+                        />
                     ))
 
                     return (

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -172,6 +172,7 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
                     indentationLevel={0}
                     isFocused={selectedId === t.tutorialInfo.id}
                     text={<TutorialItemView info={t} />}
+                    onClick={() => this._onSelect(t.tutorialInfo.id)}
                 />
             ))
 
@@ -226,6 +227,7 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
                                     text={"Tutorials"}
                                     isContainer={true}
                                     isExpanded={true}
+                                    onClick={() => {}}
                                 >
                                     {items}
                                 </SidebarContainerView>

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -21,6 +21,8 @@ import { SidebarPane } from "./../Sidebar"
 
 import { ITutorialMetadataWithProgress, TutorialManager } from "./Tutorial/TutorialManager"
 
+import { noop } from "./../../Utility"
+
 export class LearningPane implements SidebarPane {
     private _onEnter = new Event<void>()
     private _onLeave = new Event<void>()
@@ -227,7 +229,7 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
                                     text={"Tutorials"}
                                     isContainer={true}
                                     isExpanded={true}
-                                    onClick={() => {}}
+                                    onClick={noop}
                                 >
                                     {items}
                                 </SidebarContainerView>

--- a/browser/src/UI/components/SidebarItemView.tsx
+++ b/browser/src/UI/components/SidebarItemView.tsx
@@ -8,6 +8,8 @@ import * as React from "react"
 
 import { styled, withProps } from "./common"
 
+import { Sneakable } from "./../../UI/components/Sneakable"
+
 export interface ISidebarItemViewProps {
     isOver?: boolean
     canDrop?: boolean
@@ -17,6 +19,7 @@ export interface ISidebarItemViewProps {
     isContainer?: boolean
     indentationLevel: number
     icon?: JSX.Element
+    onClick: () => void
 }
 
 const px = (num: number): string => num.toString() + "px"
@@ -36,6 +39,9 @@ const SidebarItemStyleWrapper = withProps<ISidebarItemViewProps>(styled.div)`
     padding-top: 4px;
     padding-bottom: 4px;
     position: relative;
+
+    cursor: pointer;
+    pointer-events: all;
 
     .icon {
         flex: 0 0 auto;
@@ -77,11 +83,17 @@ export class SidebarItemView extends React.PureComponent<ISidebarItemViewProps, 
     public render(): JSX.Element {
         const icon = this.props.icon ? <div className="icon">{this.props.icon}</div> : null
         return (
-            <SidebarItemStyleWrapper {...this.props} className="item">
-                <SidebarItemBackground {...this.props} />
-                {icon}
-                <div className="name">{this.props.text}</div>
-            </SidebarItemStyleWrapper>
+            <Sneakable callback={this.props.onClick}>
+                <SidebarItemStyleWrapper
+                    {...this.props}
+                    className="item"
+                    onClick={this.props.onClick}
+                >
+                    <SidebarItemBackground {...this.props} />
+                    {icon}
+                    <div className="name">{this.props.text}</div>
+                </SidebarItemStyleWrapper>
+            </Sneakable>
         )
     }
 }
@@ -93,6 +105,7 @@ export interface ISidebarContainerViewProps extends IContainerProps {
     isFocused: boolean
     indentationLevel?: number
     isContainer?: boolean
+    onClick: () => void
 }
 
 interface IContainerProps {
@@ -122,6 +135,7 @@ export class SidebarContainerView extends React.PureComponent<ISidebarContainerV
                     text={this.props.text}
                     isFocused={this.props.isFocused}
                     isContainer={this.props.isContainer}
+                    onClick={this.props.onClick}
                 />
                 {this.props.isExpanded ? this.props.children : null}
             </SidebarContainer>


### PR DESCRIPTION
This fixes the first issue in #1924 - making the tutorials clickable and sneakable.

We were using a common `SidebarItemView` control, that is used in all sorts of sidebar experiences - from the explorer, plugins, etc. However, that control didn't handle the sneak/click action in a common way.

This change refactors the `SidebarItemView` to make that common functionality, and plugs in sneak/click to open the appropriate tutorial.