### PR TITLE
Browser: Enable by default

### DIFF
--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -66,8 +66,22 @@ export const activate = (
 
     const activeLayers: { [bufferId: string]: BrowserLayer } = {}
 
+    const browserEnabled = configuration.registerSetting("browser.enabled", {
+        requiresReload: false,
+        description:
+            "`browser.enabled` controls whether the embedded browser functionality is enabled",
+        defaultValue: true,
+    })
+
+    configuration.registerSetting("browser.zoomFactor", {
+        description:
+            "This sets the `zoomFactor` for nested browser windows. A value of `1` means `100%` zoom, a value of 0.5 means `50%` zoom, and a value of `2` means `200%` zoom.",
+        requiresReload: false,
+        defaultValue: 1,
+    })
+
     const openUrl = async (url: string, openMode: Oni.FileOpenMode = Oni.FileOpenMode.NewTab) => {
-        if (configuration.getValue("experimental.browser.enabled")) {
+        if (browserEnabled.getValue()) {
             url = url || configuration.getValue("browser.defaultUrl")
 
             count++
@@ -84,27 +98,20 @@ export const activate = (
         }
     }
 
-    if (configuration.getValue("experimental.browser.enabled")) {
-        commandManager.registerCommand({
-            command: "browser.openUrl.verticalSplit",
-            name: "Browser: Open in Vertical Split",
-            detail: "Open a browser window",
-            execute: (url?: string) => openUrl(url, Oni.FileOpenMode.VerticalSplit),
-        })
+    commandManager.registerCommand({
+        command: "browser.openUrl.verticalSplit",
+        name: "Browser: Open in Vertical Split",
+        detail: "Open a browser window",
+        execute: (url?: string) => openUrl(url, Oni.FileOpenMode.VerticalSplit),
+        enabled: () => browserEnabled.getValue(),
+    })
 
-        commandManager.registerCommand({
-            command: "browser.openUrl.horizontalSplit",
-            name: "Browser: Open in Horizontal Split",
-            detail: "Open a browser window",
-            execute: (url?: string) => openUrl(url, Oni.FileOpenMode.HorizontalSplit),
-        })
-    }
-
-    configuration.registerSetting("browser.zoomFactor", {
-        description:
-            "This sets the `zoomFactor` for nested browser windows. A value of `1` means `100%` zoom, a value of 0.5 means `50%` zoom, and a value of `2` means `200%` zoom.",
-        requiresReload: false,
-        defaultValue: 1,
+    commandManager.registerCommand({
+        command: "browser.openUrl.horizontalSplit",
+        name: "Browser: Open in Horizontal Split",
+        detail: "Open a browser window",
+        execute: (url?: string) => openUrl(url, Oni.FileOpenMode.HorizontalSplit),
+        enabled: () => browserEnabled.getValue(),
     })
 
     commandManager.registerCommand({
@@ -124,8 +131,7 @@ export const activate = (
     }
 
     const isBrowserLayerActive = () =>
-        !!activeLayers[editorManager.activeEditor.activeBuffer.id] &&
-        !!configuration.getValue("experimental.browser.enabled")
+        !!activeLayers[editorManager.activeEditor.activeBuffer.id] && browserEnabled.getValue()
 
     // Per-layer commands
     commandManager.registerCommand({

--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -66,7 +66,7 @@ export const activate = (
 
     const activeLayers: { [bufferId: string]: BrowserLayer } = {}
 
-    const browserEnabled = configuration.registerSetting("browser.enabled", {
+    const browserEnabledSetting = configuration.registerSetting("browser.enabled", {
         requiresReload: false,
         description:
             "`browser.enabled` controls whether the embedded browser functionality is enabled",
@@ -80,9 +80,16 @@ export const activate = (
         defaultValue: 1,
     })
 
+    const defaultUrlSetting = configuration.registerSetting("browser.defaultUrl", {
+        description:
+            "`browser.defaultUrl` sets the default url when opening a browser window, and no url was specified.",
+        requiresReload: false,
+        defaultValue: "https://github.com/onivim/oni",
+    })
+
     const openUrl = async (url: string, openMode: Oni.FileOpenMode = Oni.FileOpenMode.NewTab) => {
-        if (browserEnabled.getValue()) {
-            url = url || configuration.getValue("browser.defaultUrl")
+        if (browserEnabledSetting.getValue()) {
+            url = url || defaultUrlSetting.getValue()
 
             count++
             const buffer: Oni.Buffer = await editorManager.activeEditor.openFile(
@@ -103,7 +110,7 @@ export const activate = (
         name: "Browser: Open in Vertical Split",
         detail: "Open a browser window",
         execute: (url?: string) => openUrl(url, Oni.FileOpenMode.VerticalSplit),
-        enabled: () => browserEnabled.getValue(),
+        enabled: () => browserEnabledSetting.getValue(),
     })
 
     commandManager.registerCommand({
@@ -111,7 +118,7 @@ export const activate = (
         name: "Browser: Open in Horizontal Split",
         detail: "Open a browser window",
         execute: (url?: string) => openUrl(url, Oni.FileOpenMode.HorizontalSplit),
-        enabled: () => browserEnabled.getValue(),
+        enabled: () => browserEnabledSetting.getValue(),
     })
 
     commandManager.registerCommand({
@@ -131,7 +138,8 @@ export const activate = (
     }
 
     const isBrowserLayerActive = () =>
-        !!activeLayers[editorManager.activeEditor.activeBuffer.id] && browserEnabled.getValue()
+        !!activeLayers[editorManager.activeEditor.activeBuffer.id] &&
+        browserEnabledSetting.getValue()
 
     // Per-layer commands
     commandManager.registerCommand({


### PR DESCRIPTION
The browser feature is still pretty ripe - but I think it's in a good spot to get feedback. It's really an opt-in feature, as you only get to it via the command palette today. Having it in the wild will help track down bugs and figure out the priorities for the next set of work.

This removes the `experimental.browser.enabled` flag and replaces it with `browser.enabled`.