### PR TITLE
Prototype: Add browser layer when the buffer is http or https

### DIFF
--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -52,6 +52,7 @@ import { NeovimEditor } from "./../NeovimEditor"
 import { SplitDirection, windowManager } from "./../../Services/WindowManager"
 
 import { ImageBufferLayer } from "./ImageBufferLayer"
+import { BrowserLayer } from "./../../Services/Browser/BrowserLayer"
 
 // Helper method to wrap a react component into a layer
 const wrapReactComponentWithLayer = (id: string, component: JSX.Element): Oni.BufferLayer => {
@@ -168,6 +169,16 @@ export class OniEditor extends Utility.Disposable implements IEditor {
         )
         this._neovimEditor.bufferLayers.addBufferLayer("*", buf =>
             wrapReactComponentWithLayer("oni.layer.errors", <ErrorsContainer />),
+        )
+
+        const isBrowserEnabledForBuffer = (buf: Oni.Buffer) =>
+            buf.filePath &&
+            this._configuration.getValue("browser.enabled") &&
+            (buf.filePath.startsWith("http://") || buf.filePath.startsWith("https://"))
+        // TODO: We should be able to add this via our editor API - the `Browser` plugin should be able to add this to all editors.
+        this._neovimEditor.bufferLayers.addBufferLayer(
+            isBrowserEnabledForBuffer,
+            buf => new BrowserLayer(buf.filePath, this._configuration),
         )
 
         const extensions = this._configuration.getValue("editor.imageLayerExtensions")

--- a/browser/src/Services/Browser/BrowserLayer.tsx
+++ b/browser/src/Services/Browser/BrowserLayer.tsx
@@ -1,0 +1,56 @@
+/**
+ * BrowserLayer.tsx
+ *
+ * Buffer layer for browser functionality
+ */
+
+import * as React from "react"
+
+import * as Oni from "oni-api"
+import { Event } from "oni-types"
+
+import { Configuration } from "./../Configuration"
+
+import { BrowserView } from "./BrowserView"
+
+export class BrowserLayer implements Oni.BufferLayer {
+    private _debugEvent = new Event<void>()
+    private _goBackEvent = new Event<void>()
+    private _goForwardEvent = new Event<void>()
+    private _reloadEvent = new Event<void>()
+
+    constructor(private _url: string, private _configuration: Configuration) {}
+
+    public get id(): string {
+        return "oni.layer.browser"
+    }
+
+    public render(): JSX.Element {
+        return (
+            <BrowserView
+                configuration={this._configuration}
+                initialUrl={this._url}
+                goBack={this._goBackEvent}
+                goForward={this._goForwardEvent}
+                reload={this._reloadEvent}
+                debug={this._debugEvent}
+            />
+        )
+    }
+
+    public openDebugger(): void {
+        this._debugEvent.dispatch()
+    }
+
+    public goBack(): void {
+        this._goBackEvent.dispatch()
+    }
+
+    public goForward(): void {
+        this._goForwardEvent.dispatch()
+    }
+
+    public reload(): void {
+        this._reloadEvent.dispatch()
+    }
+}

--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -5,58 +5,14 @@
  */
 
 import { shell } from "electron"
-import * as React from "react"
-
 import * as Oni from "oni-api"
-import { Event } from "oni-types"
 
 import { CommandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 
-import { BrowserView } from "./BrowserView"
+import { BrowserLayer } from "./BrowserLayer"
 
-export class BrowserLayer implements Oni.BufferLayer {
-    private _debugEvent = new Event<void>()
-    private _goBackEvent = new Event<void>()
-    private _goForwardEvent = new Event<void>()
-    private _reloadEvent = new Event<void>()
-
-    constructor(private _url: string, private _configuration: Configuration) {}
-
-    public get id(): string {
-        return "oni.browser"
-    }
-
-    public render(): JSX.Element {
-        return (
-            <BrowserView
-                configuration={this._configuration}
-                initialUrl={this._url}
-                goBack={this._goBackEvent}
-                goForward={this._goForwardEvent}
-                reload={this._reloadEvent}
-                debug={this._debugEvent}
-            />
-        )
-    }
-
-    public openDebugger(): void {
-        this._debugEvent.dispatch()
-    }
-
-    public goBack(): void {
-        this._goBackEvent.dispatch()
-    }
-
-    public goForward(): void {
-        this._goForwardEvent.dispatch()
-    }
-
-    public reload(): void {
-        this._reloadEvent.dispatch()
-    }
-}
 export const activate = (
     commandManager: CommandManager,
     configuration: Configuration,


### PR DESCRIPTION
In line with the way we'd open a `term://` buffer, I think it would make sense to have the 'browser' available when we open an `http://` or `https://` buffer. Like this:

![browser-buffer-layer2](https://user-images.githubusercontent.com/13532591/37992836-b04ed51c-31c1-11e8-9d95-76c958c64ab6.gif)

@justinmk - what do you think about this?

The experience is a bit weird and rocky with the way `netrw` jumps in - it might be nice for Oni to disable `netrw`'s handling of `http` and `https` by default, or perhaps when the browser is enabled.