### PR TITLE
#1924 - Part 3 - Don't load init.vim for tutorial experience

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -899,9 +899,12 @@ export class NeovimEditor extends Editor implements IEditor {
         commandManager.executeCommand(command, null)
     }
 
-    public async init(filesToOpen: string[]): Promise<void> {
+    public async init(
+        filesToOpen: string[],
+        startOptions?: Partial<INeovimStartOptions>,
+    ): Promise<void> {
         Log.info("[NeovimEditor::init] Called with filesToOpen: " + filesToOpen)
-        const startOptions: INeovimStartOptions = {
+        const defaultOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
             transport: this._configuration.getValue("experimental.neovim.transport"),
             neovimPath: this._configuration.getValue("debug.neovimPath"),
@@ -909,7 +912,12 @@ export class NeovimEditor extends Editor implements IEditor {
             useDefaultConfig: this._configuration.getValue("oni.useDefaultConfig"),
         }
 
-        await this._neovimInstance.start(startOptions)
+        const combinedOptions = {
+            ...defaultOptions,
+            ...startOptions,
+        }
+
+        await this._neovimInstance.start(combinedOptions)
 
         if (this._errorInitializing) {
             return

--- a/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
+++ b/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
@@ -128,7 +128,9 @@ export class TutorialBufferLayer implements Oni.BufferLayer {
             alert("quit!")
         })
 
-        this._initPromise = this._editor.init([])
+        this._initPromise = this._editor.init([], {
+            loadInitVim: false,
+        })
 
         this._tutorialGameplayManager = new TutorialGameplayManager(this._editor)
 


### PR DESCRIPTION
This change allows for overriding the configuration options for the tutorial experience, so that the default settings are loaded. This helps to ensure a consistent experience and that the instructions are correct.

Work towards fixing #1924 