### PR TITLE
Configuration: Fix bug with setting a default value

### DIFF
--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -152,7 +152,9 @@ export class Configuration implements Oni.Configuration {
     ): IConfigurationSetting<T> {
         this._settingMetadata[name] = options
 
-        if (options.defaultValue) {
+        const currentValue = this.getValue(name, null)
+
+        if (options.defaultValue && currentValue !== null)) {
             this.setValue(name, options.defaultValue)
         }
 

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -154,7 +154,7 @@ export class Configuration implements Oni.Configuration {
 
         const currentValue = this.getValue(name, null)
 
-        if (options.defaultValue && currentValue !== null) {
+        if (options.defaultValue && currentValue === null) {
             this.setValue(name, options.defaultValue)
         }
 

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -154,7 +154,7 @@ export class Configuration implements Oni.Configuration {
 
         const currentValue = this.getValue(name, null)
 
-        if (options.defaultValue && currentValue !== null)) {
+        if (options.defaultValue && currentValue !== null) {
             this.setValue(name, options.defaultValue)
         }
 

--- a/browser/test/Services/Configuration/ConfigurationTests.ts
+++ b/browser/test/Services/Configuration/ConfigurationTests.ts
@@ -134,7 +134,7 @@ describe("Configuration", () => {
         })
     })
 
-    describe("registerConfigurationSetting", () => {
+    describe("registerSetting", () => {
         it("sets default value", () => {
             const configuration = new Configuration()
             configuration.registerSetting("test.setting", {
@@ -143,6 +143,23 @@ describe("Configuration", () => {
 
             const val = configuration.getValue("test.setting")
             assert.strictEqual(val, 1, "Validate default value gets set")
+        })
+
+        it("default value doesn't override set value", () => {
+            const configuration = new Configuration()
+
+            configuration.setValue("test.setting", 1)
+
+            configuration.registerSetting("test.setting", {
+                defaultValue: 2,
+            })
+
+            const val = configuration.getValue("test.setting")
+            assert.strictEqual(
+                val,
+                1,
+                "Validate value is 1, because it shouldn't be overwritten by the default",
+            )
         })
 
         it("notifies when value is changed", () => {


### PR DESCRIPTION
__Issue:__ The new `registerSetting` API has a bug where the default value overrides an existing value set.

__Fix:__ Only set the default value if no value has been set yet.