### PR TITLE
Refactor FileIcon to styled-components

### DIFF
--- a/browser/src/Services/FileIcon.tsx
+++ b/browser/src/Services/FileIcon.tsx
@@ -7,32 +7,58 @@
 
 import * as React from "react"
 
+import { css, keyframes, styled, withProps } from "../UI/components/common"
 import { getInstance } from "./IconThemes"
 
-export interface IFileIconProps {
+const appearAnimationKeyframes = keyframes`
+    0% {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+`
+
+const appearAnimation = css`
+    animation-name: ${appearAnimationKeyframes};
+    animation-duration: 0.25s;
+    animation-timing-function: ease-in;
+    animation-fill-mode: forwards;
+    opacity: 1;
+`
+
+const Icon = withProps<{ playAppearAnimation: boolean }>(styled.i)`
+    ${props => (props.playAppearAnimation ? appearAnimation : "")}
+`
+
+interface IFileIconProps {
     fileName: string
     language?: string
 
     isLarge?: boolean
 
-    additionalClassNames?: string
+    playAppearAnimation?: boolean
 }
 
-export class FileIcon extends React.PureComponent<IFileIconProps, {}> {
-    public render(): JSX.Element {
-        if (!this.props.fileName) {
-            return null
-        }
-
-        const icons = getInstance()
-
-        const className =
-            icons.getIconClassForFile(this.props.fileName, this.props.language) +
-            (this.props.isLarge ? " fa-lg" : "")
-        const additionalClasses = this.props.additionalClassNames || ""
-
-        return <i className={className + " " + additionalClasses} aria-hidden={true} />
+export const FileIcon = (props: IFileIconProps) => {
+    if (!props.fileName) {
+        return null
     }
+
+    const icons = getInstance()
+
+    const className =
+        icons.getIconClassForFile(props.fileName, props.language) + (props.isLarge ? " fa-lg" : "")
+
+    return (
+        <Icon
+            playAppearAnimation={props.playAppearAnimation}
+            className={className}
+            aria-hidden={true}
+        />
+    )
 }
 
 export const getFileIcon = (fileName: string) => <FileIcon fileName={fileName} isLarge={true} />

--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -12,28 +12,9 @@
     }
 }
 
-@keyframes file-icon-appear {
-    0% {
-        opacity: 0;
-        transform: scale(0.8);
-    }
-    100% {
-        opacity: 1;
-        transform: scale(1);
-    }
-}
-
 .tab-icon-appear-animation {
     animation-name: tab-icon-appear;
     animation-duration: 0.6s;
-    animation-function: ease-in;
-    animation-fill-mode: forwards;
-    opacity: 1;
-}
-
-.file-icon-appear-animation {
-    animation-name: file-icon-appear;
-    animation-duration: 0.25s;
     animation-function: ease-in;
     animation-fill-mode: forwards;
     opacity: 1;

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -176,7 +176,7 @@ export class Tab extends React.Component<ITabPropsWithClick> {
                         <FileIcon
                             fileName={this.props.iconFileName}
                             isLarge={true}
-                            additionalClassNames={"file-icon-appear-animation"}
+                            playAppearAnimation={true}
                         />
                     </div>
                     <div className="name" onClick={this.props.onClickName}>


### PR DESCRIPTION
This is one of several smaller upcoming PRs with the goal to replace all remaining `.less` files with `styled-components`.

- Move the animation code from `Tabs.less` into `FileIcon.tsx`
- Replace `additionalClassNames` prop with the (also more restrictive, but better encapsulated) `playAppearAnimation`