### PR TITLE
Fix #1924 - Part 4 - Fix issue where swapping tutorials does not work

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -136,6 +136,12 @@ export class Buffer implements IBuffer {
         this._actions.addBufferLayer(parseInt(this._id, 10), layer)
     }
 
+    public getLayerById<T>(id: string): T {
+        return (this._store
+            .getState()
+            .layers[parseInt(this._id, 10)].find(layer => layer.id === id) as any) as T
+    }
+
     public removeLayer(layer: IBufferLayer): void {
         this._actions.removeBufferLayer(parseInt(this._id, 10), layer)
     }

--- a/browser/src/Services/Learning/Tutorial/CompletionView.tsx
+++ b/browser/src/Services/Learning/Tutorial/CompletionView.tsx
@@ -122,7 +122,9 @@ export const CompletionView = (props: ICompletionViewProps): JSX.Element => {
                 </ResultsWrapper>
                 <Fixed>
                     <FooterWrapper>
-                        <AppearWithDelay delay={1.5}>Press ENTER to continue...</AppearWithDelay>
+                        <AppearWithDelay delay={1.5}>
+                            Press ENTER to continue or SPACE to restart
+                        </AppearWithDelay>
                     </FooterWrapper>
                 </Fixed>
             </Container>

--- a/browser/src/Services/Learning/Tutorial/CompletionView.tsx
+++ b/browser/src/Services/Learning/Tutorial/CompletionView.tsx
@@ -122,7 +122,7 @@ export const CompletionView = (props: ICompletionViewProps): JSX.Element => {
                 </ResultsWrapper>
                 <Fixed>
                     <FooterWrapper>
-                        <AppearWithDelay delay={1.5}>Press any key to continue...</AppearWithDelay>
+                        <AppearWithDelay delay={1.5}>Press ENTER to continue...</AppearWithDelay>
                     </FooterWrapper>
                 </Fixed>
             </Container>

--- a/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
+++ b/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
@@ -98,7 +98,7 @@ export class TutorialBufferLayer implements Oni.BufferLayer {
     >()
 
     public get id(): string {
-        return "oni.tutorial"
+        return "oni.layer.tutorial"
     }
 
     public get friendlyName(): string {
@@ -193,8 +193,11 @@ export class TutorialBufferLayer implements Oni.BufferLayer {
         if (this._completionInfo.completed) {
             const nextTutorial = this._tutorialManager.getNextTutorialId(this._currentTutorialId)
 
-            if (nextTutorial) {
+            if (nextTutorial && key === "<enter>") {
                 this.startTutorial(nextTutorial)
+            } else {
+                // No tutorial left - we'll pass through
+                return false
             }
         } else {
             this._editor.input(key)

--- a/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
+++ b/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
@@ -193,7 +193,9 @@ export class TutorialBufferLayer implements Oni.BufferLayer {
         if (this._completionInfo.completed) {
             const nextTutorial = this._tutorialManager.getNextTutorialId(this._currentTutorialId)
 
-            if (nextTutorial && key === "<enter>") {
+            if (key === "<space>") {
+                this.startTutorial(this._currentTutorialId)
+            } else if (nextTutorial && key === "<enter>") {
                 this.startTutorial(nextTutorial)
             } else {
                 // No tutorial left - we'll pass through

--- a/browser/src/Services/Learning/Tutorial/TutorialManager.ts
+++ b/browser/src/Services/Learning/Tutorial/TutorialManager.ts
@@ -2,6 +2,7 @@
  * TutorialManager
  */
 
+import * as Oni from "oni-api"
 import { Event, IEvent } from "oni-types"
 
 import { EditorManager } from "./../../EditorManager"
@@ -128,12 +129,16 @@ export class TutorialManager {
     }
 
     public async startTutorial(id: string): Promise<void> {
-        // const tutorial = this._getTutorialById(id)
-        const buf = await this._editorManager.activeEditor.openFile("oni://tutorial")
-        const layer = new TutorialBufferLayer(this)
-        layer.startTutorial(id)
-        buf.addLayer(layer)
+        const buf = await this._editorManager.activeEditor.openFile("oni://Tutorial", {
+            openMode: Oni.FileOpenMode.Edit,
+        })
+        let tutorialLayer = (buf as any).getLayerById("oni.layer.tutorial") as TutorialBufferLayer
+        if (!tutorialLayer) {
+            tutorialLayer = new TutorialBufferLayer(this)
+            buf.addLayer(tutorialLayer)
+        }
 
+        tutorialLayer.startTutorial(id)
         // Focus the editor
         const splitHandle = this._windowManager.getSplitHandle(this._editorManager
             .activeEditor as any)


### PR DESCRIPTION
This is the last issue in #1924 - being able to swap tutorials while a tutorial is in-progress.

If there is a tutorial active, we'll grab that buffer & layer, and re-use that instance to call `startTutorial`.