### PR TITLE
Extend OniCommand

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -406,9 +406,9 @@ export class NeovimEditor extends Editor implements IEditor {
         )
 
         this.trackDisposable(
-            this._neovimInstance.onOniCommand.subscribe(command => {
-                const commandToExecute = command[0]
-                const commandArgs = command.length > 0 ? command.slice(1) : []
+            this._neovimInstance.onOniCommand.subscribe(context => {
+                const commandToExecute = context.command
+                const commandArgs = context.args
 
                 commandManager.executeCommand(commandToExecute, commandArgs)
             }),

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -407,7 +407,10 @@ export class NeovimEditor extends Editor implements IEditor {
 
         this.trackDisposable(
             this._neovimInstance.onOniCommand.subscribe(command => {
-                commandManager.executeCommand(command)
+                const commandToExecute = command[0]
+                const commandArgs = command.length > 0 ? command.slice(1) : []
+
+                commandManager.executeCommand(commandToExecute, commandArgs)
             }),
         )
 

--- a/browser/src/neovim/CommandContext.ts
+++ b/browser/src/neovim/CommandContext.ts
@@ -1,0 +1,11 @@
+/**
+ * CommandContext
+ *
+ * This is a definition of the object that Neovim passes up
+ * as part of running commands.
+ */
+
+export interface CommandContext {
+    command: string
+    args: string[]
+}

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -131,7 +131,7 @@ export interface INeovimInstance {
     onTitleChanged: IEvent<string>
 
     // When an OniCommand is requested, ie :OniCommand("quickOpen.show")
-    onOniCommand: IEvent<string>
+    onOniCommand: IEvent<string[]>
 
     onHidePopupMenu: IEvent<void>
     onShowPopupMenu: IEvent<INeovimCompletionInfo>
@@ -223,7 +223,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _onDirectoryChanged = new Event<string>()
     private _onErrorEvent = new Event<Error | string>()
     private _onYank = new Event<INeovimYankInfo>()
-    private _onOniCommand = new Event<string>()
+    private _onOniCommand = new Event<string[]>()
     private _onRedrawComplete = new Event<void>()
     private _onScroll = new Event<EventContext>()
     private _onTitleChanged = new Event<string>()
@@ -286,7 +286,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         return this._onModeChanged
     }
 
-    public get onOniCommand(): IEvent<string> {
+    public get onOniCommand(): IEvent<string[]> {
         return this._onOniCommand
     }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -7,8 +7,8 @@ import { Event, IDisposable, IEvent } from "oni-types"
 
 import * as Log from "./../Log"
 import * as Performance from "./../Performance"
-import { EventContext } from "./EventContext"
 import { CommandContext } from "./CommandContext"
+import { EventContext } from "./EventContext"
 
 import { addDefaultUnitIfNeeded, measureFont } from "./../Font"
 import * as Platform from "./../Platform"

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -8,6 +8,7 @@ import { Event, IDisposable, IEvent } from "oni-types"
 import * as Log from "./../Log"
 import * as Performance from "./../Performance"
 import { EventContext } from "./EventContext"
+import { CommandContext } from "./CommandContext"
 
 import { addDefaultUnitIfNeeded, measureFont } from "./../Font"
 import * as Platform from "./../Platform"
@@ -131,7 +132,7 @@ export interface INeovimInstance {
     onTitleChanged: IEvent<string>
 
     // When an OniCommand is requested, ie :OniCommand("quickOpen.show")
-    onOniCommand: IEvent<string[]>
+    onOniCommand: IEvent<CommandContext>
 
     onHidePopupMenu: IEvent<void>
     onShowPopupMenu: IEvent<INeovimCompletionInfo>
@@ -223,7 +224,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _onDirectoryChanged = new Event<string>()
     private _onErrorEvent = new Event<Error | string>()
     private _onYank = new Event<INeovimYankInfo>()
-    private _onOniCommand = new Event<string[]>()
+    private _onOniCommand = new Event<CommandContext>()
     private _onRedrawComplete = new Event<void>()
     private _onScroll = new Event<EventContext>()
     private _onTitleChanged = new Event<string>()
@@ -286,7 +287,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         return this._onModeChanged
     }
 
-    public get onOniCommand(): IEvent<string[]> {
+    public get onOniCommand(): IEvent<CommandContext> {
         return this._onOniCommand
     }
 

--- a/browser/src/neovim/NeovimMarks.ts
+++ b/browser/src/neovim/NeovimMarks.ts
@@ -115,8 +115,8 @@ export class NeovimMarks {
         this._isWatching = true
         this._neovimInstance.callFunction("OniListenForMarks", [])
 
-        this._neovimInstance.onOniCommand.subscribe(val => {
-            if (val[0] === "_internal.notifyMarksChanged") {
+        this._neovimInstance.onOniCommand.subscribe(context => {
+            if (context.command === "_internal.notifyMarksChanged") {
                 this._updateMarks()
             }
         })

--- a/browser/src/neovim/NeovimMarks.ts
+++ b/browser/src/neovim/NeovimMarks.ts
@@ -116,7 +116,7 @@ export class NeovimMarks {
         this._neovimInstance.callFunction("OniListenForMarks", [])
 
         this._neovimInstance.onOniCommand.subscribe(val => {
-            if (val === "_internal.notifyMarksChanged") {
+            if (val[0] === "_internal.notifyMarksChanged") {
                 this._updateMarks()
             }
         })

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -146,8 +146,11 @@ class SharedNeovimInstance implements SharedNeovimInstance {
     constructor(private _configuration: Configuration, private _pluginManager: PluginManager) {
         this._neovimInstance = new NeovimInstance(5, 5, this._configuration)
 
-        this._neovimInstance.onOniCommand.subscribe((command: string) => {
-            commandManager.executeCommand(command)
+        this._neovimInstance.onOniCommand.subscribe((command: string[]) => {
+            const commandToExecute = command[0]
+            const commandArgs = command.length > 0 ? command.slice(1) : []
+
+            commandManager.executeCommand(commandToExecute, commandArgs)
         })
 
         App.registerQuitHook(async () => {

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -12,6 +12,7 @@ import { Event, IDisposable, IEvent } from "oni-types"
 
 import { NeovimInstance } from "./NeovimInstance"
 import { INeovimStartOptions } from "./NeovimProcessSpawner"
+import { CommandContext } from "./CommandContext"
 
 import { PluginManager } from "./../Plugins/PluginManager"
 import { commandManager } from "./../Services/CommandManager"
@@ -146,9 +147,9 @@ class SharedNeovimInstance implements SharedNeovimInstance {
     constructor(private _configuration: Configuration, private _pluginManager: PluginManager) {
         this._neovimInstance = new NeovimInstance(5, 5, this._configuration)
 
-        this._neovimInstance.onOniCommand.subscribe((command: string[]) => {
-            const commandToExecute = command[0]
-            const commandArgs = command.length > 0 ? command.slice(1) : []
+        this._neovimInstance.onOniCommand.subscribe((context: CommandContext) => {
+            const commandToExecute = context.command
+            const commandArgs = context.args
 
             commandManager.executeCommand(commandToExecute, commandArgs)
         })

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -10,9 +10,9 @@
 
 import { Event, IDisposable, IEvent } from "oni-types"
 
+import { CommandContext } from "./CommandContext"
 import { NeovimInstance } from "./NeovimInstance"
 import { INeovimStartOptions } from "./NeovimProcessSpawner"
-import { CommandContext } from "./CommandContext"
 
 import { PluginManager } from "./../Plugins/PluginManager"
 import { commandManager } from "./../Services/CommandManager"

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -32,6 +32,7 @@ const CiTests = [
     "QuickOpenTest",
     "StatusBar-Mode",
     "Neovim.InvalidInitVimHandlingTest",
+    "Neovim.CallOniCommands",
     "NoInstalledNeovim",
     "Sidebar.ToggleSplitTest",
 

--- a/test/ci/Neovim.CallOniCommands.ts
+++ b/test/ci/Neovim.CallOniCommands.ts
@@ -14,30 +14,37 @@ export const test = async (oni: Oni.Plugin.Api) => {
     oni.automation.sendKeys(":")
     await oni.automation.waitFor(() => !!getElementByClassName("command-line"))
     oni.automation.sendKeys('call OniCommand("quickOpen.show")')
+    oni.automation.sendKeys("<enter>")
 
     await oni.automation.waitFor(() => oni.menu.isMenuOpen())
     assert(oni.menu.isMenuOpen(), "Check menu opened correctly.")
 
+    oni.commands.executeCommand("menu.close")
+
     // Now test passing optional arguments
     // Create a test command to call, but could be swapped to use the browser
     // when more easily accessible.
-
     oni.commands.registerCommand({
         command: "ciTest.test",
         name: "Test passing over args.",
         detail: "Opens a file.",
-        execute: (file?: string) => oni.editors.activeEditor.openFile(file),
+        execute: (file?: string) => oni.editors.activeEditor.neovim.command(`:e ${file}`),
     })
-
     await oni.automation.sleep(500)
+
     oni.automation.sendKeys(":")
     await oni.automation.waitFor(() => !!getElementByClassName("command-line"))
     oni.automation.sendKeys('call OniCommand("ciTest.test", "testFile.tsx")')
+    oni.automation.sendKeys("<enter>")
 
     await oni.automation.waitFor(() =>
         oni.editors.activeEditor.activeBuffer.filePath.endsWith("testFile.tsx"),
     )
-    assert(oni.menu.isMenuOpen(), "Check file opened correctly after being passed over.")
 
-    await oni.automation.sleep(500)
+    const currentBuffer = oni.editors.activeEditor.activeBuffer.filePath
+
+    assert(
+        currentBuffer.endsWith("testFile.tsx"),
+        "Check file opened correctly after being passed over.",
+    )
 }

--- a/test/ci/Neovim.CallOniCommands.ts
+++ b/test/ci/Neovim.CallOniCommands.ts
@@ -47,4 +47,31 @@ export const test = async (oni: Oni.Plugin.Api) => {
         currentBuffer.endsWith("testFile.tsx"),
         "Check file opened correctly after being passed over.",
     )
+
+    // Finally test passing multiple optional arguments
+    oni.commands.registerCommand({
+        command: "ciTest.test2",
+        name: "Test passing over args.",
+        detail: "Opens multiple files.",
+        execute: (files?: string[]) => {
+            files.forEach(file => oni.editors.activeEditor.neovim.command(`:e ${file}`))
+        },
+    })
+    await oni.automation.sleep(500)
+
+    oni.automation.sendKeys(":")
+    await oni.automation.waitFor(() => !!getElementByClassName("command-line"))
+    oni.automation.sendKeys(
+        'call OniCommand("ciTest.test2", "testFile2.tsx", "testFile3.tsx", "testFile4.tsx")',
+    )
+    oni.automation.sendKeys("<enter>")
+
+    await oni.automation.waitFor(() => oni.editors.activeEditor.activeBuffer.id === "4")
+
+    const currentBufferId = oni.editors.activeEditor.activeBuffer.id
+
+    assert(
+        currentBufferId === "4",
+        "Check multiple files opened correctly after being passed over.",
+    )
 }

--- a/test/ci/Neovim.CallOniCommands.ts
+++ b/test/ci/Neovim.CallOniCommands.ts
@@ -1,0 +1,43 @@
+/**
+ * Test script to validate calling Oni commands from Neovim
+ */
+
+import * as assert from "assert"
+import * as Oni from "oni-api"
+
+import { getElementByClassName } from "./Common"
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    // Open the commandline and open the QuickOpen Menu.
+    oni.automation.sendKeys(":")
+    await oni.automation.waitFor(() => !!getElementByClassName("command-line"))
+    oni.automation.sendKeys('call OniCommand("quickOpen.show")')
+
+    await oni.automation.waitFor(() => oni.menu.isMenuOpen())
+    assert(oni.menu.isMenuOpen(), "Check menu opened correctly.")
+
+    // Now test passing optional arguments
+    // Create a test command to call, but could be swapped to use the browser
+    // when more easily accessible.
+
+    oni.commands.registerCommand({
+        command: "ciTest.test",
+        name: "Test passing over args.",
+        detail: "Opens a file.",
+        execute: (file?: string) => oni.editors.activeEditor.openFile(file),
+    })
+
+    await oni.automation.sleep(500)
+    oni.automation.sendKeys(":")
+    await oni.automation.waitFor(() => !!getElementByClassName("command-line"))
+    oni.automation.sendKeys('call OniCommand("ciTest.test", "testFile.tsx")')
+
+    await oni.automation.waitFor(() =>
+        oni.editors.activeEditor.activeBuffer.filePath.endsWith("testFile.tsx"),
+    )
+    assert(oni.menu.isMenuOpen(), "Check file opened correctly after being passed over.")
+
+    await oni.automation.sleep(500)
+}

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -107,7 +107,10 @@ endif
 endfunction
 
 function OniCommand(oniCommand, ...)
-    let l:function_command_and_args = [a:oniCommand, a:000]
+    let l:function_command_and_args = {}
+    let l:function_command_and_args.command = a:oniCommand
+    let l:function_command_and_args.args = a:000
+
     call OniNotify(["oni_command", l:function_command_and_args])
 endfunction
 

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -106,8 +106,9 @@ function OniGetEachContext(bufnum)
 endif
 endfunction
 
-function OniCommand(oniCommand)
-    call OniNotify(["oni_command", a:oniCommand])
+function OniCommand(oniCommand, ...)
+    let l:function_command_and_args = [a:oniCommand, a:000]
+    call OniNotify(["oni_command", l:function_command_and_args])
 endfunction
 
 augroup OniClipboard


### PR DESCRIPTION
Fix #1961.

Update `OniCommand` to take any number of arguments.
Currently, restricted to strings... not sure if that is an issue.

Added a quick CI test too.