### PR TITLE
Bugfix: Achievements - Achievements layer not updated as achievements are accomplished

### DIFF
--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -14,8 +14,8 @@ import { Bold, boxShadow, Fixed, Full, withProps } from "./../../../UI/component
 import { FlipCard } from "./../../../UI/components/FlipCard"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
-import { IDisposable } from "oni-types"
 import * as Oni from "oni-api"
+import { IDisposable } from "oni-types"
 
 import { AchievementsManager, AchievementWithProgressInfo } from "./AchievementsManager"
 

--- a/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
+++ b/browser/src/Services/Learning/Achievements/AchievementsBufferLayer.tsx
@@ -14,6 +14,7 @@ import { Bold, boxShadow, Fixed, Full, withProps } from "./../../../UI/component
 import { FlipCard } from "./../../../UI/components/FlipCard"
 import { Icon, IconSize } from "./../../../UI/Icon"
 
+import { IDisposable } from "oni-types"
 import * as Oni from "oni-api"
 
 import { AchievementsManager, AchievementWithProgressInfo } from "./AchievementsManager"
@@ -31,6 +32,8 @@ export const TrophyCaseViewWrapper = withProps<{}>(styled.div)`
     color: ${p => p.theme.foreground};
     width: 100%;
     height: 100%;
+    overflow-y: auto;
+    pointer-events: all;
 
     display: flex;
     flex-direction: column;
@@ -157,12 +160,30 @@ export class TrophyCaseView extends React.PureComponent<
     ITrophyCaseViewProps,
     ITrophyCaseViewState
 > {
+    private _disposables: IDisposable[] = []
+
     constructor(props: ITrophyCaseViewProps) {
         super(props)
 
         this.state = {
             progressInfo: props.achievements.getAchievements(),
         }
+    }
+
+    public componentDidMount(): void {
+        this._cleanSubscriptions()
+
+        const s1 = this.props.achievements.onAchievementAccomplished.subscribe(() => {
+            this.setState({
+                progressInfo: this.props.achievements.getAchievements(),
+            })
+        })
+
+        this._disposables = [s1]
+    }
+
+    public componentWillUnmount(): void {
+        this._cleanSubscriptions()
     }
 
     public render(): JSX.Element {
@@ -199,6 +220,11 @@ export class TrophyCaseView extends React.PureComponent<
                 <Full>{items}</Full>
             </TrophyCaseViewWrapper>
         )
+    }
+
+    private _cleanSubscriptions(): void {
+        this._disposables.forEach(d => d.dispose())
+        this._disposables = []
     }
 }
 


### PR DESCRIPTION
__Issue:__ If you have the achievements layer open, and you complete an achievement, the layer doesn't update to reflect it.

__Defect:__ We weren't listening to the achievement event in the react component.

__Fix:__ Subscribe to the event and revise the state when an achievement is accomplished.