### PR TITLE
Refactor HighlightText.tsx to styled-components

### DIFF
--- a/browser/src/Services/ContextMenu/ContextMenu.less
+++ b/browser/src/Services/ContextMenu/ContextMenu.less
@@ -46,11 +46,6 @@
             flex: 1 0 auto;
             min-width: 100px;
             margin-left: 8px;
-
-            .highlight {
-                // font-weight: bold;
-                text-decoration: underline;
-            }
         }
 
         .detail {

--- a/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
@@ -13,6 +13,7 @@ import * as Oni from "oni-api"
 
 import { IMenus } from "./../Menu/MenuState"
 
+import { styled } from "../../UI/components/common"
 import { Arrow, ArrowDirection } from "./../../UI/components/Arrow"
 import { HighlightText } from "./../../UI/components/HighlightText"
 import { QuickInfoDocumentation } from "./../../UI/components/QuickInfo"
@@ -117,7 +118,7 @@ export class ContextMenuItem extends React.PureComponent<IContextMenuItemProps, 
                     <Arrow direction={ArrowDirection.Right} size={5} color={arrowColor} />
                     <HighlightText
                         className="label"
-                        highlightClassName="highlight"
+                        highlightComponent={Highlight}
                         highlightText={this.props.base}
                         text={this.props.label}
                     />
@@ -127,6 +128,10 @@ export class ContextMenuItem extends React.PureComponent<IContextMenuItemProps, 
         )
     }
 }
+
+const Highlight = styled.span`
+    text-decoration: underline;
+`
 
 export interface IContextMenuDocumentationProps {
     documentation: string

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -2,12 +2,11 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 import { connect, Provider } from "react-redux"
 
-import styled from "styled-components"
-
 import { AutoSizer, List } from "react-virtualized"
 
 import * as Oni from "oni-api"
 
+import { styled } from "../../UI/components/common"
 import { HighlightTextByIndex } from "./../../UI/components/HighlightText"
 // import { Visible } from "./../../UI/components/Visible"
 import { Icon, IconSize } from "./../../UI/Icon"
@@ -225,16 +224,6 @@ const MenuItemWrapper = withProps<IMenuItemWrapperProps>(styled.div)`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    & .label .highlight {
-        font-weight: bold;
-        color: ${props => props.theme["highlight.mode.normal.background"]};
-    }
-
-    & .detail .highlight {
-        font-weight: bold;
-        color: #757575;
-    }
 `
 
 export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
@@ -266,16 +255,26 @@ export class MenuItem extends React.PureComponent<IMenuItemProps, {}> {
                     className="label"
                     text={this.props.label}
                     highlightIndices={this.props.labelHighlights}
-                    highlightClassName={"highlight"}
+                    highlightComponent={LabelHighlight}
                 />
                 <HighlightTextByIndex
                     className="detail"
                     text={this.props.detail}
                     highlightIndices={this.props.detailHighlights}
-                    highlightClassName={"highlight"}
+                    highlightComponent={DetailHighlight}
                 />
                 {this.props.additionalComponent}
             </MenuItemWrapper>
         )
     }
 }
+
+const LabelHighlight = styled.span`
+    font-weight: bold;
+    color: ${props => props.theme["highlight.mode.normal.background"]};
+`
+
+const DetailHighlight = styled.span`
+    font-weight: bold;
+    color: #757575;
+`

--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -1,71 +1,61 @@
 import * as React from "react"
 
-export interface IHighlightTextProps {
-    highlightClassName: string
+interface IHighlightTextProps {
+    highlightComponent: React.ReactType
     highlightText: string
     text: string
-    className: string
+    className?: string
 }
 
-export class HighlightText extends React.PureComponent<IHighlightTextProps, {}> {
-    public render(): JSX.Element {
-        const childNodes: JSX.Element[] = []
+export const HighlightText = ({
+    highlightComponent: HighlightComponent,
+    highlightText,
+    text = "",
+    className,
+}: IHighlightTextProps) => {
+    const letterCountDictionary = createLetterCountDictionary(highlightText)
 
-        const letterCountDictionary = createLetterCountDictionary(this.props.highlightText)
+    const textCharacters = typeof text === "string" ? [...text] : []
+    const childNodes = textCharacters.map((character, index) => {
+        const remainingLetterCountBefore = letterCountDictionary[character]
+        letterCountDictionary[character] = remainingLetterCountBefore - 1
 
-        this.props.text.split("").forEach((c: string, idx: number) => {
-            const currentVal = letterCountDictionary[c]
-            letterCountDictionary[c] = currentVal - 1
+        return remainingLetterCountBefore > 0 ? (
+            <HighlightComponent key={`${index}-${character}`}>{character}</HighlightComponent>
+        ) : (
+            <span key={`${index}-${character}`}>{character}</span>
+        )
+    })
 
-            if (currentVal > 0) {
-                childNodes.push(
-                    <span key={`${idx}-${c}`} className={this.props.highlightClassName}>
-                        {c}
-                    </span>,
-                )
-            } else {
-                childNodes.push(<span key={`${idx}-${c}`}>{c}</span>)
-            }
-        })
-
-        return <span className={this.props.className}>{childNodes}</span>
-    }
+    return <span className={className}>{childNodes}</span>
 }
 
-export interface IHighlightTextByIndexProps {
-    highlightClassName: string
+interface IHighlightTextByIndexProps {
+    highlightComponent: React.ReactType
     highlightIndices: number[]
     text: string
-    className: string
+    className?: string
 }
 
-export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIndexProps, {}> {
-    public render(): JSX.Element {
-        const childNodes: JSX.Element[] = []
-        const highlightIndices = this.props.highlightIndices || []
-        let text = this.props.text || ""
+export const HighlightTextByIndex = ({
+    highlightComponent: HighlightComponent,
+    highlightIndices = [],
+    text = "",
+    className,
+}: IHighlightTextByIndexProps) => {
+    const textCharacters = typeof text === "string" ? [...text] : []
+    const childNodes = textCharacters.map(
+        (character, index) =>
+            shouldHighlightIndex(index, highlightIndices) ? (
+                <HighlightComponent key={`${index}-${highlightIndices}-${character}`}>
+                    {character}
+                </HighlightComponent>
+            ) : (
+                <span key={`${index}-${highlightIndices}-${character}`}>{character}</span>
+            ),
+    )
 
-        if (typeof text !== "string") {
-            text = ""
-        }
-
-        text.split("").forEach((c: string, idx: number) => {
-            if (shouldHighlightIndex(idx, highlightIndices)) {
-                childNodes.push(
-                    <span
-                        key={`${idx}-${highlightIndices}-${c}`}
-                        className={this.props.highlightClassName}
-                    >
-                        {c}
-                    </span>,
-                )
-            } else {
-                childNodes.push(<span key={`${idx}-${highlightIndices}-${c}`}>{c}</span>)
-            }
-        })
-
-        return <span className={this.props.className}>{childNodes}</span>
-    }
+    return <span className={className}>{childNodes}</span>
 }
 
 function shouldHighlightIndex(index: number, highlights: number[]): boolean {
@@ -76,11 +66,14 @@ export interface LetterCountDictionary {
     [letter: string]: number
 }
 
-export function createLetterCountDictionary(text: string): LetterCountDictionary {
-    const array: string[] = text.split("")
-    return array.reduce((previousValue: any, currentValue: string) => {
-        const cur = previousValue[currentValue] || 0
-        previousValue[currentValue] = cur + 1
-        return previousValue
-    }, {})
+export function createLetterCountDictionary(text: string) {
+    const textCharacters = [...text]
+    return textCharacters.reduce(
+        (dictionary, character) => {
+            const currentLetterCount = dictionary[character] || 0
+            dictionary[character] = currentLetterCount + 1
+            return dictionary
+        },
+        {} as LetterCountDictionary,
+    )
 }

--- a/ui-tests/HighlightText.test.tsx
+++ b/ui-tests/HighlightText.test.tsx
@@ -6,15 +6,10 @@ import * as os from "os"
 
 import { HighlightTextByIndex } from "./../browser/src/UI/components/HighlightText"
 
-interface IHighlightTextByIndexProps {
-    highlightClassName: string
-    highlightIndices: number[]
-    text: string
-    className: string
-}
+const highlightComponent = "em"
 
 const initialState = {
-    highlightClassName: "highlight-test",
+    highlightComponent,
     highlightIndices: [0, 1, 3, 4],
     text: "highlight text",
     className: "test-class",
@@ -37,12 +32,12 @@ describe("<HighlightTextByIndex />", () => {
         expect(component.text()).toHaveLength(14)
 
         // Check only 4 chars were highlighed
-        expect(component.find(".highlight-test")).toHaveLength(4)
+        expect(component.find("em")).toHaveLength(4)
     })
 
     it("renders the correct text with no highlights", () => {
         const testState = {
-            highlightClassName: "highlight-test",
+            highlightComponent,
             highlightIndices: [],
             text: "no highlight text",
             className: "test-class",
@@ -57,12 +52,12 @@ describe("<HighlightTextByIndex />", () => {
         expect(component.text()).toHaveLength(17)
 
         // Check no chars were highlighed
-        expect(component.find(".highlight-test")).toHaveLength(0)
+        expect(component.find("em")).toHaveLength(0)
     })
 
     it("doesn't crash when passed a non-string", () => {
         const testState = {
-            highlightClassName: "highlight-test",
+            highlightComponent,
             highlightIndices: [0, 1, 3, 4],
             text: 10101,
             className: "test-class",


### PR DESCRIPTION
This time it's `HighlightText.tsx` that is being refactored to `styled-components`. More indirectly than directly, as its interface now takes a `highlightComponent` instead of a `highlightClassName`.

It also still takes a regular `className` prop so that the component itself can be `styled` in the future as well as for keeping it compatible with its usage within the `Menu` and the `ContextMenu`.