### PR TITLE
Add accelerator to Exit menu entry

### DIFF
--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -250,6 +250,7 @@ export const buildMenu = (mainWindow, loadInit) => {
             },
             {
                 label: "Exit",
+                accelerator: "CmdOrCtrl+Q",
                 click(item, focusedWindow) {
                     app.quit()
                 },


### PR DESCRIPTION
Currently you can quit Oni with Command+Q, but only if a window is
currently open. If you close all windows, e.g. by `:q`ing all tabs, the
app is left running but Command+Q will no longer quit the app, and you
have to press the Oni->Exit menu item.

Adding this accelerator here allows the app to be closed via the the
standard shortcut regardless of whether there are currently any windows
open.