### PR TITLE
Tutorials: Fit-and-finish fixes

### DIFF
--- a/browser/src/Services/Learning/Tutorial/Stages/FadeInLineStage.tsx
+++ b/browser/src/Services/Learning/Tutorial/Stages/FadeInLineStage.tsx
@@ -19,7 +19,7 @@ import { withProps } from "./../../../../UI/components/common"
 
 const FuzzyFadeInKeyframes = keyframes`
     0% { opacity: 0; -webkit-filter: blur(10px); }
-    100% { opacity: 1; -webkit-filter: blur(0px); }
+    100% { opacity: 1; }
 `
 const Wrapper = withProps<{}>(styled.div)`
     background-color: ${props => props.theme["editor.background"]};
@@ -28,7 +28,7 @@ const Wrapper = withProps<{}>(styled.div)`
 `
 
 const FadeInWrapper = styled.div`
-    animation: ${FuzzyFadeInKeyframes} 0.5s linear forwards;
+    animation: ${FuzzyFadeInKeyframes} 0.4s linear forwards;
 
     opacity: 0;
 `

--- a/browser/src/Services/Learning/Tutorial/Stages/MoveToGoalStage.tsx
+++ b/browser/src/Services/Learning/Tutorial/Stages/MoveToGoalStage.tsx
@@ -86,7 +86,8 @@ export class MoveToGoalStage implements ITutorialStage {
         const cursorPosition = await (context.buffer as any).getCursorPosition()
 
         this._currentCursorLine = cursorPosition.line
-        this._goalColumn = !!this._column ? this._column : cursorPosition.character
+        this._goalColumn =
+            typeof this._column === "number" ? this._column : cursorPosition.character
 
         return (
             cursorPosition.line === this._line &&


### PR DESCRIPTION
- Fix the 'fade in' animation - it was slow because it was animating the `-webkit-filter` property, which isn't very efficient.
- Fix the `MoveToGoal` stage to handle the case when the goal is at column 0 - this wasn't handled correctly before (it would let you move to _any_ column in the line)