### PR TITLE
Feature/ add menu command to open new window

### DIFF
--- a/browser/src/Services/Commands/GlobalCommands.ts
+++ b/browser/src/Services/Commands/GlobalCommands.ts
@@ -56,6 +56,10 @@ export const activate = (
         }),
         new CallbackCommand("oni.about", null, null, () => showAboutMessage()),
 
+        new CallbackCommand("oni.process.openWindow", "New Window", "Open a new window", () =>
+            multiProcess.openNewWindow(),
+        ),
+
         new CallbackCommand(
             "oni.editor.maximize",
             "Maximize Window",

--- a/browser/src/Services/MultiProcess.ts
+++ b/browser/src/Services/MultiProcess.ts
@@ -19,6 +19,10 @@ export class MultiProcess {
     public moveToNextOniInstance(direction: string): void {
         ipcRenderer.send("move-to-next-oni-instance", direction)
     }
+
+    public openNewWindow(): void {
+        ipcRenderer.send("open-oni-window")
+    }
 }
 
 export const activate = (windowManager: WindowManager): void => {

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -90,6 +90,11 @@ ipcMain.on("move-to-next-oni-instance", (event, direction: string) => {
     moveToNextOniInstance(windows, direction)
 })
 
+ipcMain.on("open-oni-window", () => {
+    Log.info("opening window")
+    createWindow([], process.cwd())
+})
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let windows: BrowserWindow[] = []


### PR DESCRIPTION
### Problem
To open a new window (on mac at least) a user must right click the dock Icon and select open a new window.

### Solution
Added a command to the command palette to open a new window by adding a method to the `multiprocess` which sends an event via the renderer to the main process asking for a new window.