### PR TITLE
Bugfix/syntax highlighting failure post setLines

### DIFF
--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
@@ -129,14 +129,15 @@ export const linesReducer: Reducer<SyntaxHighlightLines> = (
             const updatedBufferState: SyntaxHighlightLines = {
                 ...state,
             }
+            // console.log("state: ", state)
 
             for (let i = 0; i < action.lines.length; i++) {
                 const oldLine = updatedBufferState[i]
                 const newLine = action.lines[i]
 
-                if (oldLine && oldLine.line === newLine) {
-                    continue
-                }
+                // if (oldLine && oldLine.line === newLine) {
+                //     continue
+                // }
 
                 updatedBufferState[i] = {
                     tokens: [],

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
@@ -137,7 +137,7 @@ export const linesReducer: Reducer<SyntaxHighlightLines> = (
                 // check if the buffer version has changed and if so
                 // update the line - rather than check if specific line
                 // is changed
-                if (oldLine && oldLine.version === action.version) {
+                if (oldLine && oldLine.version >= action.version) {
                     continue
                 }
 

--- a/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
+++ b/browser/src/Services/SyntaxHighlighting/SyntaxHighlightingReducer.ts
@@ -129,15 +129,17 @@ export const linesReducer: Reducer<SyntaxHighlightLines> = (
             const updatedBufferState: SyntaxHighlightLines = {
                 ...state,
             }
-            // console.log("state: ", state)
 
             for (let i = 0; i < action.lines.length; i++) {
                 const oldLine = updatedBufferState[i]
                 const newLine = action.lines[i]
 
-                // if (oldLine && oldLine.line === newLine) {
-                //     continue
-                // }
+                // check if the buffer version has changed and if so
+                // update the line - rather than check if specific line
+                // is changed
+                if (oldLine && oldLine.version === action.version) {
+                    continue
+                }
 
                 updatedBufferState[i] = {
                     tokens: [],

--- a/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReducerTests.ts
+++ b/browser/test/Services/SyntaxHighlighting/SyntaxHighlightingReducerTests.ts
@@ -34,19 +34,21 @@ describe("SyntaxHighlightingReducer", () => {
                 })
             })
 
-            it("only sets changed lines to dirty", () => {
+            it("sets lines with a different buffer version to dirty", () => {
                 const originalState: SyntaxHighlighting.SyntaxHighlightLines = {
                     "0": {
                         ruleStack: null,
                         tokens: [],
                         line: "line1",
                         dirty: false,
+                        version: 1,
                     },
                     "1": {
                         ruleStack: null,
                         tokens: [],
                         line: "line2",
                         dirty: false,
+                        version: 0,
                     },
                 }
 
@@ -66,6 +68,7 @@ describe("SyntaxHighlightingReducer", () => {
                     tokens: [],
                     line: "line1",
                     dirty: false,
+                    version: 1,
                 })
 
                 assert.deepEqual(newState["1"], {
@@ -73,6 +76,7 @@ describe("SyntaxHighlightingReducer", () => {
                     tokens: [],
                     line: "line2_update",
                     dirty: true,
+                    version: 0,
                 })
             })
         })


### PR DESCRIPTION
Fixes #1838, by checking the new buffer update against the version of the old state if the version has changed then the highlighting is re-applied