### PR TITLE
Implement scroll delta threshold to improve macOS scrolling experience.

### DIFF
--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -6,6 +6,7 @@ import { IScreen } from "./../neovim"
 // Handle modifier keys
 export class Mouse extends EventEmitter {
     private _isDragging = false
+    private _scrollDelta = 0
 
     constructor(private _editorElement: HTMLDivElement, private _screen: IScreen) {
         super()
@@ -44,12 +45,16 @@ export class Mouse extends EventEmitter {
             // the other applications I use. However, because OSX is super weird, it
             // might be backwards
             if (evt.deltaY) {
-                if (evt.deltaY < 0) {
-                    scrollcmdY += `ScrollWheelUp>`
-                } else {
-                    scrollcmdY += `ScrollWheelDown>`
+                this._scrollDelta += evt.deltaY
+                if (Math.abs(this._scrollDelta) >= 100) {
+                    if (this._scrollDelta < 0) {
+                        scrollcmdY += `ScrollWheelUp>`
+                    } else {
+                        scrollcmdY += `ScrollWheelDown>`
+                    }
+                    this._scrollDelta = 0
+                    this.emit("mouse", scrollcmdY + `<${line},${column}>`)
                 }
-                this.emit("mouse", scrollcmdY + `<${line},${column}>`)
             }
 
             this._isDragging = false

--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -2,12 +2,13 @@ import { EventEmitter } from "events"
 
 import { IScreen } from "./../neovim"
 
+const SCROLL_THRESHOLD_IN_PIXELS = 100
+
 // TODO
 // Handle modifier keys
 export class Mouse extends EventEmitter {
     private _isDragging = false
     private _scrollDelta = 0
-    private SCROLL_THRESHOLD = 100
 
     constructor(private _editorElement: HTMLDivElement, private _screen: IScreen) {
         super()
@@ -42,24 +43,39 @@ export class Mouse extends EventEmitter {
                 scrollcmdY += `C-` // The S- and C- prefixes have the same effect
             }
 
-            // This is 'less than' because I made this on a mac to behave just like
-            // the other applications I use. However, because OSX is super weird, it
-            // might be backwards
-            if (evt.deltaY) {
-                this._scrollDelta += evt.deltaY
-                if (Math.abs(this._scrollDelta) >= this.SCROLL_THRESHOLD) {
-                    if (this._scrollDelta < 0) {
-                        scrollcmdY += `ScrollWheelUp>`
-                    } else {
-                        scrollcmdY += `ScrollWheelDown>`
-                    }
-                    this._scrollDelta = 0
-                    this.emit("mouse", scrollcmdY + `<${line},${column}>`)
-                }
+            const normalizedDelta = this._normalizeScrollDeltaToPixels(evt.deltaY, evt.deltaMode)
+            if (!normalizedDelta) {
+                return
             }
 
             this._isDragging = false
+            this._scrollDelta += normalizedDelta
+            if (this._scrollDeltaIsSignificant()) {
+                // This is 'less than' because I made this on a mac to behave just like
+                // the other applications I use. However, because OSX is super weird, it
+                // might be backwards.
+                if (this._scrollDelta < 0) {
+                    scrollcmdY += `ScrollWheelUp>`
+                } else {
+                    scrollcmdY += `ScrollWheelDown>`
+                }
+                this._scrollDelta = 0
+                this.emit("mouse", scrollcmdY + `<${line},${column}>`)
+            }
         })
+    }
+
+    private _normalizeScrollDeltaToPixels(delta: number, deltaMode: number): number {
+        switch (deltaMode) {
+            case WheelEvent.DOM_DELTA_PIXEL:
+                return delta
+            case WheelEvent.DOM_DELTA_LINE:
+                return delta * this._screen.fontHeightInPixels
+            case WheelEvent.DOM_DELTA_PAGE:
+                return delta * this._screen.fontHeightInPixels * this._screen.height
+            default:
+                return delta
+        }
     }
 
     private _convertEventToPosition(evt: MouseEvent): { line: number; column: number } {
@@ -70,5 +86,9 @@ export class Mouse extends EventEmitter {
             line: Math.floor(mouseX / this._screen.fontWidthInPixels),
             column: Math.floor(mouseY / this._screen.fontHeightInPixels),
         }
+    }
+
+    private _scrollDeltaIsSignificant(): boolean {
+        return Math.abs(this._scrollDelta) >= SCROLL_THRESHOLD_IN_PIXELS
     }
 }

--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -7,6 +7,7 @@ import { IScreen } from "./../neovim"
 export class Mouse extends EventEmitter {
     private _isDragging = false
     private _scrollDelta = 0
+    private SCROLL_THRESHOLD = 100
 
     constructor(private _editorElement: HTMLDivElement, private _screen: IScreen) {
         super()
@@ -46,7 +47,7 @@ export class Mouse extends EventEmitter {
             // might be backwards
             if (evt.deltaY) {
                 this._scrollDelta += evt.deltaY
-                if (Math.abs(this._scrollDelta) >= 100) {
+                if (Math.abs(this._scrollDelta) >= this.SCROLL_THRESHOLD) {
                     if (this._scrollDelta < 0) {
                         scrollcmdY += `ScrollWheelUp>`
                     } else {

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -152,7 +152,7 @@ export class CursorPositionerView extends React.PureComponent<
         const childStyle = this.state.shouldOpenDownward ? openFromTopStyle : openFromBottomStyle
         const arrowStyle = this.state.shouldOpenDownward ? openFromBottomStyle : openFromTopStyle
 
-        const arrowStyleWithAdjustments = {
+        const arrowStyleWithAdjustments: React.CSSProperties = {
             ...arrowStyle,
             left: (this.props.x + this.props.fontPixelWidth / 2).toString() + "px",
             visibility: this.props.hideArrow ? "hidden" : "visible",

--- a/browser/src/UI/components/WindowTitle.tsx
+++ b/browser/src/UI/components/WindowTitle.tsx
@@ -24,7 +24,7 @@ export class WindowTitleView extends React.PureComponent<IWindowTitleViewProps, 
             return null
         }
 
-        const style = {
+        const style: React.CSSProperties = {
             height: "22px",
             lineHeight: "22px",
             zoom: 1, // Don't allow this to be impacted by zoom


### PR DESCRIPTION
Fixes https://github.com/onivim/oni/issues/1568

Scroll events are emitted very frequently on macOS. Previously,
we were moving a single line on every scroll event, which made scrolling
on macOS way too fast.

The value `100` is taken from Windows measurements given here:
https://gist.github.com/bryphe/43caa81bbec16d90d7b47f084014774b