### PR TITLE
Add config option for showing reference buffer.

### DIFF
--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -107,13 +107,23 @@ export class ConfigurationEditManager {
             }
         }
 
-        // Create the buffer with the list of all the available options
-        await this._createReadonlyReferenceBuffer()
+        const showReferenceBuffer = this._configuration.getValue(
+            "configuration.showReferenceBuffer",
+        )
 
-        // Open the actual configuration file
-        await this._editorManager.activeEditor.openFile(normalizedEditFile, {
-            openMode: Oni.FileOpenMode.VerticalSplit,
-        })
+        if (showReferenceBuffer) {
+            // Create the buffer with the list of all the available options
+            await this._createReadonlyReferenceBuffer()
+
+            // Open the actual configuration file
+            await this._editorManager.activeEditor.openFile(normalizedEditFile, {
+                openMode: Oni.FileOpenMode.VerticalSplit,
+            })
+        } else {
+            await this._editorManager.activeEditor.openFile(normalizedEditFile, {
+                openMode: Oni.FileOpenMode.Edit,
+            })
+        }
     }
 
     private async _createReadonlyReferenceBuffer() {

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -36,6 +36,7 @@ const BaseConfiguration: IConfigurationValues = {
 
     "browser.defaultUrl": "https://duckduckgo.com",
     "configuration.editor": "typescript",
+    "configuration.showReferenceBuffer": true,
 
     "debug.fixedSize": null,
     "debug.neovimPath": null,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -41,6 +41,7 @@ export interface IConfigurationValues {
     "editor.split.mode": string
 
     "configuration.editor": string
+    "configuration.showReferenceBuffer": boolean
 
     // - textMateHighlighting
     "editor.textMateHighlighting.enabled": boolean


### PR DESCRIPTION
Since I've been working on a smaller screen for a bit, I realised that having a config option for showing the reference buffer would be appreciated, since it gets pretty crowded espcially if I have the reference buffer/my config/dev tools all open.