### PR TITLE
feature: add config option to have sidebar open by default or not

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -243,6 +243,7 @@ const BaseConfiguration: IConfigurationValues = {
     "recorder.outputPath": os.tmpdir(),
 
     "sidebar.enabled": true,
+    "sidebar.default.open": true,
     "sidebar.width": "50px",
 
     "sidebar.marks.enabled": false,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -222,6 +222,7 @@ export interface IConfigurationValues {
     "recorder.copyScreenshotToClipboard": boolean
 
     "sidebar.enabled": boolean
+    "sidebar.default.open": boolean
     "sidebar.width": string
 
     "sidebar.marks.enabled": boolean

--- a/browser/src/Services/Sidebar/index.ts
+++ b/browser/src/Services/Sidebar/index.ts
@@ -12,6 +12,9 @@ export * from "./SidebarStore"
 export const activate = (configuration: Configuration, workspace: Workspace) => {
     if (configuration.getValue("sidebar.enabled")) {
         _sidebarManager = new SidebarManager(windowManager)
+        if (!configuration.getValue("sidebar.default.open")) {
+            _sidebarManager.toggleSidebarVisibility()
+        }
 
         commandManager.registerCommand({
             command: "sidebar.toggle",


### PR DESCRIPTION
My most common action on starting `oni` is immediately closing the file explorer as although I use it, I find having this open from the beginning quite incovenient *personally*. This change gives a user the ability to set the explorer to be closed when oni launches until a user choses to have it open