### PR TITLE
Build: Add back minimal caching for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ branches:
     - /^release.*/
 
 cache:
-    - .oni-release-binaries -> package.json 
+    - .oni_build_cache -> package.json 
 
 platform:
     - x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - npm --version
   # install modules
   - yarn install --verbose
+  - npm run check-cached-binaries
 
 artifacts:
     - path: dist/*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ branches:
     - master
     - /^release.*/
 
+cache:
+    - .oni-release-binaries -> package.json 
+
 platform:
     - x86
     - x64


### PR DESCRIPTION
Looking through the windows build logs, I saw several failures where the CiTests were failing to find the neovim binary. We recently removed the cache because it was keeping around some outdated dependencies, but we do need specific caching logic for the binaries we download.

Otherwise, some of our binaries we need - like `nvim`, `rg`, will get throttled by the github releases API, and the builds will intermittently fail.

We actually already have logic for handling this caching, and we put our downloaded binaries in the `.oni-release-binaries` folder, and therefore we shouldn't need to download them frequently. Travis already accounts for this - this change adds the `.oni_build_cache` folder to appveyor too.