### PR TITLE
Bugfix/use max width for tab names

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -58,7 +58,7 @@ export interface ITabsProps {
 }
 
 const InnerName = withProps<{ isLong?: boolean }>(styled.span)`
-    ${p => p.isLong && `width: 250px;`};
+    max-width: 18em;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -134,13 +134,16 @@ const TabWrapper = styled.div`
     animation: ${TabEntranceKeyFrames} 0.1s ease-in forwards;
 `
 
+interface IChromeDivElement extends HTMLDivElement {
+    scrollIntoViewIfNeeded: (args: { behavior: string; block: string; inline: string }) => void
+}
+
 export class Tab extends React.Component<ITabPropsWithClick> {
-    private _tab: HTMLDivElement
+    private _tab: IChromeDivElement
     public componentWillReceiveProps(next: ITabPropsWithClick) {
         if (next.isSelected && this._tab) {
-            const anyTab = this._tab as any
-            if (anyTab.scrollIntoViewIfNeeded) {
-                anyTab.scrollIntoViewIfNeeded({
+            if (this._tab.scrollIntoViewIfNeeded) {
+                this._tab.scrollIntoViewIfNeeded({
                     behavior: "smooth",
                     block: "center",
                     inline: "center",
@@ -167,7 +170,7 @@ export class Tab extends React.Component<ITabPropsWithClick> {
         return (
             <Sneakable callback={() => this.props.onClickName()}>
                 <TabWrapper
-                    innerRef={(e: HTMLDivElement) => (this._tab = e)}
+                    innerRef={(e: IChromeDivElement) => (this._tab = e)}
                     className={cssClasses}
                     title={this.props.description}
                     style={style}
@@ -180,9 +183,7 @@ export class Tab extends React.Component<ITabPropsWithClick> {
                         />
                     </div>
                     <div className="name" onClick={this.props.onClickName}>
-                        <InnerName isLong={this.props.name.length > 50}>
-                            {this.props.name}
-                        </InnerName>
+                        <InnerName>{this.props.name}</InnerName>
                     </div>
                     <div className="corner enable-hover" onClick={this.props.onClickClose}>
                         <div className="icon-container x-icon-container">

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -17,7 +17,7 @@ import { addDefaultUnitIfNeeded } from "./../../Font"
 
 import { Sneakable } from "./../../UI/components/Sneakable"
 import { Icon } from "./../../UI/Icon"
-import { styled, withProps } from "./../components/common"
+import { styled } from "./../components/common"
 
 import { FileIcon } from "./../../Services/FileIcon"
 
@@ -57,8 +57,8 @@ export interface ITabsProps {
     fontSize: string
 }
 
-const InnerName = withProps<{ isLong?: boolean }>(styled.span)`
-    max-width: 18em;
+const InnerName = styled.span`
+    max-width: 20em;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
         PersistentSettings: "<rootDir>/ui-tests/mocks/PersistentSettings.ts",
         Utility: "<rootDir>/ui-tests/mocks/Utility.ts",
         Configuration: "<rootDir>/ui-tests/mocks/Configuration.ts",
+        classnames: "<rootDir>/ui-tests/mocks/classnames.ts",
     },
     snapshotSerializers: ["enzyme-to-json/serializer"],
     transform: {

--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -4,8 +4,6 @@ import * as React from "react"
 
 import { Tab, Tabs } from "../browser/src/UI/components/Tabs"
 
-jest.mock("classNames")
-
 describe("<Tabs /> Tests", () => {
     const testTabs = [
         {
@@ -39,12 +37,24 @@ describe("<Tabs /> Tests", () => {
         const wrapper = shallow(TestTabs)
         expect(shallowToJson(wrapper)).toMatchSnapshot()
     })
-    it("Should show the modified icon if the tab is dirty", () => {
+    it("Should render the correct number of tabs", () => {
         const wrapper = shallow(TestTabs)
-        const circle = wrapper
-            .find(Tab)
-            .dive()
-            .find(".circle")
-        expect(circle.length).toEqual(1)
+        expect(wrapper.children.length).toEqual(1)
+    })
+    it("Should not render if the visible props is false", () => {
+        const wrapper = shallow(
+            <Tabs
+                fontSize="1.2em"
+                maxWidth="20em"
+                height="2em"
+                fontFamily="inherit"
+                backgroundColor="#fff"
+                foregroundColor="#000"
+                shouldWrap={false}
+                visible={false}
+                tabs={testTabs}
+            />,
+        )
+        expect(wrapper.getElement()).toBe(null)
     })
 })

--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -1,0 +1,50 @@
+import { mount, shallow } from "enzyme"
+import { shallowToJson } from "enzyme-to-json"
+import * as React from "react"
+
+import { Tab, Tabs } from "../browser/src/UI/components/Tabs"
+
+jest.mock("classNames")
+
+describe("<Tabs /> Tests", () => {
+    const testTabs = [
+        {
+            id: 2,
+            name: "test",
+            description: "a test tab",
+            isSelected: true,
+            isDirty: true,
+            iconFileName: "icon",
+            highlightColor: "#000",
+        },
+    ]
+    const TestTabs = (
+        <Tabs
+            fontSize="1.2em"
+            maxWidth="20em"
+            height="2em"
+            fontFamily="inherit"
+            backgroundColor="#fff"
+            foregroundColor="#000"
+            shouldWrap={false}
+            visible={true}
+            tabs={testTabs}
+        />
+    )
+    it("renders without crashing", () => {
+        const wrapper = shallow(TestTabs)
+        expect(wrapper.length).toEqual(1)
+    })
+    it("should match last known snapshot unless we make a change", () => {
+        const wrapper = shallow(TestTabs)
+        expect(shallowToJson(wrapper)).toMatchSnapshot()
+    })
+    it("Should show the modified icon if the tab is dirty", () => {
+        const wrapper = shallow(TestTabs)
+        const circle = wrapper
+            .find(Tab)
+            .dive()
+            .find(".circle")
+        expect(circle.length).toEqual(1)
+    })
+})

--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -41,7 +41,7 @@ describe("<Tabs /> Tests", () => {
         const wrapper = shallow(TestTabs)
         expect(wrapper.children.length).toEqual(1)
     })
-    it("Should not render if the visible props is false", () => {
+    it("Should not render if the visible prop is false", () => {
         const wrapper = shallow(
             <Tabs
                 fontSize="1.2em"

--- a/ui-tests/__snapshots__/Tabs.test.tsx.snap
+++ b/ui-tests/__snapshots__/Tabs.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tabs /> Tests should match last known snapshot unless we make a change 1`] = `
+<div
+  className="tabs horizontal enable-mouse layer"
+  style={
+    Object {
+      "borderBottom": "4px solid #fff",
+      "fontFamily": "inherit",
+      "fontSize": "1.2em",
+    }
+  }
+>
+  <Tab
+    backgroundColor="#fff"
+    description="a test tab"
+    foregroundColor="#000"
+    height="2em"
+    highlightColor="#000"
+    iconFileName="icon"
+    id={2}
+    isDirty={true}
+    isSelected={true}
+    key="2"
+    maxWidth="20em"
+    name="test"
+    onClickClose={[Function]}
+    onClickName={[Function]}
+  />
+</div>
+`;

--- a/ui-tests/mocks/classnames.ts
+++ b/ui-tests/mocks/classnames.ts
@@ -1,0 +1,2 @@
+export default (component: string, classes: { [key: string]: string }) => jest.fn()
+export const classNames = jest.fn()


### PR DESCRIPTION
Realised that the strategy I added to conditionally truncate file length was missing cases as it would conditionally apply a width if the text was over 50chars.

This PR simplifies things and just uses a css `max-width` to add text overflow


BEFORE:
<img width="470" alt="screen shot 2018-04-09 at 08 26 55" src="https://user-images.githubusercontent.com/22454918/38540208-0ee33c36-3c93-11e8-86da-9c9a1c18768e.png">

(under 50chars but way too long to fit into the tab, icon is overflowing)

AFTER:
<img width="375" alt="screen shot 2018-04-10 at 07 37 35" src="https://user-images.githubusercontent.com/22454918/38540210-113be00a-3c93-11e8-9803-8ae3f32a383d.png">

Also added some initial test for the tabs components
