### PR TITLE
Bugfix: Fix markdown preview opening horizontally instead of vertically

### DIFF
--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -196,7 +196,8 @@ export class WindowManager {
             }
             case "horizontal":
             case "vertical":
-                const augmentedRefSplit = this._getAugmentedWindowSplitFromSplit(referenceSplit)
+                const augmentedRefSplit =
+                    this._getAugmentedWindowSplitFromSplit(referenceSplit) || this.activeSplit
                 this._primarySplit.split(augmentedWindow, splitLocation, augmentedRefSplit)
                 const newState = this._primarySplit.getState() as ISplitInfo<Oni.IWindowSplit>
 

--- a/browser/test/Services/WindowManager/WindowManagerTests.ts
+++ b/browser/test/Services/WindowManager/WindowManagerTests.ts
@@ -4,7 +4,7 @@
 
 import * as assert from "assert"
 
-import { WindowManager, ISplitInfo } from "./../../../src/Services/WindowManager"
+import { ISplitInfo, WindowManager } from "./../../../src/Services/WindowManager"
 import { MockWindowSplit } from "./../../Mocks"
 
 describe("WindowManagerTests", () => {

--- a/browser/test/Services/WindowManager/WindowManagerTests.ts
+++ b/browser/test/Services/WindowManager/WindowManagerTests.ts
@@ -4,7 +4,7 @@
 
 import * as assert from "assert"
 
-import { WindowManager } from "./../../../src/Services/WindowManager"
+import { WindowManager, ISplitInfo } from "./../../../src/Services/WindowManager"
 import { MockWindowSplit } from "./../../Mocks"
 
 describe("WindowManagerTests", () => {
@@ -57,15 +57,21 @@ describe("WindowManagerTests", () => {
         const split1 = new MockWindowSplit("window1")
         const split2 = new MockWindowSplit("window2")
 
-        windowManager.createSplit("horizontal", split1)
-        windowManager.createSplit("vertical", split2)
+        const handle1 = windowManager.createSplit("horizontal", split1)
+        handle1.focus()
+
+        windowManager.createSplit("vertical", split2, split1)
 
         const splitRoot = windowManager.splitRoot
 
+        const firstChild = splitRoot.splits[0] as ISplitInfo<MockWindowSplit>
+
+        assert.strictEqual(firstChild.type, "Split")
         assert.strictEqual(
-            splitRoot.direction,
+            firstChild.direction,
             "horizontal",
-            "Validate the splits are arranged horizontally (it's confusing, by this means they are vertical splits)",
+            "Validate the splits are arranged horizontally (it's confusing... but this means they are vertical splits)",
         )
+        assert.strictEqual(firstChild.splits.length, 2, "Validate both windows are in this split")
     })
 })


### PR DESCRIPTION
__Repro:__
- Enable `experimental.markdownPreview.enabled` configuration
- Open a markdown file

_Expected:_ Markdown preview should open vertically
_Actual:_ Markdown preview opens horizontally

__Defect:__ There is a bug with the window management code. If there is no `referenceSplit` defined (which is the window we are splitting from), we would ignore the direction passed in.

__Fix:__ If there is no reference split, default to the currently active split.