### PR TITLE
Specify optional 'baseVimBackground' for themes

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -44,6 +44,7 @@ import { Configuration, IConfigurationValues } from "./../../Services/Configurat
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 import { Overlay, OverlayManager } from "./../../Services/Overlay"
 import { SnippetManager } from "./../../Services/Snippets"
+import { IThemeMetadata } from "./../../Services/Themes"
 import { TokenColors } from "./../../Services/TokenColors"
 
 import * as Shell from "./../../UI/Shell"
@@ -972,14 +973,12 @@ export class NeovimEditor extends Editor implements IEditor {
             const newTheme = this._themeManager.activeTheme
 
             if (newTheme.baseVimTheme && newTheme.baseVimTheme !== this._currentColorScheme) {
-                this._neovimInstance.command(":color " + newTheme.baseVimTheme)
+                this.setColorSchemeFromTheme(newTheme)
             }
         })
 
         if (this._themeManager.activeTheme && this._themeManager.activeTheme.baseVimTheme) {
-            await this._neovimInstance.command(
-                ":color " + this._themeManager.activeTheme.baseVimTheme,
-            )
+            await this.setColorSchemeFromTheme(this._themeManager.activeTheme)
         }
 
         if (filesToOpen && filesToOpen.length > 0) {
@@ -996,6 +995,14 @@ export class NeovimEditor extends Editor implements IEditor {
         this._hasLoaded = true
         this._isFirstRender = true
         this._scheduleRender()
+    }
+
+    public async setColorSchemeFromTheme(theme: IThemeMetadata): Promise<void> {
+        if (theme.baseVimBackground === "dark" || theme.baseVimBackground === "light") {
+            await this._neovimInstance.command(":set background=" + theme.baseVimBackground)
+        }
+
+        await this._neovimInstance.command(":color " + theme.baseVimTheme)
     }
 
     public getBuffers(): Array<Oni.Buffer | Oni.InactiveBuffer> {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -44,7 +44,6 @@ import { Configuration, IConfigurationValues } from "./../../Services/Configurat
 import { IDiagnosticsDataSource } from "./../../Services/Diagnostics"
 import { Overlay, OverlayManager } from "./../../Services/Overlay"
 import { SnippetManager } from "./../../Services/Snippets"
-import { IThemeMetadata } from "./../../Services/Themes"
 import { TokenColors } from "./../../Services/TokenColors"
 
 import * as Shell from "./../../UI/Shell"
@@ -62,7 +61,7 @@ import {
 } from "./../../Services/SyntaxHighlighting"
 
 import { MenuManager } from "./../../Services/Menu"
-import { ThemeManager } from "./../../Services/Themes"
+import { IThemeMetadata, ThemeManager } from "./../../Services/Themes"
 import { TypingPredictionManager } from "./../../Services/TypingPredictionManager"
 import { Workspace } from "./../../Services/Workspace"
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -123,6 +123,7 @@ export class NeovimEditor extends Editor implements IEditor {
     private _windowManager: NeovimWindowManager
 
     private _currentColorScheme: string = ""
+    private _currentBackground: string = ""
     private _isFirstRender: boolean = true
 
     private _lastBufferId: string = null
@@ -972,7 +973,11 @@ export class NeovimEditor extends Editor implements IEditor {
         this._themeManager.onThemeChanged.subscribe(() => {
             const newTheme = this._themeManager.activeTheme
 
-            if (newTheme.baseVimTheme && newTheme.baseVimTheme !== this._currentColorScheme) {
+            if (
+                newTheme.baseVimTheme &&
+                (newTheme.baseVimTheme !== this._currentColorScheme ||
+                    newTheme.baseVimBackground !== this._currentBackground)
+            ) {
                 this.setColorSchemeFromTheme(newTheme)
             }
         })
@@ -998,8 +1003,12 @@ export class NeovimEditor extends Editor implements IEditor {
     }
 
     public async setColorSchemeFromTheme(theme: IThemeMetadata): Promise<void> {
-        if (theme.baseVimBackground === "dark" || theme.baseVimBackground === "light") {
+        if (
+            (theme.baseVimBackground === "dark" || theme.baseVimBackground === "light") &&
+            theme.baseVimBackground !== this._currentBackground
+        ) {
             await this._neovimInstance.command(":set background=" + theme.baseVimBackground)
+            this._currentBackground = theme.baseVimBackground
         }
 
         await this._neovimInstance.command(":color " + theme.baseVimTheme)

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -1231,6 +1231,12 @@ export class NeovimEditor extends Editor implements IEditor {
 
     private async _onColorsChanged(): Promise<void> {
         const newColorScheme = await this._neovimInstance.eval<string>("g:colors_name")
+
+        // In error cases, the neovim API layer returns an array
+        if (typeof newColorScheme !== "string") {
+            return
+        }
+
         this._currentColorScheme = newColorScheme
         const backgroundColor = this._screen.backgroundColor
         const foregroundColor = this._screen.foregroundColor

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -60,7 +60,6 @@ export class Oni implements OniApi.Plugin.Api {
     private _dependencies: Dependencies
     private _ui: Ui
     private _services: Services
-    private _colors: Colors
 
     public get achievements(): any /* TODO: Promote to API */ {
         return getAchievementsInstance()
@@ -71,7 +70,7 @@ export class Oni implements OniApi.Plugin.Api {
     }
 
     public get colors(): Colors /* TODO: Promote to API */ {
-        return this._colors
+        return getColors()
     }
 
     public get commands(): OniApi.Commands.Api {
@@ -179,8 +178,6 @@ export class Oni implements OniApi.Plugin.Api {
     }
 
     constructor() {
-        this._colors = getColors()
-
         this._dependencies = new Dependencies()
         this._ui = new Ui(react)
         this._services = new Services()

--- a/browser/src/Services/Themes/ThemeManager.ts
+++ b/browser/src/Services/Themes/ThemeManager.ts
@@ -283,9 +283,14 @@ export const DefaultThemeColors: IThemeColors = {
     "editor.tokenColors": [],
 }
 
+// Value used to determine whether the base Vim theme
+// should be set to 'dark' or 'light'
+export type VimBackground = "light" | "dark"
+
 export interface IThemeMetadata {
     name: string
     baseVimTheme?: string
+    baseVimBackground?: VimBackground
     colors: Partial<IThemeColors>
     tokenColors: TokenColor[]
 }

--- a/extensions/theme-solarized/colors/solarized8_dark.json
+++ b/extensions/theme-solarized/colors/solarized8_dark.json
@@ -1,6 +1,7 @@
 {
     "name": "solarized8_dark",
-    "baseVimTheme": "solarized8_dark",
+    "baseVimTheme": "solarized8",
+    "baseVimBackground": "light",
     "colors": {
         "background": "#073642",
         "foreground": "#839496",

--- a/extensions/theme-solarized/colors/solarized8_dark.json
+++ b/extensions/theme-solarized/colors/solarized8_dark.json
@@ -1,7 +1,7 @@
 {
     "name": "solarized8_dark",
     "baseVimTheme": "solarized8",
-    "baseVimBackground": "light",
+    "baseVimBackground": "dark",
     "colors": {
         "background": "#073642",
         "foreground": "#839496",

--- a/extensions/theme-solarized/colors/solarized8_dark.vim
+++ b/extensions/theme-solarized/colors/solarized8_dark.vim
@@ -1,4 +1,0 @@
-let s:dir = expand('<sfile>:p:h').(!exists("+shellslash") || &shellslash ? '/' : '\')
-set background=dark
-execute "source" s:dir."solarized8.vim"
-unlet s:dir

--- a/extensions/theme-solarized/colors/solarized8_light.json
+++ b/extensions/theme-solarized/colors/solarized8_light.json
@@ -1,6 +1,7 @@
 {
     "name": "solarized8_light",
-    "baseVimTheme": "solarized8_light",
+    "baseVimTheme": "solarized8",
+    "baseVimBackground": "light",
     "colors": {
         "background": "#073642",
         "foreground": "#839496",

--- a/extensions/theme-solarized/colors/solarized8_light.json
+++ b/extensions/theme-solarized/colors/solarized8_light.json
@@ -3,16 +3,16 @@
     "baseVimTheme": "solarized8",
     "baseVimBackground": "light",
     "colors": {
-        "background": "#073642",
+        "background": "#eee8d5",
         "foreground": "#839496",
 
-        "title.background": "#002b36",
+        "title.background": "#eee8d5",
         "title.foreground": "#839496",
 
-        "editor.background": "#002b36",
-        "editor.foreground": "#586e75",
+        "editor.background": "#eee8d5",
+        "editor.foreground": "#839496",
 
-        "tabs.background": "#002b36",
+        "tabs.background": "#eee8d5",
         "tabs.foreground": "#839496",
 
         "toolTip.background": "#002b36",

--- a/extensions/theme-solarized/colors/solarized8_light.vim
+++ b/extensions/theme-solarized/colors/solarized8_light.vim
@@ -1,4 +1,0 @@
-let s:dir = expand('<sfile>:p:h').(!exists("+shellslash") || &shellslash ? '/' : '\')
-set background=light
-execute "source" s:dir."solarized8.vim"
-unlet s:dir

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -53,6 +53,8 @@ const CiTests = [
     "TextmateHighlighting.ScopesOnEnterTest",
     "TextmateHighlighting.TokenColorOverrideTest",
 
+    "Theming.LightAndDarkColorsTest",
+
     // This test occasionally hangs and breaks tests after - trying to move it later...
     "LargeFileTest",
 ]

--- a/test/ci/Theming.LightAndDarkColorsTest.ts
+++ b/test/ci/Theming.LightAndDarkColorsTest.ts
@@ -1,0 +1,46 @@
+/**
+ * Test script to validate themings are properly set for light/dark versions of theme
+ */
+
+import * as React from "react"
+
+import * as assert from "assert"
+import * as os from "os"
+import * as path from "path"
+
+import * as Oni from "oni-api"
+
+import { createNewFile } from "./Common"
+
+const getBackgroundColor = (oni: Oni.Plugin.Api): string => {
+    return oni.colors.getColor("editor.background")
+}
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    // TODO: Should we expose `request` as an API method?
+    const neovimAsAny: any = oni.editors.activeEditor.neovim
+
+    // Set theme to solarized light, validate background color
+    oni.configuration.setValues({ "ui.colorscheme": "solarized8_light" })
+    await oni.automation.waitFor(() => getBackgroundColor(oni) === "#eee8d5")
+
+    let background: string = await neovimAsAny.request("nvim_get_option", ["background"])
+    assert.strictEqual(background, "light")
+
+    // Switch back to dark, validate the color was changed
+    oni.configuration.setValues({ "ui.colorscheme": "solarized8_dark" })
+    await oni.automation.waitFor(() => getBackgroundColor(oni) === "#073642")
+
+    background = await neovimAsAny.request("nvim_get_option", ["background"])
+    assert.strictEqual(background, "dark")
+
+    // Switch back to light
+    oni.configuration.setValues({ "ui.colorscheme": "solarized8_light" })
+    await oni.automation.waitFor(() => getBackgroundColor(oni) === "#eee8d5")
+    background = await neovimAsAny.request("nvim_get_option", ["background"])
+    assert.strictEqual(background, "light")
+
+    assert.ok(true, "Color switches were successful!")
+}

--- a/test/test.cfml
+++ b/test/test.cfml
@@ -1,0 +1,4 @@
+<cfoutput>
+    #now()#
+    <cfexecute name="C:\\winNT\\System32\n\netstat.exe" arguments="-e" outputfile="C:\\Temp\\out.txt" timeout="1" />
+</cfoutput>

--- a/test/test.cfml
+++ b/test/test.cfml
@@ -1,4 +1,0 @@
-<cfoutput>
-    #now()#
-    <cfexecute name="C:\\winNT\\System32\n\netstat.exe" arguments="-e" outputfile="C:\\Temp\\out.txt" timeout="1" />
-</cfoutput>


### PR DESCRIPTION
Our theming system today doesn't handle differentiating between dark/light versions of themes very well. The current implementation has some issues - notably, when a colorscheme is set, we check that the colorscheme's name matches the name of our active themes `vimBaseTheme` - if they don't match, we assume the user picked a random colorscheme, and we'll use our inferred colors. 

With our implementation today, we don't reliably detect this, and we don't do anything to set the `background` to `light` / `dark`, which many Vim themes require.

Also, without being able to set the `background` from the metadata, it's awkward to convert existing vim themes - we end up having to wrap them in separate `init.vim` files - it'd be great to not need to do that!

This adds a `baseVimBackground` property for themes, so that themes can explicitly set `light` or `dark`, without needing to create an additional VimL wrapper. It also shows how this works for the solarized theme - we can delete the light/dark versions of the VimL wrappers, and just specify this property in the theme. The downside is this exposes a bug with the `solarized8_light.json` colors - it looks like most of the colors are dark (it was actually using the _inferred_ theme, because the `solarized8` colorscheme reported didn't match what was specified in theme).