### PR TITLE
CanvasRenderer: Align text rendering to vertical pixel boundary

### DIFF
--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -327,7 +327,7 @@ export class CanvasRenderer implements INeovimRenderer {
             this._canvasContext.fillText(
                 text,
                 boundsStartX,
-                y * fontHeightInPixels + linePaddingInPixels / 2,
+                normalizedBoundsY + linePaddingInPixels / 2,
             )
             this._canvasContext.font = lastFontStyle
         }


### PR DESCRIPTION
This is related to #2047 - there are cases still were subpixel anti-aliasing isn't working as expected.

We can help improve that, at least in some instances, by aligning the text to pixel boundaries were possible. This change aligns the text rendering for characters to the pixel boundary. Previously, we'd measure the text - and for example, if the height was 7.0035 pixels, row 2 would be at 14.007 pixels, then row 3 would be at 21.0105 pixels, etc. This can exacerbate subpixel rendering issues and caused interleaved patches of blurry/normal text.

Note that this doesn't address pixel boundaries in the horizontal case - that is more complicated because the kerning tends to look off (we can get away with it for rows, because there is padding between lines anyway - but for kerning or the horizontal case, it looks really bad!). The right long-term fix is to completely own the rendering pipeline in #1252 , but this can at least help some of the degenerate cases today. More details in the conversation in #2047 .