### PR TITLE
[Proposal] Base config command line argument for #2022

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -123,6 +123,11 @@ export const start = async (args: string[]): Promise<void> => {
         }
     }
 
+    const baseConfig = parsedArgs["base-config"]
+    if (baseConfig) {
+        configuration.addConfigurationFile(baseConfig)
+    }
+
     configuration.start()
 
     configChange(configuration.getValues()) // initialize values


### PR DESCRIPTION
This adds a command line parameter to specify / override Oni's _base_ configuration. This lets you supply a configuration file that acts as a new set of defaults. So the order of precedence would be:

_Oni defaults_ -> _base config defaults_ -> _user configuration_ -> _workspace configuration_

This happens implicitly, as it is based on the order of 'adding' configuration files. For this parameter, we're adding the    

This parameter can be used like:
```
oni --base-config="/config.test.js"
```

@badosu - does this help you with #2022 ? Would you be able to leverage this?

If it is easier, we could also specify this via an environment variable, like `ONI_BASE_CONFIG_PATH`.