### PR TITLE
Use Vim shell option as default value for terminal.shellCommand

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -410,7 +410,7 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.showIndex": false,
     "tabs.wrap": false,
 
-    "terminal.shellCommand": os.platform() === "win32" ? "cmd" : "bash",
+    "terminal.shellCommand": null,
 
     "ui.animations.enabled": true,
     "ui.colorscheme": "nord",

--- a/browser/src/Services/Terminal.ts
+++ b/browser/src/Services/Terminal.ts
@@ -15,13 +15,12 @@ export const activate = (
     configuration: Configuration,
     editorManager: EditorManager,
 ) => {
-    const getTerminalCommand = () => {
-        const terminalCommand = configuration.getValue("terminal.shellCommand", "")
-        return `term://${terminalCommand}`
-    }
+    const openTerminal = async (openMode: Oni.FileOpenMode) => {
+        const terminalCommand =
+            configuration.getValue("terminal.shellCommand") ||
+            (await editorManager.activeEditor.neovim.callFunction("nvim_get_option", ["shell"]))
 
-    const openTerminal = (openMode: Oni.FileOpenMode) => {
-        editorManager.activeEditor.openFile(getTerminalCommand(), { openMode })
+        editorManager.activeEditor.openFile(`term://${terminalCommand}`, { openMode })
     }
 
     commandManager.registerCommand({


### PR DESCRIPTION
Currently the Oni Terminal is different from neovim Terminal (Invoked with `:terminal`), the shell is not the same on both options, oni use a configuration setting `terminal.shellCommand` and Neovim use the `shell` variable

I changed only the default value of `terminal.shellCommand` but should we be aligned with the Neovim behavior and use `shell` variable ?
And if yes do we remove the `terminal.shellCommand` ?