### PR TITLE
Regression from #2078: Event can be null when Sneak navigation is used

### DIFF
--- a/browser/src/Services/Explorer/ExplorerView.tsx
+++ b/browser/src/Services/Explorer/ExplorerView.tsx
@@ -43,8 +43,10 @@ const scrollIntoViewIfNeeded = (elem: HTMLElement) => {
     elem && elem["scrollIntoViewIfNeeded"] && elem["scrollIntoViewIfNeeded"]()
 }
 const stopPropagation = (fn: () => void) => {
-    return (e: React.MouseEvent<HTMLElement>) => {
-        e.stopPropagation()
+    return (e?: React.MouseEvent<HTMLElement>) => {
+        if (e) {
+            e.stopPropagation()
+        }
         fn()
     }
 }

--- a/browser/src/UI/components/SidebarItemView.tsx
+++ b/browser/src/UI/components/SidebarItemView.tsx
@@ -19,7 +19,7 @@ export interface ISidebarItemViewProps {
     isContainer?: boolean
     indentationLevel: number
     icon?: JSX.Element
-    onClick: (e: React.MouseEvent<HTMLElement>) => void
+    onClick: (e?: React.MouseEvent<HTMLElement>) => void
 }
 
 const px = (num: number): string => num.toString() + "px"


### PR DESCRIPTION
I broke navigation with sneak mode with #2078, because the onClick handled is called without arguments