### PR TITLE
Fix #2102 - Oni isn't working with Neovim 0.3.0

### DIFF
--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -1013,7 +1013,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         shouldExtTabs: boolean,
         shouldExtPopups: boolean,
     ) {
-        if (major >= 0 && minor >= 2 && patch >= 1) {
+        if (major > 0 || minor > 2 || (minor === 2 && patch >= 1)) {
             const useExtCmdLine = this._configuration.getValue("commandline.mode")
             const useExtWildMenu = this._configuration.getValue("wildmenu.mode")
             return {


### PR DESCRIPTION
__Issue:__ Oni won't launch with `nvim` 0.3.0 - you get the error splash screen.

__Defect:__ We check the version of Neovim to decide whether we can use certain externalization features (or if Oni can run at all). Our version check is a bit busted, though - we required a minor version >= 2 AND a patch version >= 1 - meaning minor 3/patch 0 would fall through these checks and we show an error.

__Fix:__ Revise the check so that we check for a major greater than 0, or a minor greater than 2, or a minor of 2 w/ patch >= 1. 

__Test Impact:__ Our tests today continue to validate against the `0.2.2` build, so that's covered. For early-adopters who want to use Oni with nightly `0.3.0` nvim builds, you can use the `'debug.neovimPath'` configuration setting - you can point this to the path of the neovim executable you wish to use.