### PR TITLE
[Prototype] #2019 - Part 2 - Output some documentation for configuration settings

### DIFF
--- a/browser/src/Services/Configuration/ConfigurationEditor.ts
+++ b/browser/src/Services/Configuration/ConfigurationEditor.ts
@@ -15,6 +15,7 @@ import { EditorManager } from "./../EditorManager"
 
 import { Configuration } from "./Configuration"
 import { DefaultConfiguration } from "./DefaultConfiguration"
+import { flatMap } from "./../../Utility"
 
 // For configuring Oni, JavaScript is the de-facto language, and the configuration
 // today will _always_ happen through `config.js`
@@ -131,15 +132,31 @@ export class ConfigurationEditManager {
             openMode: Oni.FileOpenMode.NewTab,
         })
 
+        const keys = Object.keys(DefaultConfiguration)
+
+        const lines = flatMap(keys, key => this._getInfoForConfigVariable(key))
+
         // Format the default configuration values as a pretty JSON object, then
         // set it as the reference buffer content
-        const referenceContent = JSON.stringify(DefaultConfiguration, null, "  ")
         await Promise.all([
-            referenceBuffer.setLines(0, 1, referenceContent.split("\n")),
+            referenceBuffer.setLines(0, 1, ["{", ...lines, "}"]),
             // FIXME: needs to be added to the Oni.Buffers API
-            (referenceBuffer as any).setLanguage("json"),
+            (referenceBuffer as any).setLanguage("typescript"),
             (referenceBuffer as any).setScratchBuffer(),
         ])
+    }
+
+    private _getInfoForConfigVariable(key: string): string[] {
+        const metadata = this._configuration.getMetadata<any>(key)
+
+        const configurationLine = `"${key}": ${JSON.stringify(DefaultConfiguration[key])},`
+
+        if (metadata && metadata.description) {
+            const val = ` // ${metadata.description}`
+            return ["", val, configurationLine, ""]
+        } else {
+            return [configurationLine]
+        }
     }
 
     private async _transpileConfiguration(


### PR DESCRIPTION
We have a new API for registering configuration variables w/ metadata (like documentation, whether the setting is hot-reloadable, etc), but we aren't really using it yet.

This change checks to see if there is metadata defined as part of the configuration registration, and outputs in the reference buffer:
![image](https://user-images.githubusercontent.com/13532591/38842622-de788878-419f-11e8-8227-323ff627d741.png)

A couple things remaining:
- [ ] Filter out the 'activate' and 'deactivate' (undefined) settings. These were automatically filtered out in the previous `JSON.stringify` strategy.
- [ ] Add a Ci Test - this can add a configuration value w/ metadata, and validate it shows up in the reference buffer.

A next step later is that we don't have a setting for the allowed set of values for the configuration setting - we should potentially add that as part of the metadata.
