### PR TITLE
Fix relative module loading for configuration

### DIFF
--- a/browser/src/Services/Configuration/FileConfigurationProvider.ts
+++ b/browser/src/Services/Configuration/FileConfigurationProvider.ts
@@ -125,8 +125,16 @@ export class FileConfigurationProvider implements IConfigurationProvider {
         let error: Error | null = null
         if (fs.existsSync(this._configurationFilePath)) {
             try {
-                const loadedConfig = global["require"](this._configurationFilePath) // tslint:disable-line no-string-literal
-                userRuntimeConfig = promoteConfigurationToRootLevel(loadedConfig)
+                const configurationContent = fs.readFileSync(this._configurationFilePath, "utf-8")
+
+                // Wrap as commonjs module and execute it to use current file path, and so resolve module relativly to current process
+                const module = { exports: {} }
+                Function("require", "exports", "module", configurationContent)(
+                    (global as any).require,
+                    module.exports,
+                    module,
+                )
+                userRuntimeConfig = promoteConfigurationToRootLevel(module.exports)
             } catch (e) {
                 e.message =
                     "[Config Error] Failed to parse " +


### PR DESCRIPTION
Currently if we want to load a module used by oni in our configuration (React for example), we need to use an absolute path because node module resolution algorithm only traverse directories up to find a node_module folder. This make it more difficult to share our onivim configuration between different computers

To fix this with this commit, we read the content of the configuration and wrap it in a "commonjs executing function" to use the same path as current oni's files and so the same algorithm