### PR TITLE
Build: Turn off verbose logging for yarn install, for now

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - node --version
   - npm --version
   # install modules
-  - yarn install --verbose
+  - yarn install
   - npm run check-cached-binaries
 
 artifacts:


### PR DESCRIPTION
Need to troubleshoot why the appveyor build cache isn't working, but unfortunately the logs are too long to see the compelte set (the major culprit is the `verbose` flag for our `yarn install`). 

Going to take it out temporarily to check the logging around the cache status.