### PR TITLE
Feature/ add delete event so watcher picks up all deletions

### DIFF
--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -63,6 +63,7 @@ export class ExplorerSplit {
         FileSystemWatcher.onChange.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
         FileSystemWatcher.onAdd.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
         FileSystemWatcher.onMove.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
+        FileSystemWatcher.onDelete.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
     }
 
     public enter(): void {

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -7,7 +7,7 @@ import * as path from "path"
 import * as React from "react"
 import { Provider } from "react-redux"
 import { Store } from "redux"
-import FileSystemWatcher from "./../../Services/FileSystemWatcher"
+import { FileSystemWatcher } from "./../../Services/FileSystemWatcher"
 
 import { Event } from "oni-types"
 
@@ -46,11 +46,19 @@ export class ExplorerSplit {
     ) {
         this._store = createStore({ notifications: NotificationsInstance() })
 
+        const Watcher = new FileSystemWatcher({
+            target: this._workspace.activeWorkspace,
+            options: { ignoreInitial: true, ignored: "**/node_modules" },
+        })
+
         this._workspace.onDirectoryChanged.subscribe(newDirectory => {
             this._store.dispatch({
                 type: "SET_ROOT_DIRECTORY",
                 rootPath: newDirectory,
             })
+
+            Watcher.unwatch(this._workspace.activeWorkspace)
+            Watcher.watch(newDirectory)
         })
 
         if (this._workspace.activeWorkspace) {
@@ -60,10 +68,10 @@ export class ExplorerSplit {
             })
         }
 
-        FileSystemWatcher.onChange.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
-        FileSystemWatcher.onAdd.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
-        FileSystemWatcher.onMove.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
-        FileSystemWatcher.onDelete.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
+        Watcher.onChange.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
+        Watcher.onAdd.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
+        Watcher.onMove.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
+        Watcher.onDelete.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
     }
 
     public enter(): void {

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -68,10 +68,10 @@ export class ExplorerSplit {
             })
         }
 
-        Watcher.onChange.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
-        Watcher.onAdd.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
-        Watcher.onMove.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
-        Watcher.onDelete.subscribe(() => this._store.dispatch({ type: "REFRESH" }))
+        const events = ["onChange", "onAdd", "onAddDir", "onMove", "onDelete", "onDeleteDir"]
+        events.forEach(event =>
+            Watcher[event].subscribe(() => this._store.dispatch({ type: "REFRESH" })),
+        )
     }
 
     public enter(): void {

--- a/browser/src/Services/FileSystemWatcher/index.ts
+++ b/browser/src/Services/FileSystemWatcher/index.ts
@@ -24,6 +24,7 @@ export class FileSystemWatcher {
     private _onAdd = new Event<IFileChangeEvent>()
     private _onAddDir = new Event<IStatsChangeEvent>()
     private _onDelete = new Event<IFileChangeEvent>()
+    private _onDeleteDir = new Event<IFileChangeEvent>()
     private _onMove = new Event<IFileChangeEvent>()
     private _onChange = new Event<IFileChangeEvent>()
 
@@ -64,6 +65,10 @@ export class FileSystemWatcher {
             return this._onDelete.dispatch(path)
         })
 
+        this._watcher.on("unlinkDir", path => {
+            return this._onDeleteDir.dispatch(path)
+        })
+
         this._watcher.on("addDir", (path, stats) => {
             return this._onAddDir.dispatch({ path, stats })
         })
@@ -81,6 +86,10 @@ export class FileSystemWatcher {
         return this._onDelete
     }
 
+    get onDeleteDir(): IEvent<IFileChangeEvent> {
+        return this._onDeleteDir
+    }
+
     get onMove(): IEvent<IFileChangeEvent> {
         return this._onMove
     }
@@ -89,7 +98,7 @@ export class FileSystemWatcher {
         return this._onAdd
     }
 
-    get addDir(): IEvent<IStatsChangeEvent> {
+    get onAddDir(): IEvent<IFileChangeEvent> {
         return this._onAddDir
     }
 }

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -138,8 +138,8 @@ export class Workspace implements IWorkspace {
 
         const filePath = await findup(projectMarkers, { cwd })
         if (filePath) {
-            const dir = path.dirname(filePath)
-            this.changeDirectory(dir)
+            const projectRoot = path.dirname(filePath)
+            return projectRoot !== this._activeWorkspace ? this.changeDirectory(projectRoot) : null
         }
     }
 


### PR DESCRIPTION
This PR adds the `unlink` event to the watcher and a hook for it as it turns out that the change event does not always accurately pick up deletions, the correct event for that seems to be unlink.

Also added a check to only watch workspace changes if the watcher was initialised to watch the workspace, this will allow the watcher to be used for other purposes without always spawning a watcher for the workspace.

Lastly added a check to see if project root is different before triggering a change dir event as it seems the explorer always refreshes and flickers when moving buffer if `navigateToProjectRoot` is set to always as it always triggers a change dir but a check to see if the dir is the same stops that