### PR TITLE
bugfix/ add check to ensure there is an error event obj and it has a name

### DIFF
--- a/browser/src/Services/UnhandledErrorMonitor.ts
+++ b/browser/src/Services/UnhandledErrorMonitor.ts
@@ -38,7 +38,9 @@ export class UnhandledErrorMonitor {
 
         window.addEventListener("error", (evt: ErrorEvent) => {
             if (!this._started) {
-                const hasOccured = this._queuedErrors.find(e => e.name === evt.error.name)
+                const hasOccured = this._queuedErrors.find(
+                    e => evt.error && e.name && e.name === evt.error.name,
+                )
                 if (!hasOccured) {
                     this._queuedErrors.push(evt.error)
                 }


### PR DESCRIPTION
Some errors that are save to the `queuedErrors` do not have names and so if an error was thrown without one this check would occasionally itself throw an error, so added a check to ensure that the props being check exist before the actual check.