### PR TITLE
Hotfix/fix fs event overload

### DIFF
--- a/browser/src/Services/Explorer/ExplorerStore.ts
+++ b/browser/src/Services/Explorer/ExplorerStore.ts
@@ -633,13 +633,17 @@ export const clearUpdateEpic: ExplorerEpic = (action$, store) =>
         .mergeMap(() => timer(2_000).mapTo(Actions.clearUpdate))
 
 const refreshEpic: ExplorerEpic = (action$, store) =>
-    action$.ofType("REFRESH").mergeMap(() => {
-        const state = store.getState()
+    action$
+        .ofType("REFRESH")
+        .auditTime(300)
+        .mergeMap(() => {
+            console.log("REFRESHING")
+            const state = store.getState()
 
-        return Object.keys(state.expandedFolders).map(p => {
-            return Actions.expandDirectory(p)
+            return Object.keys(state.expandedFolders).map(p => {
+                return Actions.expandDirectory(p)
+            })
         })
-    })
 
 const expandDirectoryEpic: ExplorerEpic = (action$, store, { fileSystem }) =>
     action$.ofType("EXPAND_DIRECTORY").flatMap(async (action: ExplorerAction) => {

--- a/browser/src/Services/Explorer/ExplorerStore.ts
+++ b/browser/src/Services/Explorer/ExplorerStore.ts
@@ -637,7 +637,6 @@ const refreshEpic: ExplorerEpic = (action$, store) =>
         .ofType("REFRESH")
         .auditTime(300)
         .mergeMap(() => {
-            console.log("REFRESHING")
             const state = store.getState()
 
             return Object.keys(state.expandedFolders).map(p => {

--- a/browser/src/Services/FileSystemWatcher/index.ts
+++ b/browser/src/Services/FileSystemWatcher/index.ts
@@ -2,6 +2,8 @@ import * as chokidar from "chokidar"
 import { Stats } from "fs"
 import { Event, IEvent } from "oni-types"
 
+import * as throttle from "lodash/throttle"
+
 import * as Workspace from "./../Workspace"
 
 export type Targets = string | string[]
@@ -61,16 +63,22 @@ export class FileSystemWatcher {
     }
 
     private _attachEventListeners() {
+        const throttledAddEvent = throttle(this._onAdd.dispatch.bind(this._onAdd), 300)
+
         this._watcher.on("add", path => {
-            return this._onAdd.dispatch(path)
+            return throttledAddEvent(path)
         })
+
+        const throttledChangeEvent = throttle(this._onChange.dispatch.bind(this._onChange), 300)
 
         this._watcher.on("change", path => {
-            return this._onChange.dispatch(path)
+            return throttledChangeEvent(path)
         })
 
+        const throttledMoveEvent = throttle(this._onMove.dispatch.bind(this._onMove), 300)
+
         this._watcher.on("move", path => {
-            return this._onMove.dispatch(path)
+            return throttledMoveEvent(path)
         })
 
         this._watcher.on("addDir", (path, stats) => {

--- a/browser/src/Services/FileSystemWatcher/index.ts
+++ b/browser/src/Services/FileSystemWatcher/index.ts
@@ -42,11 +42,11 @@ export class FileSystemWatcher {
         // to avoid a flurry of events when the watcher is initialised
         this._watcher.on("ready", () => {
             this._attachEventListeners()
+        })
 
-            this._workspace.onDirectoryChanged.subscribe(newDirectory => {
-                this.unwatch(this._activeWorkspace)
-                this.watch(newDirectory)
-            })
+        this._workspace.onDirectoryChanged.subscribe(newDirectory => {
+            this.unwatch(this._activeWorkspace)
+            this.watch(newDirectory)
         })
     }
 

--- a/browser/src/Services/FileSystemWatcher/index.ts
+++ b/browser/src/Services/FileSystemWatcher/index.ts
@@ -29,7 +29,7 @@ export class FileSystemWatcher {
     private _onAddDir = new Event<IStatsChangeEvent>()
     private _onMove = new Event<IFileChangeEvent>()
     private _onChange = new Event<IFileChangeEvent>()
-    private _defaultOptions = { ignored: "**/node_modules" }
+    private _defaultOptions = { ignored: "**/node_modules", ignoreInitial: true }
 
     constructor(watch: IFSOptions = {}) {
         this._workspace = Workspace.getInstance()
@@ -38,8 +38,6 @@ export class FileSystemWatcher {
         const optionsToUse = watch.options || this._defaultOptions
         this._watcher = chokidar.watch(fileOrFolder, optionsToUse)
 
-        // alternatively the ignoreInitial can be set in the config
-        // to avoid a flurry of events when the watcher is initialised
         this._watcher.on("ready", () => {
             this._attachEventListeners()
         })


### PR DESCRIPTION
@bryphe @CrossR important bugfix here, noted since I merged in the FileWatcher that if you switch project roots the filesystem watcher would send an event for all the subdirectories and files of the newly watched directory resulting in 100s of events which bombard oni.

I've added a throttle off `300ms` to the events being fired to stop the bombardment

Discussion Points: Wasn't sure if it would be preferable to throttle the refresh dispatch, and have the watcher respond with all the events it receives?
