### PR TITLE
Add back cache to VSCode scorer.

### DIFF
--- a/browser/src/Services/QuickOpen/Scorer/OniQuickOpenScorer.ts
+++ b/browser/src/Services/QuickOpen/Scorer/OniQuickOpenScorer.ts
@@ -5,6 +5,7 @@ import {
     IItemScore,
     prepareQuery,
     scoreItem,
+    ScorerCache,
 } from "./QuickOpenScorer"
 import { nativeSep } from "./Utilities"
 
@@ -24,7 +25,12 @@ class OniAccessor implements IItemAccessor<any> {
     }
 }
 
-export function scoreItemOni(resultObject: any, searchString: string, fuzzy: boolean): IItemScore {
+export function scoreItemOni(
+    resultObject: any,
+    searchString: string,
+    fuzzy: boolean,
+    cache: ScorerCache,
+): IItemScore {
     if (!searchString) {
         return NO_ITEM_SCORE
     }
@@ -37,7 +43,7 @@ export function scoreItemOni(resultObject: any, searchString: string, fuzzy: boo
 
     const accessor = new OniAccessor()
 
-    return scoreItem(resultObject, query, fuzzy, accessor)
+    return scoreItem(resultObject, query, fuzzy, accessor, cache)
 }
 
 export function compareItemsByScoreOni(
@@ -45,6 +51,7 @@ export function compareItemsByScoreOni(
     resultObjectB: any,
     searchString: string,
     fuzzy: boolean,
+    cache: ScorerCache,
 ): number {
     if (!searchString) {
         return 0
@@ -58,7 +65,7 @@ export function compareItemsByScoreOni(
 
     const accessor = new OniAccessor()
 
-    return compareItemsByScore(resultObjectA, resultObjectB, query, fuzzy, accessor)
+    return compareItemsByScore(resultObjectA, resultObjectB, query, fuzzy, accessor, cache)
 }
 
 export const getHighlightsFromResult = (result: IMatch[]): number[] => {

--- a/browser/src/Services/QuickOpen/Scorer/QuickOpenScorer.ts
+++ b/browser/src/Services/QuickOpen/Scorer/QuickOpenScorer.ts
@@ -343,7 +343,7 @@ export function scoreItem<T>(
     query: IPreparedQuery,
     fuzzy: boolean,
     accessor: IItemAccessor<T>,
-    // cache: ScorerCache,
+    cache: ScorerCache,
 ): IItemScore {
     if (!item || !query.value) {
         return NO_ITEM_SCORE // we need an item and query to score on at least
@@ -356,20 +356,20 @@ export function scoreItem<T>(
 
     const description = accessor.getItemDescription(item)
 
-    // let cacheHash: string
-    // if (description) {
-    //     cacheHash = `${label}${description}${query.value}${fuzzy}`
-    // } else {
-    //     cacheHash = `${label}${query.value}${fuzzy}`
-    // }
+    let cacheHash: string
+    if (description) {
+        cacheHash = `${label}${description}${query.value}${fuzzy}`
+    } else {
+        cacheHash = `${label}${query.value}${fuzzy}`
+    }
 
-    // const cached = cache[cacheHash]
-    // if (cached) {
-    //     return cached
-    // }
+    const cached = cache[cacheHash]
+    if (cached) {
+        return cached
+    }
 
     const itemScore = doScoreItem(label, description, accessor.getItemPath(item), query, fuzzy)
-    // cache[cacheHash] = itemScore
+    cache[cacheHash] = itemScore
 
     return itemScore
 }
@@ -467,11 +467,11 @@ export function compareItemsByScore<T>(
     query: IPreparedQuery,
     fuzzy: boolean,
     accessor: IItemAccessor<T>,
-    // cache: ScorerCache,
+    cache: ScorerCache,
     fallbackComparer = fallbackCompare,
 ): number {
-    const itemScoreA = scoreItem(itemA, query, fuzzy, accessor)
-    const itemScoreB = scoreItem(itemB, query, fuzzy, accessor)
+    const itemScoreA = scoreItem(itemA, query, fuzzy, accessor, cache)
+    const itemScoreB = scoreItem(itemB, query, fuzzy, accessor, cache)
 
     const scoreA = itemScoreA.score
     const scoreB = itemScoreB.score

--- a/browser/src/Services/QuickOpen/VSCodeFilter.ts
+++ b/browser/src/Services/QuickOpen/VSCodeFilter.ts
@@ -57,7 +57,7 @@ export const vsCodeFilter = (
     // TODO: Is it worth instead persisting this cache?
     // Plus side is repeated searches are fast.
     // Down side is there will be a lot of rubbish being stored too.
-    let cache: ScorerCache = {}
+    const cache: ScorerCache = {}
 
     const filteredOptions = processSearchTerm(vsCodeSearchString, options, cache)
 

--- a/browser/src/Services/QuickOpen/VSCodeFilter.ts
+++ b/browser/src/Services/QuickOpen/VSCodeFilter.ts
@@ -15,6 +15,7 @@ import {
 } from "./Scorer/OniQuickOpenScorer"
 
 import { IMenuOptionWithHighlights, shouldFilterbeCaseSensitive } from "./../Menu"
+import { ScorerCache } from "./Scorer/QuickOpenScorer"
 
 export const vsCodeFilter = (
     options: Oni.Menu.MenuOption[],
@@ -49,7 +50,16 @@ export const vsCodeFilter = (
             ? listOfSearchTerms.slice(1).join("") + listOfSearchTerms[0]
             : listOfSearchTerms[0]
 
-    const filteredOptions = processSearchTerm(vsCodeSearchString, options)
+    // Adds a cache for the scores. This is needed to stop the final score
+    // compare from repeating all the scoring logic again.
+    // Currently, this only persists for the current search, which will speed
+    // up that search only.
+    // TODO: Is it worth instead persisting this cache?
+    // Plus side is repeated searches are fast.
+    // Down side is there will be a lot of rubbish being stored too.
+    let cache: ScorerCache = {}
+
+    const filteredOptions = processSearchTerm(vsCodeSearchString, options, cache)
 
     const ret = filteredOptions.filter(fo => {
         if (fo.score === 0) {
@@ -59,15 +69,16 @@ export const vsCodeFilter = (
         }
     })
 
-    return ret.sort((e1, e2) => compareItemsByScoreOni(e1, e2, vsCodeSearchString, true))
+    return ret.sort((e1, e2) => compareItemsByScoreOni(e1, e2, vsCodeSearchString, true, cache))
 }
 
 export const processSearchTerm = (
     searchString: string,
     options: Oni.Menu.MenuOption[],
+    cache: ScorerCache,
 ): Oni.Menu.IMenuOptionWithHighlights[] => {
     const result: Oni.Menu.IMenuOptionWithHighlights[] = options.map(f => {
-        const itemScore = scoreItemOni(f, searchString, true)
+        const itemScore = scoreItemOni(f, searchString, true, cache)
         const detailHighlights = getHighlightsFromResult(itemScore.descriptionMatch)
         const labelHighlights = getHighlightsFromResult(itemScore.labelMatch)
 

--- a/browser/test/Services/QuickOpen/VSCodeFilterTests.ts
+++ b/browser/test/Services/QuickOpen/VSCodeFilterTests.ts
@@ -4,8 +4,15 @@
 
 import * as assert from "assert"
 import { processSearchTerm, vsCodeFilter } from "./../../../src/Services/QuickOpen/VSCodeFilter"
+import { ScorerCache } from "../../../src/Services/QuickOpen/Scorer/QuickOpenScorer"
 
 describe("processSearchTerm", () => {
+    let cache: ScorerCache
+
+    beforeEach(() => {
+        cache = {}
+    })
+
     it("Correctly matches word.", async () => {
         const testString = "src"
         const testList = [
@@ -13,7 +20,7 @@ describe("processSearchTerm", () => {
             { label: "index.ts", detail: "browser/test" },
         ]
 
-        const result = processSearchTerm(testString, testList)
+        const result = processSearchTerm(testString, testList, cache)
         const filteredResult = result.filter(r => r.score !== 0)
 
         // Remove the score since it can change if we updated the
@@ -39,7 +46,7 @@ describe("processSearchTerm", () => {
             { label: "index.ts", detail: "browser/SRC" },
         ]
 
-        const result = processSearchTerm(testString, testList)
+        const result = processSearchTerm(testString, testList, cache)
 
         // Check the exact case match scores higher
         const lowercase = result.find(r => r.detail === "browser/src")
@@ -57,7 +64,7 @@ describe("processSearchTerm", () => {
             { label: "index.ts", detail: "browser/test" },
         ]
 
-        const result = processSearchTerm(testString, testList)
+        const result = processSearchTerm(testString, testList, cache)
         const filteredResult = result.filter(r => r.score !== 0)
 
         assert.deepEqual(filteredResult, [])

--- a/browser/test/Services/QuickOpen/VSCodeFilterTests.ts
+++ b/browser/test/Services/QuickOpen/VSCodeFilterTests.ts
@@ -3,8 +3,8 @@
  */
 
 import * as assert from "assert"
-import { processSearchTerm, vsCodeFilter } from "./../../../src/Services/QuickOpen/VSCodeFilter"
 import { ScorerCache } from "../../../src/Services/QuickOpen/Scorer/QuickOpenScorer"
+import { processSearchTerm, vsCodeFilter } from "./../../../src/Services/QuickOpen/VSCodeFilter"
 
 describe("processSearchTerm", () => {
     let cache: ScorerCache


### PR DESCRIPTION
After adding back the cache, the sorting is certainly quicker but still not at VSCode level.

Need to have a look and see if it makes sense to keep the cache around longer, and also see if we can have the scoring not block the typing which I see occasionally.

I'm testing this on the VSCode git repo, which seems a pretty large repo and seems to show the slow down.

One note though if someone else tries to compare vs VSCode is that they have a pretty large exclude list, so you'd want to stick that in your project specific `.oni/config` to make the comparison a bit fairer. Or disable it in VSCode. It can be found in `.vscode/settings.json`.