### PR TITLE
Fix #2149 - Part 1 - Add configuration setting for explorer refresh

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -262,7 +262,13 @@ export const start = async (args: string[]): Promise<void> => {
     Sidebar.activate(configuration, workspace)
     const sidebarManager = Sidebar.getInstance()
 
-    Explorer.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
+    Explorer.activate(
+        commandManager,
+        configuration,
+        editorManager,
+        Sidebar.getInstance(),
+        workspace,
+    )
     Search.activate(commandManager, editorManager, Sidebar.getInstance(), workspace)
     Learning.activate(
         commandManager,

--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -144,6 +144,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     input.bind("r", "explorer.rename", isExplorerActive)
     input.bind("<c-e>", "explorer.create.file", isExplorerActive)
     input.bind("<c-f>", "explorer.create.folder", isExplorerActive)
+    input.bind("<c-r>", "explorer.refresh", isExplorerActive)
 
     // Browser
     input.bind("k", "browser.scrollUp")

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -106,14 +106,16 @@ export class ExplorerSplit {
         })
 
         const events = ["onChange", "onAdd", "onAddDir", "onMove", "onDelete", "onDeleteDir"]
-        events.forEach(event =>
-            this._watcher[event].subscribe(() => this._store.dispatch({ type: "REFRESH" })),
-        )
+        events.forEach(event => this._watcher[event].subscribe(() => this._refresh()))
     }
 
     private _inputInProgress = () => {
         const { register: { rename, create } } = this._store.getState()
         return rename.active || create.active
+    }
+
+    private _refresh(): void {
+        this._store.dispatch({ type: "REFRESH" })
     }
 
     private _initialiseExplorerCommands(): void {
@@ -157,6 +159,15 @@ export class ExplorerSplit {
                 "Move/Paste Selected Item",
                 "Paste the last yanked item",
                 () => !this._inputInProgress() && this._onPasteItem(),
+            ),
+        )
+
+        this._commandManager.registerCommand(
+            new CallbackCommand(
+                "explorer.refresh",
+                "Explorer: Refresh the tree",
+                "Updates the explorer with the latest state on the file system",
+                () => !this._inputInProgress() && this._refresh(),
             ),
         )
 

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -100,13 +100,15 @@ export class ExplorerSplit {
     }
 
     private _initializeFileSystemWatcher(): void {
-        this._watcher = new FileSystemWatcher({
-            target: this._workspace.activeWorkspace,
-            options: { ignoreInitial: true, ignored: "**/node_modules" },
-        })
+        if (this._configuration.getValue("explorer.autoRefresh")) {
+            this._watcher = new FileSystemWatcher({
+                target: this._workspace.activeWorkspace,
+                options: { ignoreInitial: true, ignored: "**/node_modules" },
+            })
 
-        const events = ["onChange", "onAdd", "onAddDir", "onMove", "onDelete", "onDeleteDir"]
-        events.forEach(event => this._watcher[event].subscribe(() => this._refresh()))
+            const events = ["onChange", "onAdd", "onAddDir", "onMove", "onDelete", "onDeleteDir"]
+            events.forEach(event => this._watcher[event].subscribe(() => this._refresh()))
+        }
     }
 
     private _inputInProgress = () => {

--- a/browser/src/Services/Explorer/index.tsx
+++ b/browser/src/Services/Explorer/index.tsx
@@ -28,6 +28,6 @@ export const activate = (
 
     sidebarManager.add(
         "files-o",
-        new ExplorerSplit(workspace, commandManager, configuration, editorManager),
+        new ExplorerSplit(configuration, workspace, commandManager, editorManager),
     )
 }

--- a/browser/src/Services/Explorer/index.tsx
+++ b/browser/src/Services/Explorer/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import { CommandManager } from "./../CommandManager"
+import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 import { SidebarManager } from "./../Sidebar"
 import { Workspace } from "./../Workspace"
@@ -13,9 +14,20 @@ import { ExplorerSplit } from "./ExplorerSplit"
 
 export const activate = (
     commandManager: CommandManager,
+    configuration: Configuration,
     editorManager: EditorManager,
     sidebarManager: SidebarManager,
     workspace: Workspace,
 ) => {
-    sidebarManager.add("files-o", new ExplorerSplit(workspace, commandManager, editorManager))
+    configuration.registerSetting("explorer.autoRefresh", {
+        description:
+            "When set to true, the explorer will listen for changes on the file system and refresh automatically.",
+        requiresReload: true,
+        defaultValue: false,
+    })
+
+    sidebarManager.add(
+        "files-o",
+        new ExplorerSplit(workspace, commandManager, configuration, editorManager),
+    )
 }


### PR DESCRIPTION
__Issue:__ There can be a performance degradation when upgrading from Oni 0.3.2 -> Oni 0.3.3 due to the way we watch the file system / update the UI in response to it.

__Fix:__ We'll gate the 'autoRefresh' behavior behind a flag - `explorer.autoRefresh`, which defaults to `false`. We'll enable an explicit refresh gesture with the `explorer.refresh` command, bound to `<C-r>`.