### PR TITLE
Fix #2147 - Closed splits eating window space when 'editor.split.mode' is 'oni'

### DIFF
--- a/browser/src/Services/WindowManager/LinearSplitProvider.ts
+++ b/browser/src/Services/WindowManager/LinearSplitProvider.ts
@@ -160,10 +160,14 @@ export class LinearSplitProvider implements IWindowSplitProvider {
     }
 
     public getState(): ISplitInfo<IAugmentedSplitInfo> {
+        if (this._splitProviders.length === 0) {
+            return null
+        }
+
         return {
             type: "Split",
             direction: this._direction,
-            splits: this._splitProviders.map(sp => sp.getState()),
+            splits: this._splitProviders.map(sp => sp.getState()).filter(s => s !== null),
         }
     }
 

--- a/browser/test/Services/WindowManager/WindowManagerTests.ts
+++ b/browser/test/Services/WindowManager/WindowManagerTests.ts
@@ -89,15 +89,11 @@ describe("WindowManagerTests", () => {
         split3Handle.close()
 
         const splitRoot = windowManager.splitRoot
-
         const firstChild = splitRoot.splits[0] as ISplitInfo<MockWindowSplit>
 
         assert.strictEqual(splitRoot.type, "Split")
         assert.strictEqual(splitRoot.direction, "vertical")
         assert.strictEqual(splitRoot.splits.length, 1)
-
-        console.dir(splitRoot)
-        console.dir(splitRoot.splits[0])
 
         assert.strictEqual(firstChild.type, "Split")
         assert.strictEqual(

--- a/browser/test/Services/WindowManager/WindowManagerTests.ts
+++ b/browser/test/Services/WindowManager/WindowManagerTests.ts
@@ -74,4 +74,46 @@ describe("WindowManagerTests", () => {
         )
         assert.strictEqual(firstChild.splits.length, 2, "Validate both windows are in this split")
     })
+
+    it("#2147 - doesn't leave a split container after closing", async () => {
+        const split1 = new MockWindowSplit("window1")
+        const split2 = new MockWindowSplit("window2")
+        const split3 = new MockWindowSplit("window3")
+
+        windowManager.createSplit("horizontal", split1)
+
+        const split2Handle = windowManager.createSplit("vertical", split2, split1)
+        const split3Handle = windowManager.createSplit("horizontal", split3, split2)
+
+        split2Handle.close()
+        split3Handle.close()
+
+        const splitRoot = windowManager.splitRoot
+
+        const firstChild = splitRoot.splits[0] as ISplitInfo<MockWindowSplit>
+
+        assert.strictEqual(splitRoot.type, "Split")
+        assert.strictEqual(splitRoot.direction, "vertical")
+        assert.strictEqual(splitRoot.splits.length, 1)
+
+        console.dir(splitRoot)
+        console.dir(splitRoot.splits[0])
+
+        assert.strictEqual(firstChild.type, "Split")
+        assert.strictEqual(
+            firstChild.direction,
+            "horizontal",
+            "Validate the splits are arranged horizontally (it's confusing... but this means they are vertical splits)",
+        )
+        assert.strictEqual(
+            firstChild.splits.length,
+            1,
+            "Validate there is only a single child in the 'horizontal' split.",
+        )
+        assert.strictEqual(
+            firstChild.splits[0].type,
+            "Leaf",
+            "Validate the child of the 'horizontal' split is a leaf node.",
+        )
+    })
 })


### PR DESCRIPTION
__Issue:__ When the 'editor.split.mode' is set to `oni`, closing splits can sometimes leave empty space - and unfortunately there isn't an easy workaround.

__Defect:__ Currently, because there is no explicit sizing of the splits, the available window space is distributed evenly amongst the splits. In the case where splits are closed, they can leave behind an empty split container. This empty split container still takes up some of the space, even though it contains no splits.

__Fix:__ Filter out / remove empty split containers when a split is closed.