### PR TITLE
Update delete binding to use the `isExplorerActive` filter.

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -125,8 +125,6 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     input.bind("<enter>", "menu.select")
     input.bind(["<enter>", "<space>"], "select")
 
-    input.bind("<delete>", "explorer.delete")
-
     // TODO: Scope 's' to just the local window
     input.bind("<c-g>", "sneak.show", () => isNormalMode() && !menu.isMenuOpen())
     input.bind(["<esc>", "<c-c>"], "sneak.hide")
@@ -135,7 +133,9 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
 
     // Explorer
     input.bind("d", "explorer.delete.persist", isExplorerActive)
+    input.bind("<c-delete>", "explorer.delete.persist", isExplorerActive)
     input.bind("<c-d>", "explorer.delete", isExplorerActive)
+    input.bind("<delete>", "explorer.delete", isExplorerActive)
     input.bind("y", "explorer.yank", isExplorerActive)
     input.bind("p", "explorer.paste", isExplorerActive)
     input.bind("u", "explorer.undo", isExplorerActive)


### PR DESCRIPTION
Updated the explorer delete binding to use the `isExplorerActive` filter, otherwise if you have a folder/file selected in it and hit delete (even whilst in insert mode!) you'll delete that folder.

I was getting random files being deleted whilst working and couldn't work out why. Luckily I have everything in git so it was no hassle, but could have been a lot worse. Since my keyboard has a function layer which sticks `delete` right on the home row, I use it a lot more than maybe other vim users who would need to move their hands to hit it.

What I'm less sure about is why I didn't hit this back when the `delete` was originally added, since it was added in Jan I think. Perhaps it was just because I was using the explorer less than I am now.