### PR TITLE
add Change Operator and Visual Mode tutorials

### DIFF
--- a/browser/src/Services/Learning/Tutorial/Notes.tsx
+++ b/browser/src/Services/Learning/Tutorial/Notes.tsx
@@ -268,6 +268,27 @@ export const DeleteWordKey = (): JSX.Element => {
     )
 }
 
+export const ChangeOperatorKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="c"
+            description={
+                <span>
+                    <Bold>+ motion</Bold>: Change text specified by a `motion`. Examples:
+                </span>
+            }
+        />
+    )
+}
+export const ChangeWordKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="cw"
+            description={<span>Delete to the end of the current word and enter Insert mode.</span>}
+        />
+    )
+}
+
 export const HJKLKeys = (): JSX.Element => {
     return (
         <NoteWrapper style={{ margin: "2em 0em" }}>

--- a/browser/src/Services/Learning/Tutorial/Notes.tsx
+++ b/browser/src/Services/Learning/Tutorial/Notes.tsx
@@ -345,3 +345,20 @@ export const PasteKey = (): JSX.Element => {
         <KeyWithDescription keyCharacter="P" description={<span>Paste BEFORE the cursor</span>} />
     )
 }
+
+export const VisualModeKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="v"
+            description={<span>Move into Visual mode for selecting text</span>}
+        />
+    )
+}
+export const VisualLineModeKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="V"
+            description={<span>Move into line-wise Visual mode for selecting lines</span>}
+        />
+    )
+}

--- a/browser/src/Services/Learning/Tutorial/Tutorials/ChangeOperatorTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/ChangeOperatorTutorial.tsx
@@ -1,0 +1,48 @@
+/**
+ * ChangeOperatorTutorial.tsx
+ *
+ * Tutorial that exercises the change operator
+ */
+
+import * as React from "react"
+
+import { ITutorial, ITutorialMetadata, ITutorialStage } from "./../ITutorial"
+import * as Notes from "./../Notes"
+import * as Stages from "./../Stages"
+
+const Line1 = "The change operator can be used for quikcly fixing typos"
+const Line1Marker = "The change operator can be used for ".length
+const Line1Pending = "The change operator can be used for  fixing typos"
+const Line1Fixed = "The change operator can be used for quickly fixing typos"
+
+export class ChangeOperatorTutorial implements ITutorial {
+    private _stages: ITutorialStage[]
+
+    constructor() {
+        this._stages = [
+            new Stages.SetBufferStage([Line1]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 0, Line1Marker),
+            new Stages.WaitForStateStage("Fix the typo by hitting 'cw'", [Line1Pending]),
+            new Stages.WaitForStateStage("Enter the word 'quickly'", [Line1Fixed]),
+            new Stages.WaitForModeStage("Exit Insert mode by hitting <esc>", "normal"),
+        ]
+    }
+
+    public get metadata(): ITutorialMetadata {
+        return {
+            id: "oni.tutorials.change_operator",
+            name: "Change Operator: c",
+            description:
+                "Now that you know about operators and motions pairing like a noun and a verb, we can start learning more operators.  The `c` operator allows you to _change_ text.  It deletes the selected text and immediately enters Insert mode so you can enter new text.  The text to be changed is defined by any motion just like the delete operator.  It might not seem very impressive right now but `c` will become more useful as you learn more motions.",
+            level: 210,
+        }
+    }
+
+    public get stages(): ITutorialStage[] {
+        return this._stages
+    }
+
+    public get notes(): JSX.Element[] {
+        return [<Notes.HJKLKeys />, <Notes.ChangeOperatorKey />, <Notes.ChangeWordKey />]
+    }
+}

--- a/browser/src/Services/Learning/Tutorial/Tutorials/CopyPasteTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/CopyPasteTutorial.tsx
@@ -76,8 +76,8 @@ export class CopyPasteTutorial implements ITutorial {
             id: "oni.tutorials.copy_paste",
             name: "Copy & Paste: y, p",
             description:
-                'Now that you know about operators and motions pairing like a noun and a verb, we can start learning new operators.  The `y` operator can be used to copy ("yank") text which can then be pasted with `p`.  Using `p` pastes _after_ the cursor, and `P` pastes _before_ the cursor.  The `y` operator behaves just like the `d` operator and can be paired with any motion.',
-            level: 210,
+                "Now that you know the delete and change operators, let's learn vim's final operator: `y`.  The `y` operator can be used to copy (\"yank\") text which can then be pasted with `p`.  Using `p` pastes _after_ the cursor, and `P` pastes _before_ the cursor.  The `y` operator behaves just like the `d` and `c` operators and can be paired with any motion.",
+            level: 220,
         }
     }
 

--- a/browser/src/Services/Learning/Tutorial/Tutorials/VisualModeTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/VisualModeTutorial.tsx
@@ -97,6 +97,13 @@ export class VisualModeTutorial implements ITutorial {
     }
 
     public get notes(): JSX.Element[] {
-        return [<Notes.HJKLKeys />, <Notes.WordKey />, <Notes.BeginningKey />, <Notes.EndKey />]
+        return [
+            <Notes.HJKLKeys />,
+            <Notes.WordKey />,
+            <Notes.BeginningKey />,
+            <Notes.EndKey />,
+            <Notes.VisualModeKey />,
+            <Notes.VisualLineModeKey />,
+        ]
     }
 }

--- a/browser/src/Services/Learning/Tutorial/Tutorials/VisualModeTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/VisualModeTutorial.tsx
@@ -1,0 +1,102 @@
+/**
+ * VisualModeTutorial.tsx
+ *
+ * Tutorial for learning how to select text in visual mode.
+ */
+
+import * as React from "react"
+
+import { ITutorial, ITutorialMetadata, ITutorialStage } from "./../ITutorial"
+import * as Notes from "./../Notes"
+import * as Stages from "./../Stages"
+
+const Line1 = "Text can be selectedselected with 'v'."
+const Line2 = "Selected text can then be (y)anked, (c)hanged, or (d)eleted with a single keypress"
+const Line3 = "To select entire lines, use 'V' to include line-ending characters."
+const Line4 = "Selected lines can also be  with a single keypress"
+const Line1Marker = "Text can be ".length
+const Line1Marker2 = "Text can be selecte".length
+const Line1Change = "Text can be selected with 'v'."
+const Line2Marker = "Selected text can then be ".length
+const Line2Marker2 = "Selected text can then be (y)anked, (c)hanged, or (d)elete".length
+const Line4Marker = "Selected lines can also be".length
+const Line4PostPaste =
+    "Selected lines can also be (y)anked, (c)hanged, or (d)eleted with a single keypress"
+const Line3Marker = "To select entire lines, use 'V' to include ".length
+const Line3Marker2 = "To select entire lines, use 'V' to include line-endin".length
+const Line3Pending = "To select entire lines, use 'V' to include  characters."
+const Line3Change = "To select entire lines, use 'V' to include newline characters."
+const Line3Marker3 = "To select entire lines, use 'V' to include newlin".length
+
+export class VisualModeTutorial implements ITutorial {
+    private _stages: ITutorialStage[]
+
+    constructor() {
+        this._stages = [
+            new Stages.SetBufferStage([Line1, Line2, Line3, Line4]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 0, Line1Marker),
+            new Stages.WaitForModeStage("Change to Visual mode with 'v'", "visual"),
+            new Stages.MoveToGoalStage("Move to the goal marker", 0, Line1Marker2),
+            new Stages.WaitForStateStage("Hit 'd' to delete the selected text", [
+                Line1Change,
+                Line2,
+                Line3,
+                Line4,
+            ]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 1, Line2Marker),
+            new Stages.WaitForModeStage("Change to Visual mode with 'v'", "visual"),
+            new Stages.MoveToGoalStage("Move to the goal marker", 1, Line2Marker2),
+            new Stages.WaitForRegisterStage(
+                "Yank the selection with 'y'",
+                "(y)anked, (c)hanged, or (d)eleted",
+            ),
+            new Stages.MoveToGoalStage("Move to the goal marker", 3, Line4Marker),
+            new Stages.WaitForStateStage("Paste the yanked text with 'p'", [
+                Line1Change,
+                Line2,
+                Line3,
+                Line4PostPaste,
+            ]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 2, Line3Marker),
+            new Stages.WaitForModeStage("Change to Visual mode with 'v'", "visual"),
+            new Stages.MoveToGoalStage("Move to the goal marker", 2, Line3Marker2),
+            new Stages.WaitForStateStage("Change the selected text with 'c'", [
+                Line1Change,
+                Line2,
+                Line3Pending,
+                Line4PostPaste,
+            ]),
+            new Stages.WaitForStateStage("Enter the word 'newline'", [
+                Line1Change,
+                Line2,
+                Line3Change,
+                Line4PostPaste,
+            ]),
+            new Stages.WaitForModeStage("Exit Insert mode by hitting <esc>", "normal"),
+            new Stages.WaitForModeStage("Move into Visual Line mode with 'V'", "visual"),
+            new Stages.MoveToGoalStage("Move to the next line", 3, Line3Marker3),
+            new Stages.WaitForStateStage("Delete the selected lines with 'd'", [
+                Line1Change,
+                Line2,
+            ]),
+        ]
+    }
+
+    public get metadata(): ITutorialMetadata {
+        return {
+            id: "oni.tutorials.visual_mode",
+            name: "Visual Select: v, V",
+            description:
+                "Sometimes the text you want to modify isn't on a simple word boundary.  We often need to change, yank, or delete any arbitrary text.  Rather than performing a cursor movement and hoping you affected the correct characters, you can visually select text.  Using 'v' will select characters as you move, and 'V' will select lines",
+            level: 230,
+        }
+    }
+
+    public get stages(): ITutorialStage[] {
+        return this._stages
+    }
+
+    public get notes(): JSX.Element[] {
+        return [<Notes.HJKLKeys />, <Notes.WordKey />, <Notes.BeginningKey />, <Notes.EndKey />]
+    }
+}

--- a/browser/src/Services/Learning/Tutorial/Tutorials/index.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/index.tsx
@@ -6,6 +6,7 @@ import { ITutorial } from "./../ITutorial"
 
 import { BasicMovementTutorial } from "./BasicMovementTutorial"
 import { BeginningsAndEndingsTutorial } from "./BeginningsAndEndingsTutorial"
+import { ChangeOperatorTutorial } from "./ChangeOperatorTutorial"
 import { CopyPasteTutorial } from "./CopyPasteTutorial"
 import { DeleteCharacterTutorial } from "./DeleteCharacterTutorial"
 import { DeleteOperatorTutorial } from "./DeleteOperatorTutorial"
@@ -13,6 +14,7 @@ import { MoveAndInsertTutorial } from "./MoveAndInsertTutorial"
 import { SearchInBufferTutorial } from "./SearchInBufferTutorial"
 import { SwitchModeTutorial } from "./SwitchModeTutorial"
 import { VerticalMovementTutorial } from "./VerticalMovementTutorial"
+import { VisualModeTutorial } from "./VisualModeTutorial"
 import { WordMotionTutorial } from "./WordMotionTutorial"
 
 export * from "./DeleteCharacterTutorial"
@@ -29,4 +31,6 @@ export const AllTutorials: ITutorial[] = [
     new WordMotionTutorial(),
     new SearchInBufferTutorial(),
     new CopyPasteTutorial(),
+    new ChangeOperatorTutorial(),
+    new VisualModeTutorial(),
 ]


### PR DESCRIPTION
As mentioned in #2035, I felt a "visual mode" tutorial should come next.  However, once I started working on it I realized I would want to demo visual mode with all three operators: `y`ank, `d`elete, and `c`hange.  Since there wasn't a Change Operator tutorial yet, I threw one together.  Personally, I think `change` is most useful when used in conjunction with `t`/`f`/`i`/`a`.  Since we haven't written those tutorials yet, I only included `cw` in the Change Operator tutorial.  While I *could* add steps for `ce`, `cb`, `cj`, and `ck`, I don't feel like those operations are very beneficial and would just confuse a user as to why you'd want to do those things.

After looking back at these tutorials, I feel like I should probably repeat some operations to reinforce the learning.  The current state is function though, so adding reinforcement could probably come in a separate pull request.