### PR TITLE
Sidebar - Plugins: First round of improvements for plugins pane

### DIFF
--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -18,6 +18,56 @@ import { PluginManager } from "./../Plugins/PluginManager"
 
 import { noop } from "./../Utility"
 
+import * as Common from "./../UI/components/common"
+
+import styled from "styled-components"
+
+const PluginIconWrapper = styled.div`
+    background-color: rgba(0, 0, 0, 0.1);
+    width: 36px;
+    height: 36px;
+`
+
+const PluginCommandsWrapper = styled.div`
+    flex: 0 0 auto;
+`
+
+const PluginInfoWrapper = styled.div`
+    flex: 1 1 auto;
+    width: 100%;
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    margin-left: 8px;
+    margin-right: 8px;
+`
+
+const PluginTitleWrapper = styled.div`
+    font-size: 1.1em;
+`
+
+export interface PluginSidebarItemViewProps {
+    name: string
+}
+
+export class PluginSidebarItemView extends React.PureComponent<PluginSidebarItemViewProps, {}> {
+    public render(): JSX.Element {
+        return (
+            <Common.Container direction={"horizontal"} fullWidth={true}>
+                <Common.Fixed style={{ width: "40px", height: "40px" }}>
+                    <Common.Center>
+                        <PluginIconWrapper />
+                    </Common.Center>
+                </Common.Fixed>
+                <PluginInfoWrapper>
+                    <PluginTitleWrapper>{this.props.name}</PluginTitleWrapper>
+                </PluginInfoWrapper>
+                <PluginCommandsWrapper />
+            </Common.Container>
+        )
+    }
+}
+
 export class PluginsSidebarPane implements SidebarPane {
     private _onEnter = new Event<void>()
     private _onLeave = new Event<void>()
@@ -62,6 +112,7 @@ export interface IPluginsSidebarPaneViewState {
     isActive: boolean
     defaultPluginsExpanded: boolean
     userPluginsExpanded: boolean
+    workspacePluginsExpanded: boolean
 }
 
 export class PluginsSidebarPaneView extends React.PureComponent<
@@ -77,6 +128,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
             isActive: false,
             defaultPluginsExpanded: false,
             userPluginsExpanded: true,
+            workspacePluginsExpanded: false,
         }
     }
 
@@ -107,6 +159,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
         const allIds = [
             "container.default",
             ...defaultPluginIds,
+            "container.workspace",
             "container.user",
             ...userPluginIds,
         ]
@@ -122,7 +175,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             indentationLevel={0}
                             isFocused={p.id === selectedId}
                             isContainer={false}
-                            text={p.id}
+                            text={<PluginSidebarItemView name={p.name || p.id} />}
                             onClick={noop}
                         />
                     ))
@@ -132,7 +185,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             indentationLevel={0}
                             isFocused={p.id === selectedId}
                             isContainer={false}
-                            text={p.id}
+                            text={<PluginSidebarItemView name={p.name || p.id} />}
                             onClick={noop}
                         />
                     ))
@@ -144,16 +197,25 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                                 isContainer={true}
                                 isExpanded={this.state.defaultPluginsExpanded}
                                 isFocused={selectedId === "container.default"}
-                                onClick={noop}
+                                onClick={() => this._onSelect("container.default")}
                             >
                                 {defaultPluginItems}
+                            </SidebarContainerView>
+                            <SidebarContainerView
+                                text={"Workspace"}
+                                isContainer={true}
+                                isExpanded={this.state.workspacePluginsExpanded}
+                                isFocused={selectedId === "container.workspace"}
+                                onClick={() => this._onSelect("container.workspace")}
+                            >
+                                {[]}
                             </SidebarContainerView>
                             <SidebarContainerView
                                 text={"User"}
                                 isContainer={true}
                                 isExpanded={this.state.userPluginsExpanded}
                                 isFocused={selectedId === "container.user"}
-                                onClick={noop}
+                                onClick={() => this._onSelect("container.user")}
                             >
                                 {userPluginItems}
                             </SidebarContainerView>

--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -115,6 +115,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
             <VimNavigator
                 ids={allIds}
                 active={this.state.isActive}
+                onSelected={id => this._onSelect(id)}
                 render={(selectedId: string) => {
                     const defaultPluginItems = defaultPlugins.map(p => (
                         <SidebarItemView
@@ -139,7 +140,8 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                     return (
                         <div>
                             <SidebarContainerView
-                                text={"Default"}
+                                text={"Bundled"}
+                                isContainer={true}
                                 isExpanded={this.state.defaultPluginsExpanded}
                                 isFocused={selectedId === "container.default"}
                                 onClick={noop}
@@ -148,6 +150,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                             </SidebarContainerView>
                             <SidebarContainerView
                                 text={"User"}
+                                isContainer={true}
                                 isExpanded={this.state.userPluginsExpanded}
                                 isFocused={selectedId === "container.user"}
                                 onClick={noop}
@@ -159,6 +162,29 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                 }}
             />
         )
+    }
+
+    private _onSelect(id: string): void {
+        switch (id) {
+            case "container.default":
+                this._toggleDefaultPluginsExpanded()
+                return
+            case "container.user":
+                this._toggleUserPluginsExpanded()
+                return
+        }
+    }
+
+    private _toggleDefaultPluginsExpanded(): void {
+        this.setState({
+            defaultPluginsExpanded: !this.state.defaultPluginsExpanded,
+        })
+    }
+
+    private _toggleUserPluginsExpanded(): void {
+        this.setState({
+            userPluginsExpanded: !this.state.userPluginsExpanded,
+        })
     }
 
     private _clearExistingSubscriptions(): void {


### PR DESCRIPTION
We currently have a plugins sidebar pane, but it's gated by this flag - `sidebar.plugins.enabled` (which defaults to `false` right now). It's not very usable, but this is a first round of improvements.

__Before:__
![image](https://user-images.githubusercontent.com/13532591/39668072-da307f0e-5078-11e8-87e8-066d3bab0c30.png)

__After:__
![image](https://user-images.githubusercontent.com/13532591/39668077-e800041a-5078-11e8-98b0-226add61b84c.png)

Starting to carve out room for an icon, version number, as well as information about the run state.

The plan is for these sidebar items to be an entry point to more detailed information about the plugin, as a buffer layer.

Next steps after this PR:
- [ ] Add UI to show whether or not the plugin is 'enabled' or 'disabled'
- [ ] Start the 'buffer layer' to show more detailed information about the plugin, capabilities, configuration, etc.


