### PR TITLE
Bugfix/ pass selected tab  id to sneak callback

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -176,7 +176,7 @@ export class Tab extends React.PureComponent<ITabPropsWithClick> {
         }
 
         return (
-            <Sneakable callback={this.props.onClickName}>
+            <Sneakable callback={() => this.props.onClickName(this.props.id)}>
                 <TabWrapper
                     innerRef={(e: IChromeDivElement) => (this._tab = e)}
                     className={cssClasses}


### PR DESCRIPTION
Noted since #2171 that trying to sneak between tabs no longer worked, this seems to be due to to the selected tab id not being passed to the sneak handler. This PR re-adds the argument for the handler fixing the functionality