### PR TITLE
Feature/add latex preview

### DIFF
--- a/extensions/oni-plugin-markdown-preview/package.json
+++ b/extensions/oni-plugin-markdown-preview/package.json
@@ -22,6 +22,7 @@
     },
     "tbd-dependencies": {
         "marked": "^0.3.6",
+        "mathjax": "^2.7.4",
         "dompurify": "1.0.2",
         "oni-types": "^0.0.4",
         "oni-api": "^0.0.9"

--- a/package.json
+++ b/package.json
@@ -694,6 +694,7 @@
         "fs-extra": "^5.0.0",
         "keyboard-layout": "^2.0.13",
         "marked": "^0.3.6",
+        "mathjax-electron": "^2.0.1",
         "minimist": "1.2.0",
         "msgpack-lite": "0.1.26",
         "ocaml-language-server": "^1.0.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6536,6 +6536,10 @@ math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
 
+mathjax-electron@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mathjax-electron/-/mathjax-electron-2.0.1.tgz#da044a0bf9fff470e01c0fb31974bc7986e7323d"
+
 md5-hex@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"


### PR DESCRIPTION
Hi,

Added a Latex-preview to the current markdown-preview plugin.
My intention is for that plugin to be a previewer for static data like Markdown, Latex, (maybe) HTML, etc.
Is this acceptable?

Also, there is a huge diff in `package.json` and `yarn.lock` - will try to get rid of the bloatware.