### PR TITLE
Feature: Sneak tags for automation

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -31,6 +31,7 @@ import { getInstance as getNotificationsInstance } from "./../../Services/Notifi
 import { getInstance as getOverlayInstance } from "./../../Services/Overlay"
 import { recorder } from "./../../Services/Recorder"
 import { getInstance as getSidebarInstance } from "./../../Services/Sidebar"
+import { getInstance as getSneakInstance } from "./../../Services/Sneak"
 import { getInstance as getSnippetsInstance } from "./../../Services/Snippets"
 import { getInstance as getStatusBarInstance } from "./../../Services/StatusBar"
 import { getInstance as getTokenColorsInstance } from "./../../Services/TokenColors"
@@ -139,6 +140,10 @@ export class Oni implements OniApi.Plugin.Api {
 
     public get sidebar(): any {
         return getSidebarInstance()
+    }
+
+    public get sneak(): any {
+        return getSneakInstance()
     }
 
     public get snippets(): OniApi.Snippets.SnippetManager {

--- a/browser/src/Services/Browser/AddressBarView.tsx
+++ b/browser/src/Services/Browser/AddressBarView.tsx
@@ -80,7 +80,7 @@ export class AddressBarView extends React.PureComponent<
 
     private _renderAddressSpan(): JSX.Element {
         return (
-            <Sneakable callback={() => this._setActive()}>
+            <Sneakable callback={() => this._setActive()} tag={"browser.address"}>
                 <span onClick={() => this._setActive()}>{this.props.url}</span>
             </Sneakable>
         )

--- a/browser/src/Services/Sidebar/SidebarView.tsx
+++ b/browser/src/Services/Sidebar/SidebarView.tsx
@@ -17,6 +17,7 @@ import { withProps } from "./../../UI/components/common"
 import { Sneakable } from "./../../UI/components/Sneakable"
 
 export interface ISidebarIconProps {
+    id: string
     active: boolean
     focused: boolean
     iconName: string
@@ -90,7 +91,7 @@ export class SidebarIcon extends React.PureComponent<ISidebarIconProps, {}> {
     public render(): JSX.Element {
         const notification = this.props.hasNotification ? <SidebarIconNotification /> : null
         return (
-            <Sneakable callback={this.props.onClick}>
+            <Sneakable callback={this.props.onClick} tag={this.props.id}>
                 <SidebarIconWrapper {...this.props} tabIndex={0}>
                     <SidebarIconInner>
                         <Icon name={this.props.iconName} size={IconSize.Large} />

--- a/browser/src/Services/Sidebar/SidebarView.tsx
+++ b/browser/src/Services/Sidebar/SidebarView.tsx
@@ -155,6 +155,7 @@ export class SidebarView extends React.PureComponent<ISidebarViewProps, {}> {
                             const isFocused = e.id === selectedId && this.props.isActive
                             return (
                                 <SidebarIcon
+                                    id={e.id}
                                     key={e.id}
                                     iconName={e.icon}
                                     active={isActive}

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -12,7 +12,7 @@ import { Event, IDisposable, IEvent } from "oni-types"
 
 import { Overlay, OverlayManager } from "./../Overlay"
 
-import { createStore as createSneakStore, ISneakInfo, ISneakState } from "./SneakStore"
+import { createStore as createSneakStore, ISneakInfo, ISneakState, IAugmentedSneakInfo } from "./SneakStore"
 import { ConnectedSneakView } from "./SneakView"
 
 export type SneakProvider = () => Promise<ISneakInfo[]>
@@ -39,6 +39,23 @@ export class Sneak {
         this._providers.push(provider)
         const dispose = () => (this._providers = this._providers.filter(prov => prov !== provider))
         return { dispose }
+    }
+
+    // Get the first sneak with a 'tag' matching the passed in tag
+    public getSneakMatchingTag(tag: string): IAugmentedSneakInfo | null {
+
+        if (!this.isActive) {
+            return null
+        }
+
+        const sneaks = this._store.getState().sneaks
+
+        if (sneaks || sneaks.length === 0) {
+            return null
+        }
+
+        return sneaks.find(s => s.tag && s.tag === tag)
+        
     }
 
     public show(): void {

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -12,7 +12,7 @@ import { Event, IDisposable, IEvent } from "oni-types"
 
 import { Overlay, OverlayManager } from "./../Overlay"
 
-import { createStore as createSneakStore, ISneakInfo, ISneakState, IAugmentedSneakInfo } from "./SneakStore"
+import { createStore as createSneakStore, IAugmentedSneakInfo, ISneakInfo, ISneakState } from "./SneakStore"
 import { ConnectedSneakView } from "./SneakView"
 
 export type SneakProvider = () => Promise<ISneakInfo[]>
@@ -55,7 +55,7 @@ export class Sneak {
         }
 
         return sneaks.find(s => s.tag && s.tag === tag)
-        
+
     }
 
     public show(): void {

--- a/browser/src/Services/Sneak/SneakStore.ts
+++ b/browser/src/Services/Sneak/SneakStore.ts
@@ -13,6 +13,9 @@ import { createStore as createReduxStore } from "./../../Redux"
 export interface ISneakInfo {
     rectangle: Shapes.Rectangle
     callback: () => void
+
+    // `tag` is an optional string used to identify the sneak
+    tag?: string
 }
 
 export interface IAugmentedSneakInfo extends ISneakInfo {

--- a/browser/src/UI/components/Sneakable.tsx
+++ b/browser/src/UI/components/Sneakable.tsx
@@ -14,6 +14,7 @@ import { /* SneakProvider, Sneak,*/ getInstance as getSneak } from "./../../Serv
 import { EmptyArray } from "./../../Utility"
 
 export interface ISneakableProps {
+    tag?: string
     callback?: (evt?: any) => void
 }
 
@@ -39,6 +40,7 @@ export class Sneakable extends React.PureComponent<ISneakableProps, {}> {
                             rect.width,
                             rect.height,
                         ),
+                        tag: this.props.tag || null,
                     },
                 ]
             } else {


### PR DESCRIPTION
__Issue:__ When trying to write automated tests against Sneak, it can be difficult because the order of sneak tag evaluation is not always deterministic (it depends on the order sneak providers are evaluated).

__Fix:__ For now - have a more explicit way to get a specific sneak entry, so that automation can know which key sequence triggers it.

Later, we might want a more thorough solution - the non-determinism might be annoying for users too, if commonly used items switch keys.