### PR TITLE
Feature - Buffer Layers: Add 'visibleLines' to the context for buffer layers

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -40,7 +40,7 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
             const layers =
                 this.props.layers[windowState.bufferId] || (EmptyArray as Oni.BufferLayer[])
 
-            const layerContext = {
+            const layerContext: Oni.BufferLayerRenderContext = {
                 isActive: windowState.windowId === this.props.activeWindowId,
                 windowId: windowState.windowId,
                 fontPixelWidth: this.props.fontPixelWidth,
@@ -50,6 +50,8 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
                 bufferToPixel: windowState.bufferToPixel,
                 dimensions: windowState.dimensions,
                 visibleLines: windowState.visibleLines,
+                topBufferLine: windowState.topBufferLine,
+                bottomBufferLine: windowState.bottomBufferLine,
             }
 
             const layerElements = layers.map(l => {

--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -42,12 +42,13 @@ export class NeovimBufferLayersView extends React.PureComponent<NeovimBufferLaye
             const layerContext = {
                 isActive: windowState.windowId === this.props.activeWindowId,
                 windowId: windowState.windowId,
-
                 fontPixelWidth: this.props.fontPixelWidth,
                 fontPixelHeight: this.props.fontPixelHeight,
                 bufferToScreen: windowState.bufferToScreen,
                 screenToPixel: windowState.screenToPixel,
+                bufferToPixel: windowState.bufferToPixel,
                 dimensions: windowState.dimensions,
+                visibleLines: windowState.visibleLines,
             }
 
             const layerElements = layers.map(l => {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -408,6 +408,7 @@ export class NeovimEditor extends Editor implements IEditor {
                         activeWindow.topBufferLine,
                         activeWindow.dimensions,
                         activeWindow.bufferToScreen,
+                        activeWindow.visibleLines,
                     )
                 }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -225,9 +225,11 @@ export interface ISetWindowState {
 
         bufferToScreen: Oni.Coordinates.BufferToScreen
         screenToPixel: Oni.Coordinates.ScreenToPixel
+        bufferToPixel: any /* TODO */
 
         topBufferLine: number
         bottomBufferLine: number
+        visibleLines: string[]
     }
 }
 
@@ -516,6 +518,7 @@ export const setWindowCursor = (windowId: number, line: number, column: number) 
     },
 })
 
+
 export const setWindowState = (
     windowId: number,
     bufferId: number,
@@ -526,6 +529,7 @@ export const setWindowState = (
     topBufferLine: number,
     dimensions: Oni.Shapes.Rectangle,
     bufferToScreen: Oni.Coordinates.BufferToScreen,
+    visibleLines: string[],
 ) => (dispatch: DispatchFunction, getState: GetStateFunction) => {
     const { fontPixelWidth, fontPixelHeight } = getState()
 
@@ -547,6 +551,16 @@ export const setWindowState = (
         }
     }
 
+    const bufferToPixel = (position: types.Position): Oni.Coordinates.PixelSpacePoint => {
+        const screenPosition = bufferToScreen(position)
+        
+        if (!screenPosition) {
+            return null
+        }
+
+        return screenToPixel(screenPosition)
+    }
+
     dispatch({
         type: "SET_WINDOW_STATE",
         payload: {
@@ -558,8 +572,10 @@ export const setWindowState = (
             line,
             bufferToScreen,
             screenToPixel,
+            bufferToPixel,
             bottomBufferLine,
             topBufferLine,
+            visibleLines,
         },
     })
 }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -225,7 +225,7 @@ export interface ISetWindowState {
 
         bufferToScreen: Oni.Coordinates.BufferToScreen
         screenToPixel: Oni.Coordinates.ScreenToPixel
-        bufferToPixel: any /* TODO */
+        bufferToPixel: Oni.Coordinates.BufferToPixel
 
         topBufferLine: number
         bottomBufferLine: number

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -518,7 +518,6 @@ export const setWindowCursor = (windowId: number, line: number, column: number) 
     },
 })
 
-
 export const setWindowState = (
     windowId: number,
     bufferId: number,
@@ -553,7 +552,7 @@ export const setWindowState = (
 
     const bufferToPixel = (position: types.Position): Oni.Coordinates.PixelSpacePoint => {
         const screenPosition = bufferToScreen(position)
-        
+
         if (!screenPosition) {
             return null
         }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
@@ -413,10 +413,12 @@ export const windowStateReducer = (
                         line: a.payload.line,
                         bufferToScreen: a.payload.bufferToScreen,
                         screenToPixel: a.payload.screenToPixel,
+                        bufferToPixel: a.payload.bufferToPixel,
                         dimensions: a.payload.dimensions,
 
                         topBufferLine: a.payload.topBufferLine,
                         bottomBufferLine: a.payload.bottomBufferLine,
+                        visibleLines: a.payload.visibleLines,
                     },
                 },
             }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
@@ -159,7 +159,7 @@ export interface IWindow {
 
     bufferToScreen: Oni.Coordinates.BufferToScreen
     screenToPixel: Oni.Coordinates.ScreenToPixel
-    bufferToPixel: any /* TODO: Oni.Coordinates.BufferToPixel */
+    bufferToPixel: Oni.Coordinates.BufferToPixel
 
     dimensions: Oni.Shapes.Rectangle
     topBufferLine: number

--- a/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
@@ -159,10 +159,13 @@ export interface IWindow {
 
     bufferToScreen: Oni.Coordinates.BufferToScreen
     screenToPixel: Oni.Coordinates.ScreenToPixel
+    bufferToPixel: any /* TODO: Oni.Coordinates.BufferToPixel */
 
     dimensions: Oni.Shapes.Rectangle
     topBufferLine: number
     bottomBufferLine: number
+
+    visibleLines: string[]
 }
 
 export function readConf<K extends keyof IConfigurationValues>(

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -39,6 +39,8 @@ export interface NeovimActiveWindowState {
     topBufferLine: number
     bottomBufferLine: number
 
+    visibleLines: string[]
+
     bufferToScreen: Oni.Coordinates.BufferToScreen
     dimensions: Oni.Shapes.Rectangle
 }
@@ -235,6 +237,7 @@ export class NeovimWindowManager extends Utility.Disposable {
                 bottomBufferLine: context.windowBottomLine - 1,
                 topBufferLine: context.windowTopLine,
                 dimensions,
+                visibleLines: lines || [],
                 bufferToScreen: getBufferToScreenFromRanges(offset, expandedWidthRanges),
             }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
     "homepage": "https://www.onivim.io",
     "version": "0.3.5",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
-    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
+    "keywords": [
+        "vim",
+        "neovim",
+        "text",
+        "editor",
+        "ide",
+        "vim"
+    ],
     "main": "./lib/main/src/main.js",
     "bin": {
         "oni": "./cli/oni",
@@ -44,23 +51,39 @@
         "mac": {
             "artifactName": "${productName}-${version}-osx.${ext}",
             "category": "public.app-category.developer-tools",
-            "target": ["dmg"],
-            "files": ["bin/osx/**/*"]
+            "target": [
+                "dmg"
+            ],
+            "files": [
+                "bin/osx/**/*"
+            ]
         },
         "linux": {
             "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
             "maintainer": "bryphe@outlook.com",
-            "target": ["tar.gz", "deb", "rpm"]
+            "target": [
+                "tar.gz",
+                "deb",
+                "rpm"
+            ]
         },
         "win": {
-            "target": ["zip", "dir"],
-            "files": ["bin/x86/**/*"]
+            "target": [
+                "zip",
+                "dir"
+            ],
+            "files": [
+                "bin/x86/**/*"
+            ]
         },
         "fileAssociations": [
             {
                 "name": "ADA source",
                 "role": "Editor",
-                "ext": ["adb", "ads"]
+                "ext": [
+                    "adb",
+                    "ads"
+                ]
             },
             {
                 "name": "Compiled AppleScript",
@@ -80,12 +103,20 @@
             {
                 "name": "ASP document",
                 "role": "Editor",
-                "ext": ["asp", "asa"]
+                "ext": [
+                    "asp",
+                    "asa"
+                ]
             },
             {
                 "name": "ASP.NET document",
                 "role": "Editor",
-                "ext": ["aspx", "ascx", "asmx", "ashx"]
+                "ext": [
+                    "aspx",
+                    "ascx",
+                    "asmx",
+                    "ashx"
+                ]
             },
             {
                 "name": "BibTeX bibliography",
@@ -100,7 +131,13 @@
             {
                 "name": "C++ source",
                 "role": "Editor",
-                "ext": ["cc", "cp", "cpp", "cxx", "c++"]
+                "ext": [
+                    "cc",
+                    "cp",
+                    "cpp",
+                    "cxx",
+                    "c++"
+                ]
             },
             {
                 "name": "C# source",
@@ -125,7 +162,10 @@
             {
                 "name": "Clojure source",
                 "role": "Editor",
-                "ext": ["clj", "cljs"]
+                "ext": [
+                    "clj",
+                    "cljs"
+                ]
             },
             {
                 "name": "Comma separated values",
@@ -140,12 +180,20 @@
             {
                 "name": "CGI script",
                 "role": "Editor",
-                "ext": ["cgi", "fcgi"]
+                "ext": [
+                    "cgi",
+                    "fcgi"
+                ]
             },
             {
                 "name": "Configuration file",
                 "role": "Editor",
-                "ext": ["cfg", "conf", "config", "htaccess"]
+                "ext": [
+                    "cfg",
+                    "conf",
+                    "config",
+                    "htaccess"
+                ]
             },
             {
                 "name": "Cascading style sheet",
@@ -170,7 +218,10 @@
             {
                 "name": "Erlang source",
                 "role": "Editor",
-                "ext": ["erl", "hrl"]
+                "ext": [
+                    "erl",
+                    "hrl"
+                ]
             },
             {
                 "name": "F-Script source",
@@ -180,17 +231,32 @@
             {
                 "name": "Fortran source",
                 "role": "Editor",
-                "ext": ["f", "for", "fpp", "f77", "f90", "f95"]
+                "ext": [
+                    "f",
+                    "for",
+                    "fpp",
+                    "f77",
+                    "f90",
+                    "f95"
+                ]
             },
             {
                 "name": "Header",
                 "role": "Editor",
-                "ext": ["h", "pch"]
+                "ext": [
+                    "h",
+                    "pch"
+                ]
             },
             {
                 "name": "C++ header",
                 "role": "Editor",
-                "ext": ["hh", "hpp", "hxx", "h++"]
+                "ext": [
+                    "hh",
+                    "hpp",
+                    "hxx",
+                    "h++"
+                ]
             },
             {
                 "name": "Go source",
@@ -200,17 +266,28 @@
             {
                 "name": "GTD document",
                 "role": "Editor",
-                "ext": ["gtd", "gtdlog"]
+                "ext": [
+                    "gtd",
+                    "gtdlog"
+                ]
             },
             {
                 "name": "Haskell source",
                 "role": "Editor",
-                "ext": ["hs", "lhs"]
+                "ext": [
+                    "hs",
+                    "lhs"
+                ]
             },
             {
                 "name": "HTML document",
                 "role": "Editor",
-                "ext": ["htm", "html", "phtml", "shtml"]
+                "ext": [
+                    "htm",
+                    "html",
+                    "phtml",
+                    "shtml"
+                ]
             },
             {
                 "name": "Include file",
@@ -250,7 +327,10 @@
             {
                 "name": "JavaScript source",
                 "role": "Editor",
-                "ext": ["js", "htc"]
+                "ext": [
+                    "js",
+                    "htc"
+                ]
             },
             {
                 "name": "Java Server Page",
@@ -275,7 +355,14 @@
             {
                 "name": "Lisp source",
                 "role": "Editor",
-                "ext": ["lisp", "cl", "l", "lsp", "mud", "el"]
+                "ext": [
+                    "lisp",
+                    "cl",
+                    "l",
+                    "lsp",
+                    "mud",
+                    "el"
+                ]
             },
             {
                 "name": "Log file",
@@ -295,7 +382,12 @@
             {
                 "name": "Markdown document",
                 "role": "Editor",
-                "ext": ["markdown", "mdown", "markdn", "md"]
+                "ext": [
+                    "markdown",
+                    "mdown",
+                    "markdn",
+                    "md"
+                ]
             },
             {
                 "name": "Makefile source",
@@ -305,17 +397,29 @@
             {
                 "name": "Mediawiki document",
                 "role": "Editor",
-                "ext": ["wiki", "wikipedia", "mediawiki"]
+                "ext": [
+                    "wiki",
+                    "wikipedia",
+                    "mediawiki"
+                ]
             },
             {
                 "name": "MIPS assembler source",
                 "role": "Editor",
-                "ext": ["s", "mips", "spim", "asm"]
+                "ext": [
+                    "s",
+                    "mips",
+                    "spim",
+                    "asm"
+                ]
             },
             {
                 "name": "Modula-3 source",
                 "role": "Editor",
-                "ext": ["m3", "cm3"]
+                "ext": [
+                    "m3",
+                    "cm3"
+                ]
             },
             {
                 "name": "MoinMoin document",
@@ -335,17 +439,28 @@
             {
                 "name": "OCaml source",
                 "role": "Editor",
-                "ext": ["ml", "mli", "mll", "mly"]
+                "ext": [
+                    "ml",
+                    "mli",
+                    "mll",
+                    "mly"
+                ]
             },
             {
                 "name": "Mustache document",
                 "role": "Editor",
-                "ext": ["mustache", "hbs"]
+                "ext": [
+                    "mustache",
+                    "hbs"
+                ]
             },
             {
                 "name": "Pascal source",
                 "role": "Editor",
-                "ext": ["pas", "p"]
+                "ext": [
+                    "pas",
+                    "p"
+                ]
             },
             {
                 "name": "Patch file",
@@ -355,7 +470,11 @@
             {
                 "name": "Perl source",
                 "role": "Editor",
-                "ext": ["pl", "pod", "perl"]
+                "ext": [
+                    "pl",
+                    "pod",
+                    "perl"
+                ]
             },
             {
                 "name": "Perl module",
@@ -365,47 +484,80 @@
             {
                 "name": "PHP source",
                 "role": "Editor",
-                "ext": ["php", "php3", "php4", "php5"]
+                "ext": [
+                    "php",
+                    "php3",
+                    "php4",
+                    "php5"
+                ]
             },
             {
                 "name": "PostScript source",
                 "role": "Editor",
-                "ext": ["ps", "eps"]
+                "ext": [
+                    "ps",
+                    "eps"
+                ]
             },
             {
                 "name": "Property list",
                 "role": "Editor",
-                "ext": ["dict", "plist", "scriptSuite", "scriptTerminology"]
+                "ext": [
+                    "dict",
+                    "plist",
+                    "scriptSuite",
+                    "scriptTerminology"
+                ]
             },
             {
                 "name": "Python source",
                 "role": "Editor",
-                "ext": ["py", "rpy", "cpy", "python"]
+                "ext": [
+                    "py",
+                    "rpy",
+                    "cpy",
+                    "python"
+                ]
             },
             {
                 "name": "R source",
                 "role": "Editor",
-                "ext": ["r", "s"]
+                "ext": [
+                    "r",
+                    "s"
+                ]
             },
             {
                 "name": "Ragel source",
                 "role": "Editor",
-                "ext": ["rl", "ragel"]
+                "ext": [
+                    "rl",
+                    "ragel"
+                ]
             },
             {
                 "name": "Remind document",
                 "role": "Editor",
-                "ext": ["rem", "remind"]
+                "ext": [
+                    "rem",
+                    "remind"
+                ]
             },
             {
                 "name": "reStructuredText document",
                 "role": "Editor",
-                "ext": ["rst", "rest"]
+                "ext": [
+                    "rst",
+                    "rest"
+                ]
             },
             {
                 "name": "HTML with embedded Ruby",
                 "role": "Editor",
-                "ext": ["rhtml", "erb"]
+                "ext": [
+                    "rhtml",
+                    "erb"
+                ]
             },
             {
                 "name": "SQL with embedded Ruby",
@@ -415,17 +567,28 @@
             {
                 "name": "Ruby source",
                 "role": "Editor",
-                "ext": ["rb", "rbx", "rjs", "rxml"]
+                "ext": [
+                    "rb",
+                    "rbx",
+                    "rjs",
+                    "rxml"
+                ]
             },
             {
                 "name": "Sass source",
                 "role": "Editor",
-                "ext": ["sass", "scss"]
+                "ext": [
+                    "sass",
+                    "scss"
+                ]
             },
             {
                 "name": "Scheme source",
                 "role": "Editor",
-                "ext": ["scm", "sch"]
+                "ext": [
+                    "scm",
+                    "sch"
+                ]
             },
             {
                 "name": "Setext document",
@@ -473,7 +636,10 @@
             {
                 "name": "SWIG source",
                 "role": "Editor",
-                "ext": ["i", "swg"]
+                "ext": [
+                    "i",
+                    "swg"
+                ]
             },
             {
                 "name": "Tcl source",
@@ -483,12 +649,20 @@
             {
                 "name": "TeX document",
                 "role": "Editor",
-                "ext": ["tex", "sty", "cls"]
+                "ext": [
+                    "tex",
+                    "sty",
+                    "cls"
+                ]
             },
             {
                 "name": "Plain text document",
                 "role": "Editor",
-                "ext": ["text", "txt", "utf8"]
+                "ext": [
+                    "text",
+                    "txt",
+                    "utf8"
+                ]
             },
             {
                 "name": "Textile document",
@@ -508,17 +682,32 @@
             {
                 "name": "XML document",
                 "role": "Editor",
-                "ext": ["xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml"]
+                "ext": [
+                    "xml",
+                    "xsd",
+                    "xib",
+                    "rss",
+                    "tld",
+                    "pt",
+                    "cpt",
+                    "dtml"
+                ]
             },
             {
                 "name": "XSL stylesheet",
                 "role": "Editor",
-                "ext": ["xsl", "xslt"]
+                "ext": [
+                    "xsl",
+                    "xslt"
+                ]
             },
             {
                 "name": "Electronic business card",
                 "role": "Editor",
-                "ext": ["vcf", "vcard"]
+                "ext": [
+                    "vcf",
+                    "vcard"
+                ]
             },
             {
                 "name": "Visual Basic source",
@@ -528,7 +717,10 @@
             {
                 "name": "YAML document",
                 "role": "Editor",
-                "ext": ["yaml", "yml"]
+                "ext": [
+                    "yaml",
+                    "yml"
+                ]
             },
             {
                 "name": "Text document",
@@ -590,95 +782,65 @@
     "scripts": {
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
-        "build":
-            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
-        "build-debug":
-            "yarn run build:browser-debug && yarn run build:main && yarn run build:plugins",
+        "build": "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
+        "build-debug": "yarn run build:browser-debug && yarn run build:main && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
         "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
         "build:main": "cd main && tsc -p tsconfig.json",
-        "build:plugins":
-            "yarn run build:plugin:oni-plugin-typescript && yarn run build:plugin:oni-plugin-markdown-preview",
+        "build:plugins": "yarn run build:plugin:oni-plugin-typescript && yarn run build:plugin:oni-plugin-markdown-preview",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
-        "build:plugin:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn run build",
+        "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:test": "yarn run build:test:unit && yarn run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "yarn run build:test:unit:browser && yarn run build:test:unit:main",
-        "build:test:unit:browser":
-            "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit:browser": "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
         "build:test:unit:main": "rimraf lib_test/main && cd main && tsc -p tsconfig.test.json",
         "build:webview_preload": "cd webview_preload && tsc -p tsconfig.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
-        "debug:test:unit:browser":
-            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "demo:screenshot":
-            "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
-        "demo:video":
-            "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
-        "dist:win:x86":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-        "dist:win:x64":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
-        "pack:win":
-            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo:screenshot": "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
+        "demo:video": "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
+        "dist:win:x86": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "dist:win:x64": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
+        "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "yarn run test:unit && yarn run test:integration",
-        "test:integration":
-            "yarn run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
+        "test:integration": "yarn run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:react": "jest --config ./jest.config.js ./ui-tests",
         "test:react:watch": "jest --config ./jest.config.js ./ui-tests --watch",
         "test:react:coverage": "jest --config ./jest.config.js ./ui-tests --coverage",
-        "test:unit:browser":
-            "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "test:unit:browser": "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
         "test:unit": "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:react",
-        "test:unit:main":
-            "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
+        "test:unit:main": "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
         "upload:dist": "node build/script/UploadDistributionBuildsToAzure",
         "fix-lint": "yarn run fix-lint:browser && yarn run fix-lint:main && yarn run fix-lint:test",
-        "fix-lint:browser":
-            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
         "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
         "lint": "yarn run lint:browser && yarn run lint:main && yarn run lint:test",
-        "lint:browser":
-            "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-        "lint:test":
-            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "ccov:instrument":
-            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-        "ccov:test:browser":
-            "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
-        "ccov:remap:browser:html":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
-        "ccov:remap:browser:lcov":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
+        "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser": "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
+        "ccov:remap:browser:html": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
+        "ccov:remap:browser:lcov": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
         "ccov:clean": "rimraf coverage",
         "ccov:upload": "codecov",
         "launch": "electron lib/main/src/main.js",
-        "start":
-            "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
-        "start-hot":
-            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start": "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
+        "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
         "start-not-dev": "cross-env electron main.js",
-        "watch:browser":
-            "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
-        "watch:plugins":
-            "yarn run watch:plugins:oni-plugin-typescript && yarn run watch:plugins:oni-plugin-markdown-preview",
+        "watch:browser": "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
+        "watch:plugins": "yarn run watch:plugins:oni-plugin-typescript && yarn run watch:plugins:oni-plugin-markdown-preview",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-        "watch:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
-        "install:plugins":
-            "yarn run install:plugins:oni-plugin-markdown-preview && yarn run install:plugins:oni-plugin-prettier",
-        "install:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
-        "install:plugins:oni-plugin-prettier":
-            "cd extensions/oni-plugin-prettier && yarn install --prod",
+        "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "install:plugins": "yarn run install:plugins:oni-plugin-markdown-preview && yarn run install:plugins:oni-plugin-prettier",
+        "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-prettier": "cd extensions/oni-plugin-prettier && yarn install --prod",
         "postinstall": "yarn run install:plugins && electron-rebuild && opencollective postinstall",
-        "profile:webpack":
-            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
+        "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
     "repository": {
         "type": "git",
@@ -698,7 +860,7 @@
         "minimist": "1.2.0",
         "msgpack-lite": "0.1.26",
         "ocaml-language-server": "^1.0.27",
-        "oni-api": "^0.0.42",
+        "oni-api": "^0.0.44",
         "oni-neovim-binaries": "0.1.1",
         "oni-ripgrep": "0.0.4",
         "oni-types": "0.0.4",

--- a/test/ci/Api.Buffer.AddLayer.tsx
+++ b/test/ci/Api.Buffer.AddLayer.tsx
@@ -26,9 +26,7 @@ export class TestLayer implements Oni.BufferLayer {
             className += "inactive"
         }
 
-        const contextAsAny = context as any
-
-        return <div className={className}>{contextAsAny.visibleLines.join(os.EOL)}</div>
+        return <div className={className}>{context.visibleLines.join(os.EOL)}</div>
     }
 }
 

--- a/test/ci/Api.Buffer.AddLayer.tsx
+++ b/test/ci/Api.Buffer.AddLayer.tsx
@@ -26,7 +26,9 @@ export class TestLayer implements Oni.BufferLayer {
             className += "inactive"
         }
 
-        return <div className={className} />
+        const contextAsAny = context as any
+
+        return <div className={className}>{contextAsAny.visibleLines.join(os.EOL)}</div>
     }
 }
 
@@ -45,12 +47,17 @@ const getInactiveLayerElements = () => {
 export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
 
-    await createNewFile("js", oni)
+    await createNewFile("js", oni, "line1\nline2")
 
     oni.editors.activeEditor.activeBuffer.addLayer(new TestLayer())
 
     // Wait for layer to appear
     await oni.automation.waitFor(() => getLayerElements().length === 1)
+
+    // Validate the buffer layer has rendered the 'visibleLines'
+    const element = getLayerElements()[0]
+    assert.ok(element.textContent.indexOf("line1") >= 0, "Validate line1 is present in the layer")
+    assert.ok(element.textContent.indexOf("line2") >= 0, "Validate line2 is present in the layer")
 
     // Validate elements
     assert.strictEqual(getActiveLayerElements().length, 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7326,9 +7326,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@^0.0.42:
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.42.tgz#79cab4289809bda1c7b86590119f0c7aaa5a053e"
+oni-api@^0.0.44:
+  version "0.0.44"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.44.tgz#26e4999ba5da0be0e7f25b6705c2d5412fe4eb23"
 
 oni-neovim-binaries@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
This feature adds two new pieces of functionality to buffer layers:
- `visibleLines` - the text currently visible in a buffer window
- `bufferToPixel` - given a buffer position (line, column), this returns the pixel position in the window

We actually were already gathering all this info in `NeovimWindowManager`, this just plumbs it through so that the buffer layers have access to it.

The motivation for this is to allow for even richer types of buffer layers - it's often the case that the buffer layer is dependent on the current visible text. An example would be implementing something like indent guides in #836 - we could implement a buffer layer like:

```
export class IndentGuideBufferLayer implements Oni.BufferLayer {
      public render(bufferLayerContext: Oni.BufferLayerContext): JSX.Element[] {
             return bufferLayerContext.visibleLines.map((line, idx) => {
                  return <IndentGuide line={line} y={bufferLayerContext.screenToPixel(0, idx).pixelY} height={bufferLayerContext.fontPixelHeight} />
             })
     }
}
```

Where `<IndentGuide />` is a React element that renders appropriate whitespace elements. We use the `screenToPixel` method to figure out where the line is located, and grab the height that is already available in the context - so the `IndentGuide` would have everything it needs.

We could also implement something like an inline color highlighter:
- For each 'visible line', check to see if there are any tokens matching a hex/rgb color
- If so, parse, and use the `screenToPixel` API to figure out the location of the item
- Render a color element nearby

So this opens up some cool possibilities in terms of what we can do with our 'buffer layers'