### PR TITLE
Add `--plugin-develop` flag

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -133,6 +133,13 @@ export const start = async (args: string[]): Promise<void> => {
     PluginManager.activate(configuration)
     const pluginManager = PluginManager.getInstance()
 
+    const developmentPlugin = parsedArgs["plugin-develop"]
+    alert(parsedArgs)
+    if (developmentPlugin) {
+        alert(developmentPlugin)
+        pluginManager.addDevelopmentPlugin(developmentPlugin)
+    }
+
     Performance.startMeasure("Oni.Start.Plugins.Discover")
     pluginManager.discoverPlugins()
     Performance.endMeasure("Oni.Start.Plugins.Discover")

--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -134,9 +134,9 @@ export const start = async (args: string[]): Promise<void> => {
     const pluginManager = PluginManager.getInstance()
 
     const developmentPlugin = parsedArgs["plugin-develop"]
-    alert(parsedArgs)
+
     if (developmentPlugin) {
-        alert(developmentPlugin)
+        Log.info("Registering development plugin: " + developmentPlugin)
         pluginManager.addDevelopmentPlugin(developmentPlugin)
     }
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -37,7 +37,7 @@ export class PluginManager implements Oni.IPluginManager {
     constructor(private _config: Configuration) {}
 
     public addDevelopmentPlugin(pluginPath: string): void {
-       this._developmentPluginsPath.push(pluginPath) 
+       this._developmentPluginsPath.push(pluginPath)
     }
 
     public discoverPlugins(): void {

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -24,6 +24,8 @@ export class PluginManager implements Oni.IPluginManager {
     private _pluginsActivated: boolean = false
     private _installer: IPluginInstaller = new YarnPluginInstaller()
 
+    private _developmentPluginsPath: string[] = []
+
     public get plugins(): Plugin[] {
         return this._plugins
     }
@@ -33,6 +35,10 @@ export class PluginManager implements Oni.IPluginManager {
     }
 
     constructor(private _config: Configuration) {}
+
+    public addDevelopmentPlugin(pluginPath: string): void {
+       this._developmentPluginsPath.push(pluginPath) 
+    }
 
     public discoverPlugins(): void {
         const corePluginRootPaths: string[] = [corePluginsRoot, extensionsRoot]
@@ -55,12 +61,14 @@ export class PluginManager implements Oni.IPluginManager {
             this._createPlugin(p, "user"),
         )
 
+        const developmentPlugins = this._developmentPluginsPath.map((dev) => this._createPlugin(dev, "development"))
+
         this._rootPluginPaths = [
             ...corePluginRootPaths,
             ...defaultPluginRootPaths,
             ...userPluginsRootPath,
         ]
-        this._plugins = [...corePlugins, ...defaultPlugins, ...userPlugins]
+        this._plugins = [...corePlugins, ...defaultPlugins, ...userPlugins, ...developmentPlugins]
 
         this._anonymousPlugin = new AnonymousPlugin()
     }
@@ -76,7 +84,7 @@ export class PluginManager implements Oni.IPluginManager {
     }
 
     public getAllRuntimePaths(): string[] {
-        const pluginPaths = this._getAllPluginPaths(this._rootPluginPaths)
+        const pluginPaths = [...this._getAllPluginPaths(this._rootPluginPaths), ...this._developmentPluginsPath]
 
         return pluginPaths.concat(this._rootPluginPaths)
     }


### PR DESCRIPTION
This is meant to be used in conjunction with the starter kit I'm working on for Oni plugins here:
https://github.com/onivim/oni-plugin-starter-kit

This change adds a `--plugin-develop` flag, which allows you to specify a plugin directory to load on launch.

This is to facilitate an `F5` scenario from oni-plugin-starter-kit, with the flow being that I have a _workspace command_ defined in `oni-plugin-starter-kit` which will spin up a new Oni instance with the plugin loaded for debugging and testing.