### PR TITLE
Performance: Add selector for NeovimBufferLayerView

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -6,6 +6,7 @@
 
 import * as React from "react"
 import { connect } from "react-redux"
+import { createSelector } from "reselect"
 
 import * as Oni from "oni-api"
 
@@ -118,20 +119,27 @@ const EmptyState: NeovimBufferLayersViewProps = {
     fontPixelWidth: -1,
 }
 
+const activeVimTabPage = (state: State.IState) => state.activeVimTabPage
+const windowState = (state: State.IState) => state.windowState
+
+const windowSelector = createSelector([activeVimTabPage, windowState], (tabPage: State.IVimTabPage, windowState: State.IWindowState) => {
+    const windows = tabPage.windowIds.map(windowId => {
+        return windowState.windows[windowId]
+    })
+
+     return windows.sort((a, b) => a.windowId - b.windowId)
+})
+
 const mapStateToProps = (state: State.IState): NeovimBufferLayersViewProps => {
     if (!state.activeVimTabPage) {
         return EmptyState
     }
 
-    const windows = state.activeVimTabPage.windowIds.map(windowId => {
-        return state.windowState.windows[windowId]
-    })
-
-    const wins = windows.sort((a, b) => a.windowId - b.windowId)
+    const windows = windowSelector(state)
 
     return {
         activeWindowId: state.windowState.activeWindow,
-        windows: wins,
+        windows: windows,
         layers: state.layers,
         fontPixelWidth: state.fontPixelWidth,
         fontPixelHeight: state.fontPixelHeight,

--- a/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimBufferLayersView.tsx
@@ -119,16 +119,19 @@ const EmptyState: NeovimBufferLayersViewProps = {
     fontPixelWidth: -1,
 }
 
-const activeVimTabPage = (state: State.IState) => state.activeVimTabPage
-const windowState = (state: State.IState) => state.windowState
+const getActiveVimTabPage = (state: State.IState) => state.activeVimTabPage
+const getWindowState = (state: State.IState) => state.windowState
 
-const windowSelector = createSelector([activeVimTabPage, windowState], (tabPage: State.IVimTabPage, windowState: State.IWindowState) => {
-    const windows = tabPage.windowIds.map(windowId => {
-        return windowState.windows[windowId]
-    })
+const windowSelector = createSelector(
+    [getActiveVimTabPage, getWindowState],
+    (tabPage: State.IVimTabPage, windowState: State.IWindowState) => {
+        const windows = tabPage.windowIds.map(windowId => {
+            return windowState.windows[windowId]
+        })
 
-     return windows.sort((a, b) => a.windowId - b.windowId)
-})
+        return windows.sort((a, b) => a.windowId - b.windowId)
+    },
+)
 
 const mapStateToProps = (state: State.IState): NeovimBufferLayersViewProps => {
     if (!state.activeVimTabPage) {
@@ -139,7 +142,7 @@ const mapStateToProps = (state: State.IState): NeovimBufferLayersViewProps => {
 
     return {
         activeWindowId: state.windowState.activeWindow,
-        windows: windows,
+        windows,
         layers: state.layers,
         fontPixelWidth: state.fontPixelWidth,
         fontPixelHeight: state.fontPixelHeight,


### PR DESCRIPTION
I was doing some performance testing, just to see if we have any components that aggressively re-render. I ran this code in the console:
```
for(let i = 0; i < 100; i++) { window.setTimeout(() => {Oni.editors.activeEditor._neovimEditor._store.dispatch({type: "NOOP"}) }, 10)}
```

This sends a 'no-op' event to the store - this won't change the value of our `state`, so if our components are set up correctly, there should be no re-rendering.

However, I saw that the `NeovimBufferLayerView` was re-rendering consistently.

This was because everytime we evaluate `mapStateToProps`, a new `windows` array was being created and sorted, and this failed the shallow comparison.

The fix for this is to add a selector, so we only re-evaluate the `windows` array when some of the dependent state has changed.