### PR TITLE
Improve WebGL Renderer stability

### DIFF
--- a/browser/src/Renderer/WebGL/WebGLAtlas.ts
+++ b/browser/src/Renderer/WebGL/WebGLAtlas.ts
@@ -1,5 +1,3 @@
-const textureSizeInPixels = 1024 // This should be a safe size for all graphics chips
-const maxTextureCount = 8 // TODO possibly use MAX_ARRAY_TEXTURE_LAYERS here
 const backgroundColor = "black"
 const foregroundColor = "white"
 
@@ -10,6 +8,8 @@ export interface IWebGLAtlasOptions {
     linePaddingInPixels: number
     devicePixelRatio: number
     offsetGlyphVariantCount: number
+    textureSizeInPixels: number
+    textureLayerCount: number
 }
 
 export interface WebGLGlyph {
@@ -24,19 +24,21 @@ export interface WebGLGlyph {
     subpixelWidth: number
 }
 
+export class WebGLTextureSpaceExceededError extends Error {}
+
 export class WebGLAtlas {
     private _glyphContext: CanvasRenderingContext2D
     private _glyphs = new Map<string, Map<number, WebGLGlyph>>()
     private _texture: WebGLTexture
-    private _currentTextureIndex = 0
-    private _currentTextureChangedSinceLastUpload = false
+    private _currentTextureLayerIndex = 0
+    private _currentTextureLayerChangedSinceLastUpload = false
     private _nextX = 0
     private _nextY = 0
 
     constructor(private _gl: WebGL2RenderingContext, private _options: IWebGLAtlasOptions) {
         const glyphCanvas = document.createElement("canvas")
-        glyphCanvas.width = textureSizeInPixels
-        glyphCanvas.height = textureSizeInPixels
+        glyphCanvas.width = this._options.textureSizeInPixels
+        glyphCanvas.height = this._options.textureSizeInPixels
         this._glyphContext = glyphCanvas.getContext("2d", { alpha: false })
         this._glyphContext.font = `${this._options.fontSize} ${this._options.fontFamily}`
         this._glyphContext.fillStyle = foregroundColor
@@ -64,17 +66,21 @@ export class WebGLAtlas {
             this._gl.CLAMP_TO_EDGE,
         )
 
+        const textureLayerCount = Math.min(
+            this._options.textureLayerCount,
+            this._gl.MAX_ARRAY_TEXTURE_LAYERS,
+        )
         this._gl.texImage3D(
             this._gl.TEXTURE_2D_ARRAY,
             0,
             this._gl.RGBA,
-            textureSizeInPixels,
-            textureSizeInPixels,
-            maxTextureCount,
+            this._options.textureSizeInPixels,
+            this._options.textureSizeInPixels,
+            textureLayerCount,
             0,
             this._gl.RGBA,
             this._gl.UNSIGNED_BYTE,
-            new Uint8Array(textureSizeInPixels * textureSizeInPixels * maxTextureCount * 4),
+            null,
         )
     }
 
@@ -95,50 +101,27 @@ export class WebGLAtlas {
     }
 
     public uploadTexture() {
-        if (this._currentTextureChangedSinceLastUpload) {
+        if (this._currentTextureLayerChangedSinceLastUpload) {
             this._gl.bindTexture(this._gl.TEXTURE_2D_ARRAY, this._texture)
             this._gl.texSubImage3D(
                 this._gl.TEXTURE_2D_ARRAY,
                 0,
                 0,
                 0,
-                this._currentTextureIndex,
-                textureSizeInPixels,
-                textureSizeInPixels,
+                this._currentTextureLayerIndex,
+                this._options.textureSizeInPixels,
+                this._options.textureSizeInPixels,
                 1,
                 this._gl.RGBA,
                 this._gl.UNSIGNED_BYTE,
                 this._glyphContext.canvas,
             )
-            this._currentTextureChangedSinceLastUpload = false
+            this._currentTextureLayerChangedSinceLastUpload = false
         }
-    }
-
-    private _switchToNextTexture() {
-        if (this._currentTextureIndex >= this._gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS) {
-            throw new Error(
-                "The WebGL renderer ran out of texture space. Please re-open the editor or switch to a different renderer.",
-            )
-        }
-
-        this.uploadTexture()
-
-        this._glyphContext.fillStyle = backgroundColor
-        this._glyphContext.fillRect(
-            0,
-            0,
-            this._glyphContext.canvas.width,
-            this._glyphContext.canvas.width,
-        )
-        this._glyphContext.fillStyle = foregroundColor
-        this._currentTextureIndex++
-        this._nextX = 0
-        this._nextY = 0
-        this._currentTextureChangedSinceLastUpload = true
     }
 
     private _rasterizeGlyph(text: string, variantIndex: number) {
-        this._currentTextureChangedSinceLastUpload = true
+        this._currentTextureLayerChangedSinceLastUpload = true
 
         const {
             devicePixelRatio,
@@ -152,13 +135,13 @@ export class WebGLAtlas {
         const { width: subpixelWidth } = this._glyphContext.measureText(text)
         const width = Math.ceil(variantOffset) + Math.ceil(subpixelWidth)
 
-        if ((this._nextX + width) * devicePixelRatio > textureSizeInPixels) {
+        if ((this._nextX + width) * devicePixelRatio > this._options.textureSizeInPixels) {
             this._nextX = 0
             this._nextY = Math.ceil(this._nextY + height)
         }
 
-        if ((this._nextY + height) * devicePixelRatio > textureSizeInPixels) {
-            this._switchToNextTexture()
+        if ((this._nextY + height) * devicePixelRatio > this._options.textureSizeInPixels) {
+            this._switchToNextLayer()
         }
 
         const x = this._nextX
@@ -169,13 +152,37 @@ export class WebGLAtlas {
         return {
             width: width * devicePixelRatio,
             height: height * devicePixelRatio,
-            textureIndex: this._currentTextureIndex,
-            textureU: x * devicePixelRatio / textureSizeInPixels,
-            textureV: y * devicePixelRatio / textureSizeInPixels,
-            textureWidth: width * devicePixelRatio / textureSizeInPixels,
-            textureHeight: height * devicePixelRatio / textureSizeInPixels,
+            textureIndex: this._currentTextureLayerIndex,
+            textureU: x * devicePixelRatio / this._options.textureSizeInPixels,
+            textureV: y * devicePixelRatio / this._options.textureSizeInPixels,
+            textureWidth: width * devicePixelRatio / this._options.textureSizeInPixels,
+            textureHeight: height * devicePixelRatio / this._options.textureSizeInPixels,
             subpixelWidth: subpixelWidth * devicePixelRatio,
             variantOffset,
         } as WebGLGlyph
+    }
+
+    private _switchToNextLayer() {
+        if (this._currentTextureLayerIndex + 1 >= this._options.textureLayerCount) {
+            throw new WebGLTextureSpaceExceededError(
+                "The WebGL renderer ran out of texture space. Please re-open the editor " +
+                    "with more texture layers or switch to a different renderer.",
+            )
+        }
+
+        this.uploadTexture()
+
+        this._glyphContext.fillStyle = backgroundColor
+        this._glyphContext.fillRect(
+            0,
+            0,
+            this._glyphContext.canvas.width,
+            this._glyphContext.canvas.width,
+        )
+        this._glyphContext.fillStyle = foregroundColor
+        this._currentTextureLayerIndex++
+        this._nextX = 0
+        this._nextY = 0
+        this._currentTextureLayerChangedSinceLastUpload = true
     }
 }

--- a/browser/src/Renderer/WebGL/WebGLAtlas.ts
+++ b/browser/src/Renderer/WebGL/WebGLAtlas.ts
@@ -15,7 +15,7 @@ export interface IWebGLAtlasOptions {
 export interface WebGLGlyph {
     width: number
     height: number
-    textureIndex: number
+    textureLayerIndex: number
     textureWidth: number
     textureHeight: number
     textureU: number
@@ -152,7 +152,7 @@ export class WebGLAtlas {
         return {
             width: width * devicePixelRatio,
             height: height * devicePixelRatio,
-            textureIndex: this._currentTextureLayerIndex,
+            textureLayerIndex: this._currentTextureLayerIndex,
             textureU: x * devicePixelRatio / this._options.textureSizeInPixels,
             textureV: y * devicePixelRatio / this._options.textureSizeInPixels,
             textureWidth: width * devicePixelRatio / this._options.textureSizeInPixels,

--- a/browser/src/Renderer/WebGL/WebGLAtlas.ts
+++ b/browser/src/Renderer/WebGL/WebGLAtlas.ts
@@ -121,8 +121,6 @@ export class WebGLAtlas {
             )
         }
 
-        console.warn("switching to next texture #", this._currentTextureIndex + 2)
-
         this.uploadTexture()
 
         this._glyphContext.fillStyle = backgroundColor

--- a/browser/src/Renderer/WebGL/WebGLRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLRenderer.ts
@@ -20,10 +20,19 @@ export class WebGLRenderer implements INeovimRenderer {
     public start(editorElement: HTMLElement): void {
         this._editorElement = editorElement
         this._colorNormalizer = new CachedColorNormalizer()
+
+        const canvasElement = document.createElement("canvas")
+        this._editorElement.innerHTML = ""
+        this._editorElement.appendChild(canvasElement)
+
+        this._gl = canvasElement.getContext("webgl2") as WebGL2RenderingContext
     }
 
     public redrawAll(screenInfo: IScreen): void {
-        this._initializeCanvasIfRequired()
+        if (!this._editorElement) {
+            return
+        }
+
         this._updateCanvasDimensions()
         this._createNewRendererIfRequired(screenInfo)
         this._clear(screenInfo.backgroundColor)
@@ -46,16 +55,6 @@ export class WebGLRenderer implements INeovimRenderer {
 
     public onAction(action: any): void {
         // do nothing
-    }
-
-    private _initializeCanvasIfRequired() {
-        if (!this._gl) {
-            const canvasElement = document.createElement("canvas")
-            this._editorElement.innerHTML = ""
-            this._editorElement.appendChild(canvasElement)
-
-            this._gl = canvasElement.getContext("webgl2") as WebGL2RenderingContext
-        }
     }
 
     private _updateCanvasDimensions() {

--- a/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
@@ -9,7 +9,7 @@ import {
 
 // tslint:disable-next-line:no-bitwise
 const maxGlyphInstances = 1 << 14 // TODO find a reasonable way of determining this
-const glyphInstanceFieldCount = 12
+const glyphInstanceFieldCount = 13
 const glyphInstanceSizeInBytes = glyphInstanceFieldCount * Float32Array.BYTES_PER_ELEMENT
 
 const vertexShaderAttributes = {
@@ -17,8 +17,9 @@ const vertexShaderAttributes = {
     targetOrigin: 1,
     targetSize: 2,
     textColorRGBA: 3,
-    atlasOrigin: 4,
-    atlasSize: 5,
+    atlasIndex: 4,
+    atlasOrigin: 5,
+    atlasSize: 6,
 }
 
 const vertexShaderSource = `
@@ -28,12 +29,14 @@ const vertexShaderSource = `
     layout (location = 1) in vec2 targetOrigin;
     layout (location = 2) in vec2 targetSize;
     layout (location = 3) in vec4 textColorRGBA;
-    layout (location = 4) in vec2 atlasOrigin;
-    layout (location = 5) in vec2 atlasSize;
+    layout (location = 4) in float atlasIndex;
+    layout (location = 5) in vec2 atlasOrigin;
+    layout (location = 6) in vec2 atlasSize;
 
     uniform vec2 viewportScale;
 
     flat out vec4 textColor;
+    flat out int convertedAtlasIndex;
     out vec2 atlasPosition;
 
     void main() {
@@ -41,6 +44,7 @@ const vertexShaderSource = `
         vec2 targetPosition = targetPixelPosition * viewportScale + vec2(-1.0, 1.0);
         gl_Position = vec4(targetPosition, 0.0, 1.0);
         textColor = textColorRGBA;
+        convertedAtlasIndex = int(atlasIndex);
         atlasPosition = atlasOrigin + unitQuadVertex * atlasSize;
     }
 `.trim()
@@ -49,15 +53,17 @@ const firstPassFragmentShaderSource = `
     #version 300 es
 
     precision mediump float;
+    precision mediump sampler2DArray;
 
     layout(location = 0) out vec4 outColor;
     flat in vec4 textColor;
+    flat in int convertedAtlasIndex;
     in vec2 atlasPosition;
 
-    uniform sampler2D atlasTexture;
+    uniform sampler2DArray atlasTextures;
 
     void main() {
-      vec4 atlasColor = texture(atlasTexture, atlasPosition);
+      vec4 atlasColor = texture(atlasTextures, vec3(atlasPosition, convertedAtlasIndex));
       outColor = textColor.a * atlasColor;
     }
 `.trim()
@@ -66,15 +72,17 @@ const secondPassFragmentShaderSource = `
     #version 300 es
 
     precision mediump float;
+    precision mediump sampler2DArray;
 
     layout(location = 0) out vec4 outColor;
     flat in vec4 textColor;
+    flat in int convertedAtlasIndex;
     in vec2 atlasPosition;
 
-    uniform sampler2D atlasTexture;
+    uniform sampler2DArray atlasTextures;
 
     void main() {
-        vec3 atlasColor = texture(atlasTexture, atlasPosition).rgb;
+        vec3 atlasColor = texture(atlasTextures, vec3(atlasPosition, convertedAtlasIndex)).rgb;
         vec3 outColorRGB = atlasColor * textColor.rgb;
         float outColorA = max(outColorRGB.r, max(outColorRGB.g, outColorRGB.b));
         outColor = vec4(outColorRGB, outColorA);
@@ -90,8 +98,10 @@ export class WebGlTextRenderer {
 
     private _firstPassProgram: WebGLProgram
     private _firstPassViewportScaleLocation: WebGLUniformLocation
+    private _firstPassAtlasTexturesLocation: WebGLUniformLocation
     private _secondPassProgram: WebGLProgram
     private _secondPassViewportScaleLocation: WebGLUniformLocation
+    private _secondPassAtlasTexturesLocation: WebGLUniformLocation
     private _unitQuadVerticesBuffer: WebGLBuffer
     private _unitQuadElementIndicesBuffer: WebGLBuffer
     private _glyphInstances: Float32Array
@@ -125,6 +135,15 @@ export class WebGlTextRenderer {
         this._secondPassViewportScaleLocation = this._gl.getUniformLocation(
             this._secondPassProgram,
             "viewportScale",
+        )
+
+        this._firstPassAtlasTexturesLocation = this._gl.getUniformLocation(
+            this._firstPassProgram,
+            "atlasTextures",
+        )
+        this._secondPassAtlasTexturesLocation = this._gl.getUniformLocation(
+            this._secondPassProgram,
+            "atlasTextures",
         )
 
         this.createBuffers()
@@ -211,6 +230,17 @@ export class WebGlTextRenderer {
         )
         this._gl.vertexAttribDivisor(vertexShaderAttributes.textColorRGBA, 1)
 
+        this._gl.enableVertexAttribArray(vertexShaderAttributes.atlasIndex)
+        this._gl.vertexAttribPointer(
+            vertexShaderAttributes.atlasIndex,
+            1,
+            this._gl.FLOAT,
+            false,
+            glyphInstanceSizeInBytes,
+            8 * Float32Array.BYTES_PER_ELEMENT,
+        )
+        this._gl.vertexAttribDivisor(vertexShaderAttributes.atlasIndex, 1)
+
         this._gl.enableVertexAttribArray(vertexShaderAttributes.atlasOrigin)
         this._gl.vertexAttribPointer(
             vertexShaderAttributes.atlasOrigin,
@@ -218,7 +248,7 @@ export class WebGlTextRenderer {
             this._gl.FLOAT,
             false,
             glyphInstanceSizeInBytes,
-            8 * Float32Array.BYTES_PER_ELEMENT,
+            9 * Float32Array.BYTES_PER_ELEMENT,
         )
         this._gl.vertexAttribDivisor(vertexShaderAttributes.atlasOrigin, 1)
 
@@ -229,7 +259,7 @@ export class WebGlTextRenderer {
             this._gl.FLOAT,
             false,
             glyphInstanceSizeInBytes,
-            10 * Float32Array.BYTES_PER_ELEMENT,
+            11 * Float32Array.BYTES_PER_ELEMENT,
         )
         this._gl.vertexAttribDivisor(vertexShaderAttributes.atlasSize, 1)
     }
@@ -287,9 +317,13 @@ export class WebGlTextRenderer {
         this._gl.enable(this._gl.BLEND)
 
         this._gl.useProgram(this._firstPassProgram)
+
         this._gl.uniform2f(this._firstPassViewportScaleLocation, viewportScaleX, viewportScaleY)
+        this._gl.uniform1i(this._firstPassAtlasTexturesLocation, 0)
+
         this._gl.bindBuffer(this._gl.ARRAY_BUFFER, this._glyphInstancesBuffer)
         this._gl.bufferData(this._gl.ARRAY_BUFFER, this._glyphInstances, this._gl.STREAM_DRAW)
+
         this._gl.blendFuncSeparate(
             this._gl.ZERO,
             this._gl.ONE_MINUS_SRC_COLOR,
@@ -299,13 +333,17 @@ export class WebGlTextRenderer {
         this._gl.drawElementsInstanced(this._gl.TRIANGLES, 6, this._gl.UNSIGNED_BYTE, 0, glyphCount)
 
         this._gl.useProgram(this._secondPassProgram)
+
         this._gl.blendFuncSeparate(
             this._gl.ONE,
             this._gl.ONE,
             this._gl.ONE,
             this._gl.ONE_MINUS_SRC_ALPHA,
         )
+
         this._gl.uniform2f(this._secondPassViewportScaleLocation, viewportScaleX, viewportScaleY)
+        this._gl.uniform1i(this._secondPassAtlasTexturesLocation, 0)
+
         this._gl.drawElementsInstanced(this._gl.TRIANGLES, 6, this._gl.UNSIGNED_BYTE, 0, glyphCount)
     }
 
@@ -328,11 +366,13 @@ export class WebGlTextRenderer {
         this._glyphInstances[5 + startOffset] = color[1]
         this._glyphInstances[6 + startOffset] = color[2]
         this._glyphInstances[7 + startOffset] = color[3]
+        // atlasIndex
+        this._glyphInstances[8 + startOffset] = glyph.textureIndex
         // atlasOrigin
-        this._glyphInstances[8 + startOffset] = glyph.textureU
-        this._glyphInstances[9 + startOffset] = glyph.textureV
+        this._glyphInstances[9 + startOffset] = glyph.textureU
+        this._glyphInstances[10 + startOffset] = glyph.textureV
         // atlasSize
-        this._glyphInstances[10 + startOffset] = glyph.textureWidth
-        this._glyphInstances[11 + startOffset] = glyph.textureHeight
+        this._glyphInstances[11 + startOffset] = glyph.textureWidth
+        this._glyphInstances[12 + startOffset] = glyph.textureHeight
     }
 }


### PR DESCRIPTION
This fixes two issues with the WebGL renderer:

### First Issue: Texture space used up
This issue was first reported by @adelarsq
The WebGL texture space that we allocated for prerendering the glyphs was fixed until now. For large screens with high DPI and/or with much scrolling, the renderer ran out of space at some point. This caused it to crash entirely.

#### Fix:
We now use a texture array instead of a single texture which enables us to load multiple layers of our webgl atlas into the GPU. Like that, we can gradually fill each layer while adding new glyphs and switch to the next one whenever the current one is full. We can still run out of space when all layers are full, but the renderer will now recreate a new atlas with twice as many layers once that happens.

The renderer always starts with 2 texture layers at 1024x1024 each. All hardware should support at least 256 texture layers (with many of them going up to 2048 as can be seen [here](https://webglstats.com/webgl2/parameter/MAX_ARRAY_TEXTURE_LAYERS)), so this should be enough.

I chose to go with comparably small texture layers of only 1024x1024 even though most hardware would support at least sizes of 2048 (see [here](https://webglstats.com/webgl2/parameter/MAX_3D_TEXTURE_SIZE)) because the layered approach enables us to do the following optimization:
- Everytime we add a new glyph to the atlas, we have to upload the texture to the GPU again
- Since we only ever change the last layer of the atlas, we would re-upload unchanged data in all other layers if we re-upload everything
- Using `gl.texSubImage3D`, we can thus only re-upload the last layer of the atlas and keep the unchanged data from the previous  uploads

The most expensive part of GPU-based calculation is almost always the communication between CPU and GPU. This approach allows us to minimize the data that needs to be uploaded to the GPU per draw call with new glyphs to 1024x1024x4 (WxHxRGBA) instead of 1024x1024x4xlayerCount. The number 1024 itself only comes from a gut feeling though, so actual experimentation could still lead us to a larger or smaller number.

### Second Issue: `Cannot read property 'canvas' of null`
This error was reported by @justinmk in https://github.com/onivim/oni/pull/2120#issuecomment-388108639
For some reason, the `NeovimRenderer` component can cause `INeovimRenderer.redrawAll()` to be called before `INeovimRenderer.start(editorElement)`, leading to this `TypeError`.

#### Fix:
Since I was not sure how exactly the usage`ResizeObserver` and the React lifecycle methods would have needed to be changed to fix this without breaking something else, I just switched to skipping the entire `redrawAll` body in the `WebGLRenderer`. This is also what we do in the `CanvasRenderer`.

I would however prefer to clean up the interface between the `NeovimRenderer` and the implementations of `INeovimRenderer` instead at some point in time since this seems unintuitive to me; why is there a `start` method if the caller does not guarantee that to be called first? :)

Edit: This change also introduces the fix for blurry rendering from #2183 resp. #2047 to the WebGL Renderer

@nathansobo The sampler array strategy might also be relevant for Xray. Maybe this is could be the first occasion where we pay back some effort to your project :)