### PR TITLE
Add bold and italic rendering to the WebGLRenderer

### DIFF
--- a/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
@@ -258,7 +258,7 @@ export class WebGlTextRenderer {
                 if (!isWhiteSpace(char)) {
                     const variantIndex =
                         Math.round(x * this._subpixelDivisor) % this._subpixelDivisor
-                    const glyph = this._atlas.getGlyph(char, variantIndex)
+                    const glyph = this._atlas.getGlyph(char, cell.bold, cell.italic, variantIndex)
                     const colorToUse = cell.foregroundColor || defaultForegroundColor || "white"
                     const normalizedTextColor = this._colorNormalizer.normalizeColor(colorToUse)
 


### PR DESCRIPTION
This adds functionality to render bold and italic characters to the WebGL renderer. I think the changes are best explained as a comparison between previous and new behavior.

Previously, we did the following:
- For each character that should be rendered, perform a lookup in our `_glyphs` map to find _another_ map containing e.g. 4 (determined by`offsetGlyphVariantCount`) different variants of the character, each with a different fraction of a pixel as x-offset. We need these variants so that the kerning does not get messed up on regular-DPI screens.
- Query the glyph from the second map that most closely matches the required fractional pixel offset (e.g. for `x = 10.56px` and `offsetGlyphVariantCount = 4`, each variant is offset by an additional `1/4px = 0.25px`. That means the best match is `0.5px` offset, which corresponds to the index `2`.)
- If the requested glyph has not yet been added to the map, render it and add it to the map.
- Use the glyph data and WebGL to color the glyph and copy it from the atlas to the editor view 

For the rendering of bold and italic characters, we need another dimension in this mapping:
Additionally to the existing regular glyph style, there can now be an italic one, a bold one, and a bold italic one. Each of the styles also needs to account for different fractional pixel offsets though, so we need another dimension in our mapping. The revamped algorithm thus looks as follows:
- For each character that should be rendered, perform a lookup in our `_glyphs` map to find a *two-dimensional array* (or an array of arrays, whichever feels more comfortable to you). The first dimension is the style that should be rendered. It always has a length of 4, each of which represents one style as mentioned above. The second dimension works the same as before, accounting for the fractional pixel offsets.
- Find the index of the style you want to render as follows:
regular -> 0
bold => 1
italic => 2
bold italic => 3
Then use that index to find an array of length `offsetGlyphVariantCount` containing the different offset variants for the glyph with the given style
- Continue with the rest as before

I hope this is somewhat understandable :D Otherwise maybe a look at the code gives some more insights.

CC @nathansobo again since this might also be interesting for Xray. If you find the time, I'd also love to hear your opinion on the switch from `Map` to the two-dimensional `Array` I did.

Once we get this in, the only features missing in the WebGL renderer in comparison with the canvas renderer should be ligatures and support for transparent backgrounds.