### PR TITLE
Cleanup tutorials

### DIFF
--- a/browser/src/Services/Learning/Tutorial/Notes.tsx
+++ b/browser/src/Services/Learning/Tutorial/Notes.tsx
@@ -112,6 +112,10 @@ export const OKey = (): JSX.Element => {
     )
 }
 
+export const UKey = (): JSX.Element => {
+    return <KeyWithDescription keyCharacter="u" description={<span>Undo a single change</span>} />
+}
+
 export const GGKey = (): JSX.Element => {
     return (
         <KeyWithDescription

--- a/browser/src/Services/Learning/Tutorial/Tutorials/BeginningsAndEndingsTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/BeginningsAndEndingsTutorial.tsx
@@ -40,8 +40,8 @@ export class BeginningsAndEndingsTutorial implements ITutorial {
                 2,
                 Line3.length - 1,
             ),
-            new Stages.MoveToGoalStage("Use '0' to move to the BEGINNING of the line", 2, 0),
             new Stages.MoveToGoalStage("Use '_' to move to the FIRST CHARACTER", 2, 4),
+            new Stages.MoveToGoalStage("Use '0' to move to the BEGINNING of the line", 2, 0),
             new Stages.MoveToGoalStage(
                 "Use '$' to move to the END of the line",
                 2,
@@ -55,8 +55,8 @@ export class BeginningsAndEndingsTutorial implements ITutorial {
             id: "oni.tutorials.beginnings_and_endings",
             name: "Motion: _, 0, $",
             description:
-                "Using `h` and `l` isn't always the most efficient way to get around a line. You can use the `0` key to move to the very beginning a line, and `$` to move to the end. `_` moves to the first character in the line, which is often more convenient than `0`.",
-            level: 160,
+                "You don't need to keep hitting `w` or `b` when you need to go all the way to the beginning or the end of a line. You can use the `0` key to move to the very beginning a line, and `$` to move to the end. Also, `_` moves to the first character in the line, which is often more convenient than `0`.",
+            level: 140,
         }
     }
 

--- a/browser/src/Services/Learning/Tutorial/Tutorials/ChangeOperatorTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/ChangeOperatorTutorial.tsx
@@ -14,6 +14,9 @@ const Line1 = "The change operator can be used for quikcly fixing typos"
 const Line1Marker = "The change operator can be used for ".length
 const Line1Pending = "The change operator can be used for  fixing typos"
 const Line1Fixed = "The change operator can be used for quickly fixing typos"
+const Line2 = "Learning Vim can be tedious and repetitive"
+const Line2Fix1 = "Learning Vim can be fun and repetitive"
+const Line2Fix2 = "Learning Vim can be fun and exciting"
 
 export class ChangeOperatorTutorial implements ITutorial {
     private _stages: ITutorialStage[]
@@ -24,6 +27,20 @@ export class ChangeOperatorTutorial implements ITutorial {
             new Stages.MoveToGoalStage("Move to the goal marker", 0, Line1Marker),
             new Stages.WaitForStateStage("Fix the typo by hitting 'cw'", [Line1Pending]),
             new Stages.WaitForStateStage("Enter the word 'quickly'", [Line1Fixed]),
+            new Stages.WaitForModeStage("Exit Insert mode by hitting <esc>", "normal"),
+            new Stages.SetBufferStage([Line1Fixed, Line2]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 1, Line2.indexOf("tedious")),
+            new Stages.WaitForStateStage("Change 'tedious' to 'fun'", [Line1Fixed, Line2Fix1]),
+            new Stages.WaitForModeStage("Exit Insert mode by hitting <esc>", "normal"),
+            new Stages.MoveToGoalStage(
+                "Move to the goal marker",
+                1,
+                Line2Fix1.indexOf("repetitive"),
+            ),
+            new Stages.WaitForStateStage("Change 'repetitive' to 'exciting'", [
+                Line1Fixed,
+                Line2Fix2,
+            ]),
             new Stages.WaitForModeStage("Exit Insert mode by hitting <esc>", "normal"),
         ]
     }
@@ -43,6 +60,11 @@ export class ChangeOperatorTutorial implements ITutorial {
     }
 
     public get notes(): JSX.Element[] {
-        return [<Notes.HJKLKeys />, <Notes.ChangeOperatorKey />, <Notes.ChangeWordKey />]
+        return [
+            <Notes.HJKLKeys />,
+            <Notes.ChangeOperatorKey />,
+            <Notes.ChangeWordKey />,
+            <Notes.EscKey />,
+        ]
     }
 }

--- a/browser/src/Services/Learning/Tutorial/Tutorials/CopyPasteTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/CopyPasteTutorial.tsx
@@ -16,7 +16,12 @@ const Line2YankMarker = "Any deleted ".length
 const Line2PasteMarker = "Any deleted text or yanked".length
 const Line2PostPaste1 = "Any deleted text or yanked text can then be pasted with 'p'"
 const Line2PostPaste2 = "text Any deleted text or yanked text can then be pasted with 'p'"
-const Line1PostTranspose = "iLke the 'd' operator, 'y' can be used to yank (copy) text"
+
+const TransposeLine = "Sipmle tpyos can aslo be fiexd with 'xp'"
+const TransposeLine1 = "Simple tpyos can aslo be fiexd with 'xp'"
+const TransposeLine2 = "Simple typos can aslo be fiexd with 'xp'"
+const TransposeLine3 = "Simple typos can also be fiexd with 'xp'"
+const TransposeLine4 = "Simple typos can also be fixed with 'xp'"
 
 export class CopyPasteTutorial implements ITutorial {
     private _stages: ITutorialStage[]
@@ -65,9 +70,21 @@ export class CopyPasteTutorial implements ITutorial {
                 Line2PostPaste2,
             ]),
             new Stages.WaitForStateStage(
-                "Since deleted text is also copied, transposing characters is simple.  Try 'xp'",
-                [Line2PostPaste2, Line2PostPaste2, Line1PostTranspose, Line2PostPaste2],
+                "Copied text can be pasted multiple times, past again with 'p'",
+                [Line2PostPaste2, Line2PostPaste2, Line1, Line1, Line2PostPaste2],
             ),
+            new Stages.SetBufferStage([TransposeLine]),
+            new Stages.MoveToGoalStage("Move to the first typo", 0, 2),
+            new Stages.WaitForStateStage(
+                "Since deleted text is also copied, transposing characters is simple.  Try 'xp'",
+                [TransposeLine1],
+            ),
+            new Stages.MoveToGoalStage("Move to the next typo", 0, 8),
+            new Stages.WaitForStateStage("Again, fix the typo with 'xp'", [TransposeLine2]),
+            new Stages.MoveToGoalStage("Move to the next typo", 0, 18),
+            new Stages.WaitForStateStage("Again, fix the typo with 'xp'", [TransposeLine3]),
+            new Stages.MoveToGoalStage("Move to the next typo", 0, 27),
+            new Stages.WaitForStateStage("Again, fix the typo with 'xp'", [TransposeLine4]),
         ]
     }
 

--- a/browser/src/Services/Learning/Tutorial/Tutorials/InsertAndUndoTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/InsertAndUndoTutorial.tsx
@@ -1,5 +1,5 @@
 /**
- * MoveAndInsertTutorial.tsx
+ * InsertAndUndoTutorial.tsx
  *
  * Tutorial that brings together moving and inserting
  */
@@ -10,10 +10,10 @@ import { ITutorial, ITutorialMetadata, ITutorialStage } from "./../ITutorial"
 import * as Notes from "./../Notes"
 import * as Stages from "./../Stages"
 
-const TutorialLine1Original = "There is text msng this ."
+const TutorialLine1Original = "There is text msing this ."
 const TutorialLine1Correct = "There is some text missing from this line."
 
-export class MoveAndInsertTutorial implements ITutorial {
+export class InsertAndUndoTutorial implements ITutorial {
     private _stages: ITutorialStage[]
 
     constructor() {
@@ -22,16 +22,16 @@ export class MoveAndInsertTutorial implements ITutorial {
             new Stages.MoveToGoalStage("Move to the letter 't'", 0, 9),
             new Stages.WaitForModeStage("Press 'i' to enter insert mode", "insert"),
             new Stages.CorrectLineStage(
-                "Add the missing word 'some'",
+                "Add the missing word 'some '",
                 0,
                 TutorialLine1Correct,
                 "green",
-                "There is some",
+                "There is some ",
             ),
             new Stages.WaitForModeStage("Press '<esc>' to exit insert mode", "normal"),
             new Stages.MoveToGoalStage("Move to the letter 's'", 0, 20),
             new Stages.CorrectLineStage(
-                "Correct the word: `msng` should be `missing`",
+                "Correct the word: `msing` should be `missing`",
                 0,
                 TutorialLine1Correct,
                 "green",
@@ -42,7 +42,7 @@ export class MoveAndInsertTutorial implements ITutorial {
                 0,
                 TutorialLine1Correct,
                 "green",
-                "There is some text missing from",
+                "There is some text missing from ",
             ),
             new Stages.CorrectLineStage(
                 "Add the missing word 'line'",
@@ -51,16 +51,29 @@ export class MoveAndInsertTutorial implements ITutorial {
                 "green",
                 "There is some text missing from this line.",
             ),
+            new Stages.WaitForModeStage("Press '<esc>' to exit insert mode", "normal"),
+            new Stages.WaitForStateStage("Press 'u' to undo the last change", [
+                "There is some text missing from this .",
+                TutorialLine1Correct,
+            ]),
+            new Stages.WaitForStateStage("Press 'u' to undo another change", [
+                "There is some text missing this .",
+                TutorialLine1Correct,
+            ]),
+            new Stages.WaitForStateStage("Press 'u' to undo yet another change", [
+                "There is some text msing this .",
+                TutorialLine1Correct,
+            ]),
         ]
     }
 
     public get metadata(): ITutorialMetadata {
         return {
-            id: "oni.tutorial.move_and_insert",
-            name: "Moving and Inserting",
+            id: "oni.tutorial.insert_and_undo",
+            name: "Insert and Undo",
             description:
-                "It's important to be able to switch between normal and insert mode, in order to edit text! Let's put together the cursor motion and insert mode from the previous tutorials.",
-            level: 130,
+                "It's important to be able to switch between normal and insert mode, in order to edit text! Let's put together the cursor motion and insert mode from the previous tutorials.  If you make any mistakes, you can undo inserted text with 'u'.",
+            level: 170,
         }
     }
 
@@ -69,6 +82,6 @@ export class MoveAndInsertTutorial implements ITutorial {
     }
 
     public get notes(): JSX.Element[] {
-        return [<Notes.HJKLKeys />, <Notes.IKey />, <Notes.EscKey />]
+        return [<Notes.HJKLKeys />, <Notes.IKey />, <Notes.EscKey />, <Notes.UKey />]
     }
 }

--- a/browser/src/Services/Learning/Tutorial/Tutorials/SearchInBufferTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/SearchInBufferTutorial.tsx
@@ -33,7 +33,11 @@ export class SearchInBufferTutorial implements ITutorial {
         this._stages = [
             // Forward search
             new Stages.SetBufferStage([Line1, Line2]),
-            new Stages.MoveToGoalStage("Use '/' to search for the word 'move'", 1, 28),
+            new Stages.MoveToGoalStage(
+                "Use '/' to enter search mode, type the word 'move', then hit <enter>",
+                1,
+                28,
+            ),
             new Stages.SetBufferStage([Line1, Line2, Line3]),
             new Stages.MoveToGoalStage("Use 'n' to go to the next instance of 'move'", 2, 21),
             new Stages.SetBufferStage([Line1, Line2, Line3, EmptyLine, EmptyLine, Line4]),
@@ -53,11 +57,19 @@ export class SearchInBufferTutorial implements ITutorial {
             // Backward search
             new Stages.SetBufferStage([Line7]),
             new Stages.SetCursorPositionStage(0, 48),
-            new Stages.MoveToGoalStage("Use '?' to search for the word 'you'", 0, 21),
+            new Stages.MoveToGoalStage("Use '?' to search backwards for the word 'you'", 0, 21),
             new Stages.SetBufferStage([Line7, Line8, Line9]),
-            new Stages.MoveToGoalStage("Use 'N' to go to the previous instance of 'you'", 2, 14),
+            new Stages.MoveToGoalStage(
+                "Use 'N' to go to the previous (backwards) instance of 'you'",
+                2,
+                14,
+            ),
             new Stages.SetBufferStage([Line7, Line8, Line9, Line10]),
-            new Stages.MoveToGoalStage("Use 'n' to go to the next instance of 'move'", 0, 21),
+            new Stages.MoveToGoalStage(
+                "Use 'n' to go to the next (backwards) instance of 'move'",
+                0,
+                21,
+            ),
         ]
     }
 
@@ -67,7 +79,7 @@ export class SearchInBufferTutorial implements ITutorial {
             name: "Motion: /, ?, n, N",
             description:
                 "To navigate a buffer efficiently, Oni lets you search for strings with `/` and `?`. `n` and `N` let you navigate quickly between the matches!",
-            level: 180,
+            level: 160,
         }
     }
 

--- a/browser/src/Services/Learning/Tutorial/Tutorials/WordMotionTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/WordMotionTutorial.tsx
@@ -27,46 +27,36 @@ export class WordMotionTutorial implements ITutorial {
             new Stages.SetBufferStage([Line1, Line2]),
             new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 1, 10 /* todo */),
             new Stages.MoveToGoalStage(
-                "Use the '0' key to move to the beginning of the line",
+                "Use the 'e' key to move to the end of the current word",
                 1,
-                0,
+                12,
             ),
             new Stages.MoveToGoalStage(
-                "Use the 'e' key to move to the end of the first word",
+                "Use the 'e' key to move to the end of the next word",
                 1,
-                2,
+                15,
             ),
             new Stages.MoveToGoalStage(
-                "Use the 'e' key to move to the end of the second word",
+                "Use the 'e' key to move to the end of the next word",
                 1,
-                6,
-            ),
-            new Stages.MoveToGoalStage(
-                "Use the 'e' key to move to the end of the third word",
-                1,
-                8,
+                20,
             ),
             new Stages.SetBufferStage([Line1, Line2, Line3]),
-            new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 2, 8 /* todo */),
+            new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 2, 20 /* todo */),
             new Stages.MoveToGoalStage(
-                "Use the '$' key to move to the end of the line",
+                "Use the 'b' key to move to the beginning of the current word",
                 2,
-                Line3.length - 1,
+                17,
             ),
             new Stages.MoveToGoalStage(
-                "Use the 'b' key to move to the beginning of the last word",
+                "Use the 'b' key to move to the beginning of the previous word",
                 2,
-                Line3.length - "word.".length,
+                14,
             ),
             new Stages.MoveToGoalStage(
-                "Use the 'b' key to move to the beginning of the second-to-last word",
+                "Use the 'b' key to move to the beginning of the previous word",
                 2,
-                Line3.length - "PREVIOUS word.".length,
-            ),
-            new Stages.MoveToGoalStage(
-                "Use the 'b' key to move to the beginning of the third-to-last word",
-                2,
-                Line3.length - "the PREVIOUS word.".length,
+                10,
             ),
         ]
     }
@@ -76,8 +66,8 @@ export class WordMotionTutorial implements ITutorial {
             id: "oni.tutorials.word_motion",
             name: "Motion: w, e, b",
             description:
-                "Often, `h` and `l` aren't the fastest way to move in a line. Word motions can be useful here - and even more useful when coupled with operators (we'll explore those later)! The `w` key moves to the first letter of the next word, the `b` key moves to the beginning letter of the previous word, and the `e` key moves to the end of the next word.",
-            level: 170,
+                "Often, `h` and `l` aren't the fastest way to move in a line. Word motions can be useful here - and even more useful when coupled with operators (we'll explore those later)! The `w` key moves to the first letter of the next word, the `e` key moves to the end of the next word, and the `b` key moves to the beginning letter of the previous word.",
+            level: 130,
         }
     }
 
@@ -86,6 +76,6 @@ export class WordMotionTutorial implements ITutorial {
     }
 
     public get notes(): JSX.Element[] {
-        return [<Notes.HJKLKeys />, <Notes.WordKey />, <Notes.BeginningKey />, <Notes.EndKey />]
+        return [<Notes.HJKLKeys />, <Notes.WordKey />, <Notes.EndKey />, <Notes.BeginningKey />]
     }
 }

--- a/browser/src/Services/Learning/Tutorial/Tutorials/index.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/index.tsx
@@ -10,7 +10,7 @@ import { ChangeOperatorTutorial } from "./ChangeOperatorTutorial"
 import { CopyPasteTutorial } from "./CopyPasteTutorial"
 import { DeleteCharacterTutorial } from "./DeleteCharacterTutorial"
 import { DeleteOperatorTutorial } from "./DeleteOperatorTutorial"
-import { MoveAndInsertTutorial } from "./MoveAndInsertTutorial"
+import { InsertAndUndoTutorial } from "./InsertAndUndoTutorial"
 import { SearchInBufferTutorial } from "./SearchInBufferTutorial"
 import { SwitchModeTutorial } from "./SwitchModeTutorial"
 import { VerticalMovementTutorial } from "./VerticalMovementTutorial"
@@ -26,7 +26,7 @@ export const AllTutorials: ITutorial[] = [
     new BasicMovementTutorial(),
     new DeleteCharacterTutorial(),
     new DeleteOperatorTutorial(),
-    new MoveAndInsertTutorial(),
+    new InsertAndUndoTutorial(),
     new VerticalMovementTutorial(),
     new WordMotionTutorial(),
     new SearchInBufferTutorial(),


### PR DESCRIPTION
I went through the tutorials and tried to clean them up a bit.  Originally, I just wanted to add some repetition to reinforce the commands but then I got carried away and kept tweaking things.  I don't think my changes will offend anyone, but who knows.

The changes I made:
- I re-arranged the tutorials so all the "motions" come before editing a file (Insert Mode).  I also re-arranged the motions to follow (what I consider) a more logical flow.  It goes from `h/j/k/l` to `w/e/b` to `0/$/_`, then to `gg/G` and search.  In my mind, this goes from smaller-jumps to larger-jumps and simple movements to more complex movements.
- The `w/e/b` tutorial was using `0/$` when those already have a dedicated tutorial for them.  And after my re-arranging, `w/e/b` came before that tutorial.  I removed all references of `0/$` in `w/e/b` to remove confusion.
- Changed "Motion and Insert" to be "Insert and Undo".  Since all the motion tutorials are non-destructive, I wanted them to be before any edits to the file.  I also wanted to make sure we taught `u`ndo as soon as we taught destructive changes so the user can undo any mistakes when trying to complete later tutorials.  Sometimes you can modify the wrong text and without `u` there's no way to successfully complete the tutorial.
- Added some repetition to the ChangeOperator tutorial.  I had just thrown together the tutorial with a single example so I could reference `c`hange in my VisualMode tutorial.  Now it has a couple more uses of `cw` for reinforcement.
- Added some repetition of `xp` to the CopyPaste tutorial.  Again, I originally only had one example of this and it was the last item in the tutorial so the "you win" animation played before you could even see what `xp` had changed.
- Fixed some issues in the MoveAndInsert/InsertAndUndo tutorial where the marker was claiming success before you entered a `space` after the added word.  This was throwing me off because it claimed I had completed the step but then wasn't matching the text in the next step so I couldn't complete the tutorial.
- Cleaned up the wording in Search tutorial to be more descriptive in case this is the user's first introduction to search mode.