### PR TITLE
Add glyph padding/overlap to the WebGLAtlas and WebGLTextRenderer

### DIFF
--- a/browser/src/Renderer/WebGL/WebGLAtlas.ts
+++ b/browser/src/Renderer/WebGL/WebGLAtlas.ts
@@ -6,6 +6,7 @@ export interface IWebGLAtlasOptions {
     fontSize: string
     lineHeightInPixels: number
     linePaddingInPixels: number
+    glyphPaddingInPixels: number
     devicePixelRatio: number
     offsetGlyphVariantCount: number
     textureSizeInPixels: number
@@ -21,7 +22,7 @@ export interface WebGLGlyph {
     textureU: number
     textureV: number
     variantOffset: number
-    subpixelWidth: number
+    subpixelWidth: number // TODO remove this as it is unused
 }
 
 export class WebGLTextureSpaceExceededError extends Error {}
@@ -140,13 +141,17 @@ export class WebGLAtlas {
             devicePixelRatio,
             lineHeightInPixels,
             linePaddingInPixels,
+            glyphPaddingInPixels,
             offsetGlyphVariantCount,
         } = this._options
+        const style = getGlyphStyleString(isBold, isItalic)
+        this._glyphContext.font = `${style} ${this._options.fontSize} ${this._options.fontFamily}`
         const variantOffset = variantIndex / offsetGlyphVariantCount
 
-        const height = lineHeightInPixels
-        const { width: subpixelWidth } = this._glyphContext.measureText(text)
-        const width = Math.ceil(variantOffset) + Math.ceil(subpixelWidth)
+        const height = lineHeightInPixels + 2 * glyphPaddingInPixels
+        const { width: measuredGlyphWidth } = this._glyphContext.measureText(text)
+        const width =
+            Math.ceil(variantOffset) + Math.ceil(measuredGlyphWidth) + 2 * glyphPaddingInPixels
 
         if ((this._nextX + width) * devicePixelRatio > this._options.textureSizeInPixels) {
             this._nextX = 0
@@ -159,9 +164,11 @@ export class WebGLAtlas {
 
         const x = this._nextX
         const y = this._nextY
-        const style = getGlyphStyleString(isBold, isItalic)
-        this._glyphContext.font = `${style} ${this._options.fontSize} ${this._options.fontFamily}`
-        this._glyphContext.fillText(text, x + variantOffset, y + linePaddingInPixels / 2)
+        this._glyphContext.fillText(
+            text,
+            x + glyphPaddingInPixels + variantOffset,
+            y + glyphPaddingInPixels + linePaddingInPixels / 2,
+        )
         this._nextX += width
 
         return {
@@ -172,7 +179,7 @@ export class WebGLAtlas {
             textureV: y * devicePixelRatio / this._options.textureSizeInPixels,
             textureWidth: width * devicePixelRatio / this._options.textureSizeInPixels,
             textureHeight: height * devicePixelRatio / this._options.textureSizeInPixels,
-            subpixelWidth: subpixelWidth * devicePixelRatio,
+            subpixelWidth: measuredGlyphWidth * devicePixelRatio,
             variantOffset,
         } as WebGLGlyph
     }

--- a/browser/src/Renderer/WebGL/WebGLRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLRenderer.ts
@@ -82,6 +82,7 @@ export class WebGLRenderer implements INeovimRenderer {
             fontSize,
             lineHeightInPixels: fontHeightInPixels,
             linePaddingInPixels,
+            glyphPaddingInPixels: Math.ceil(fontHeightInPixels / 4),
             devicePixelRatio,
             offsetGlyphVariantCount,
             textureSizeInPixels: this._textureSizeInPixels,

--- a/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
@@ -93,6 +93,7 @@ const isWhiteSpace = (text: string) => text === null || text === "" || text === 
 
 export class WebGlTextRenderer {
     private _atlas: WebGLAtlas
+    private _glyphOverlapInPixels: number
     private _subpixelDivisor: number
     private _devicePixelRatio: number
 
@@ -113,8 +114,9 @@ export class WebGlTextRenderer {
         private _colorNormalizer: IColorNormalizer,
         atlasOptions: IWebGLAtlasOptions,
     ) {
-        this._devicePixelRatio = atlasOptions.devicePixelRatio
+        this._glyphOverlapInPixels = atlasOptions.glyphPaddingInPixels
         this._subpixelDivisor = atlasOptions.offsetGlyphVariantCount
+        this._devicePixelRatio = atlasOptions.devicePixelRatio
         this._atlas = new WebGLAtlas(this._gl, atlasOptions)
 
         this._firstPassProgram = createProgram(
@@ -274,6 +276,7 @@ export class WebGlTextRenderer {
     ) {
         const pixelRatioAdaptedFontWidth = fontWidthInPixels * this._devicePixelRatio
         const pixelRatioAdaptedFontHeight = fontHeightInPixels * this._devicePixelRatio
+        const pixelRatioAdaptedGlyphOverlap = this._glyphOverlapInPixels * this._devicePixelRatio
 
         let glyphCount = 0
         let y = 0
@@ -294,8 +297,8 @@ export class WebGlTextRenderer {
 
                     this.updateGlyphInstance(
                         glyphCount,
-                        Math.round(x - glyph.variantOffset),
-                        y,
+                        Math.round(x - glyph.variantOffset) - pixelRatioAdaptedGlyphOverlap,
+                        y - pixelRatioAdaptedGlyphOverlap,
                         glyph,
                         normalizedTextColor,
                     )


### PR DESCRIPTION
This should fix #2202, please see the issue for discussion and reasoning behind the changes