### PR TITLE
Performance: Limit chorded keys to evaluate

### DIFF
--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -20,6 +20,7 @@ export interface KeyBindingMap {
 }
 
 const MAX_DELAY_BETWEEN_KEY_CHORD = 250 /* milliseconds */
+const MAX_CHORD_SIZE = 4
 
 import { KeyboardResolver } from "./../Input/Keyboard/KeyboardResolver"
 
@@ -39,7 +40,7 @@ export const getRecentKeyPresses = (
     keys: KeyPressInfo[],
     maxTimeBetweenKeyPresses: number,
 ): KeyPressInfo[] => {
-    return keys.reduce(
+    const chords = keys.reduce(
         (prev, curr) => {
             if (prev.length === 0) {
                 return [curr]
@@ -55,6 +56,8 @@ export const getRecentKeyPresses = (
         },
         [] as KeyPressInfo[],
     )
+
+    return chords.slice(0, MAX_CHORD_SIZE)
 }
 
 export class InputManager implements Oni.Input.InputManager {


### PR DESCRIPTION
__Issue:__ This was mentioned in #1822 , and manifests when holding down a key (ie, holding the down arrow key when scrolling). The `keydown` handler takes longer and longer to execute until the CPU is pegged and the responsiveness suffers.

__Defect:__ In our `handleKey` method, we look at recent key presses to see if they match any chorded key bindings (like `input.bind('jk')`. We only look at recent keypresses (~250ms), however, this list grows and grows while the key is being held down.

__Fix:__ Cap the keys to evaluate to four most recent. This improves performance and should be more than sufficient for the chorded key feature. After this change, in my profiling, the `handleKey` method was no longer the bottleneck.

Would love to have some sort of performance regression test for issues like these - does anyone know of a service or infrastructure for this?