### PR TITLE
Fix #2205, enable sidebar.width config setting

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -376,7 +376,7 @@ const BaseConfiguration: IConfigurationValues = {
 
     "sidebar.enabled": true,
     "sidebar.default.open": true,
-    "sidebar.width": "50px",
+    "sidebar.width": "15em",
 
     "sidebar.marks.enabled": false,
     "sidebar.plugins.enabled": false,

--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -8,7 +8,6 @@ import styled, { keyframes } from "styled-components"
 
 import { Event, IDisposable, IEvent } from "oni-types"
 
-import { configuration } from "../Configuration"
 import { enableMouse, withProps } from "./../../UI/components/common"
 
 import { ISidebarEntry, ISidebarState, SidebarManager, SidebarPane } from "./SidebarStore"
@@ -65,6 +64,7 @@ export class SidebarContentSplit {
 
 export interface ISidebarContentViewProps extends ISidebarContentContainerProps {
     activeEntry: ISidebarEntry
+    width: string
 }
 
 export interface ISidebarContentContainerProps {
@@ -174,10 +174,7 @@ export class SidebarContentView extends React.PureComponent<
         const header = activeEntry && activeEntry.pane ? activeEntry.pane.title : null
 
         return (
-            <SidebarContentWrapper
-                className="sidebar-content"
-                width={configuration.getValue("sidebar.width")}
-            >
+            <SidebarContentWrapper className="sidebar-content" width={this.props.width}>
                 <SidebarHeaderView hasFocus={this.state.active} headerName={header} />
                 <SidebarInnerPaneWrapper key={activeEntry.id}>
                     {activeEntry.pane.render()}
@@ -200,6 +197,7 @@ export const mapStateToProps = (
     return {
         ...containerProps,
         activeEntry,
+        width: state.width,
     }
 }
 

--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -8,6 +8,7 @@ import styled, { keyframes } from "styled-components"
 
 import { Event, IDisposable, IEvent } from "oni-types"
 
+import { configuration } from "../Configuration"
 import { enableMouse, withProps } from "./../../UI/components/common"
 
 import { ISidebarEntry, ISidebarState, SidebarManager, SidebarPane } from "./SidebarStore"
@@ -82,7 +83,7 @@ const EntranceKeyframes = keyframes`
 
 export const SidebarContentWrapper = withProps<{}>(styled.div)`
     ${enableMouse}
-    width: 200px;
+    width: ${props => props.width};
     color: ${props => props.theme["editor.foreground"]};
     background-color: ${props => props.theme["editor.background"]};
     height: 100%;
@@ -173,7 +174,10 @@ export class SidebarContentView extends React.PureComponent<
         const header = activeEntry && activeEntry.pane ? activeEntry.pane.title : null
 
         return (
-            <SidebarContentWrapper className="sidebar-content">
+            <SidebarContentWrapper
+                className="sidebar-content"
+                width={configuration.getValue("sidebar.width")}
+            >
                 <SidebarHeaderView hasFocus={this.state.active} headerName={header} />
                 <SidebarInnerPaneWrapper key={activeEntry.id}>
                     {activeEntry.pane.render()}

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -87,7 +87,7 @@ export class SidebarManager {
         if (width) {
             this._store.dispatch({
                 type: "SET_WIDTH",
-                width: width,
+                width,
             })
         }
     }

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -7,6 +7,7 @@
 import { Reducer, Store } from "redux"
 import { createStore as createReduxStore } from "./../../Redux"
 
+import { configuration } from "../Configuration"
 import { WindowManager, WindowSplitHandle } from "./../WindowManager"
 import { SidebarContentSplit } from "./SidebarContentSplit"
 import { SidebarSplit } from "./SidebarSplit"
@@ -20,6 +21,8 @@ export interface ISidebarState {
     activeEntryId: string
 
     isActive: boolean
+
+    width: string
 }
 
 export type SidebarIcon = string
@@ -65,12 +68,27 @@ export class SidebarManager {
     constructor(private _windowManager: WindowManager = null) {
         this._store = createStore()
 
+        configuration.onConfigurationChanged.subscribe(val => {
+            if (typeof val["sidebar.width"] === "string") {
+                this.setWidth(val["sidebar.width"])
+            }
+        })
+
         if (_windowManager) {
             this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
             this._contentSplit = this._windowManager.createSplit(
                 "left",
                 new SidebarContentSplit(this),
             )
+        }
+    }
+
+    public setWidth(width: string): void {
+        if (width) {
+            this._store.dispatch({
+                type: "SET_WIDTH",
+                width: width,
+            })
         }
     }
 
@@ -139,6 +157,7 @@ const DefaultSidebarState: ISidebarState = {
     entries: [],
     activeEntryId: null,
     isActive: false,
+    width: configuration.getValue("sidebar.width"),
 }
 
 export type SidebarActions =
@@ -153,6 +172,10 @@ export type SidebarActions =
     | {
           type: "SET_NOTIFICATION"
           id: string
+      }
+    | {
+          type: "SET_WIDTH"
+          width: string
       }
     | {
           type: "ENTER"
@@ -180,6 +203,11 @@ export const sidebarReducer: Reducer<ISidebarState> = (
             return {
                 ...newState,
                 isActive: false,
+            }
+        case "SET_WIDTH":
+            return {
+                ...newState,
+                width: action.width,
             }
         case "SET_ACTIVE_ID":
             return {

--- a/browser/src/Services/Sidebar/SidebarStore.ts
+++ b/browser/src/Services/Sidebar/SidebarStore.ts
@@ -73,6 +73,7 @@ export class SidebarManager {
                 this.setWidth(val["sidebar.width"])
             }
         })
+        this.setWidth(configuration.getValue("sidebar.width"))
 
         if (_windowManager) {
             this._iconSplit = this._windowManager.createSplit("left", new SidebarSplit(this))
@@ -157,7 +158,7 @@ const DefaultSidebarState: ISidebarState = {
     entries: [],
     activeEntryId: null,
     isActive: false,
-    width: configuration.getValue("sidebar.width"),
+    width: null,
 }
 
 export type SidebarActions =


### PR DESCRIPTION
Fixes #2205.  The `DefaultConfiguration.ts` had an entry for `"sidebar.width": "200px"` but any attempt to modify the value was ignored.  This is because the value was actually hard-coded to be `200px`, ignoring the config completely.  I changed it to pull that value from the config instead.  Also, @badosu suggested we change the units from `px` to `em` to handle high-resolution displays.

The current state of the Pull Request is functional; it behaves exactly as I'd expect.  However, it doesn't automatically update when saving the config.  So you can't really play with values and see which size works best for you.  Instead, you have to close and re-open Oni each time to see the changes.  I'm putting `[WIP]` on the Pull Request because I'd like to fix the dynamic updating before merging in.