### PR TITLE
[WIP] Bugfix/do not clear oni backupdir on startup

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -136,6 +136,7 @@ const BaseConfiguration: IConfigurationValues = {
 
     "explorer.persistDeletedFiles": true,
     "explorer.maxUndoFileSizeInBytes": 500_000,
+    "explorer.backupDirectory": "oni_backup",
 
     "environment.additionalPaths": [],
 

--- a/browser/src/Services/Explorer/ExplorerFileSystem.ts
+++ b/browser/src/Services/Explorer/ExplorerFileSystem.ts
@@ -5,7 +5,7 @@
  */
 
 import * as fs from "fs"
-import { emptyDirSync, ensureDirSync, mkdirp, move, pathExists, remove, writeFile } from "fs-extra"
+import { ensureDirSync, mkdirp, move, pathExists, remove, writeFile } from "fs-extra"
 import * as os from "os"
 import * as path from "path"
 import { promisify } from "util"
@@ -53,7 +53,6 @@ export class FileSystem implements IFileSystem {
 
     public init = () => {
         ensureDirSync(this._backupDirectory)
-        emptyDirSync(this._backupDirectory)
     }
 
     public async readdir(directoryPath: string): Promise<FolderOrFile[]> {

--- a/browser/src/Services/Explorer/ExplorerFileSystem.ts
+++ b/browser/src/Services/Explorer/ExplorerFileSystem.ts
@@ -8,8 +8,10 @@ import * as fs from "fs"
 import { ensureDirSync, mkdirp, move, pathExists, remove, writeFile } from "fs-extra"
 import * as os from "os"
 import * as path from "path"
+import * as trash from "trash"
 import { promisify } from "util"
 
+import { configuration } from "./../../Services/Configuration"
 import { FolderOrFile } from "./ExplorerStore"
 
 /**
@@ -35,18 +37,26 @@ export class FileSystem implements IFileSystem {
         exists(path: string): Promise<boolean>
     }
 
-    private _backupDirectory = path.join(os.tmpdir(), "oni_backup")
+    private _backupDirectory: string
+    private _backupStrategy: string
 
     public get backupDir(): string {
         return this._backupDirectory
     }
 
-    constructor(nfs: typeof fs) {
+    public get backupStrategy(): string {
+        return this._backupStrategy
+    }
+
+    constructor(nfs: typeof fs, private _config = configuration) {
         this._fs = {
             readdir: promisify(nfs.readdir.bind(nfs)),
             stat: promisify(nfs.stat.bind(nfs)),
             exists: promisify(nfs.exists.bind(nfs)),
         }
+
+        this._backupStrategy = this._config.getValue("explorer.backupDirectory")
+        this._backupDirectory = this._getBackupDirectory(this._backupStrategy)
 
         this.init()
     }
@@ -100,6 +110,9 @@ export class FileSystem implements IFileSystem {
      * @param {string} fileOrFolder The file or folder path
      */
     public restoreNode = async (prevPath: string): Promise<void> => {
+        if (this._backupStrategy === "trash") {
+            return
+        }
         const name = path.basename(prevPath)
         const backupPath = path.join(this._backupDirectory, name)
         await move(backupPath, prevPath)
@@ -118,10 +131,13 @@ export class FileSystem implements IFileSystem {
     public persistNode = async (fileOrFolder: string): Promise<void> => {
         const { size } = await this._fs.stat(fileOrFolder)
         const hasEnoughSpace = os.freemem() > size
-        if (hasEnoughSpace) {
+
+        if (hasEnoughSpace && this._backupStrategy !== "trash") {
             const filename = path.basename(fileOrFolder)
             const newPath = path.join(this._backupDirectory, filename)
             await move(fileOrFolder, newPath, { overwrite: true })
+        } else if (this._backupStrategy === "trash") {
+            await trash(fileOrFolder)
         }
     }
 
@@ -171,6 +187,16 @@ export class FileSystem implements IFileSystem {
     }
 
     private areDifferent = (src: string, dest: string) => src !== dest
+
+    private _getBackupDirectory = (option: string) => {
+        switch (option) {
+            case "oni_backup":
+                return path.join(os.tmpdir(), "oni_backup")
+            case "trash":
+            default:
+                return option
+        }
+    }
 }
 
 export const OniFileSystem = new FileSystem(fs)

--- a/browser/src/Services/Explorer/trash.d.ts
+++ b/browser/src/Services/Explorer/trash.d.ts
@@ -1,0 +1,7 @@
+declare module "trash" {
+    interface Options {
+        glob: boolean
+    }
+
+    export default function trash(input: string[], opts?: Options): Promise<void>
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
     "homepage": "https://www.onivim.io",
     "version": "0.3.5",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
-    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
+    "keywords": [
+        "vim",
+        "neovim",
+        "text",
+        "editor",
+        "ide",
+        "vim"
+    ],
     "main": "./lib/main/src/main.js",
     "bin": {
         "oni": "./cli/oni",
@@ -44,23 +51,39 @@
         "mac": {
             "artifactName": "${productName}-${version}-osx.${ext}",
             "category": "public.app-category.developer-tools",
-            "target": ["dmg"],
-            "files": ["bin/osx/**/*"]
+            "target": [
+                "dmg"
+            ],
+            "files": [
+                "bin/osx/**/*"
+            ]
         },
         "linux": {
             "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
             "maintainer": "bryphe@outlook.com",
-            "target": ["tar.gz", "deb", "rpm"]
+            "target": [
+                "tar.gz",
+                "deb",
+                "rpm"
+            ]
         },
         "win": {
-            "target": ["zip", "dir"],
-            "files": ["bin/x86/**/*"]
+            "target": [
+                "zip",
+                "dir"
+            ],
+            "files": [
+                "bin/x86/**/*"
+            ]
         },
         "fileAssociations": [
             {
                 "name": "ADA source",
                 "role": "Editor",
-                "ext": ["adb", "ads"]
+                "ext": [
+                    "adb",
+                    "ads"
+                ]
             },
             {
                 "name": "Compiled AppleScript",
@@ -80,12 +103,20 @@
             {
                 "name": "ASP document",
                 "role": "Editor",
-                "ext": ["asp", "asa"]
+                "ext": [
+                    "asp",
+                    "asa"
+                ]
             },
             {
                 "name": "ASP.NET document",
                 "role": "Editor",
-                "ext": ["aspx", "ascx", "asmx", "ashx"]
+                "ext": [
+                    "aspx",
+                    "ascx",
+                    "asmx",
+                    "ashx"
+                ]
             },
             {
                 "name": "BibTeX bibliography",
@@ -100,7 +131,13 @@
             {
                 "name": "C++ source",
                 "role": "Editor",
-                "ext": ["cc", "cp", "cpp", "cxx", "c++"]
+                "ext": [
+                    "cc",
+                    "cp",
+                    "cpp",
+                    "cxx",
+                    "c++"
+                ]
             },
             {
                 "name": "C# source",
@@ -125,7 +162,10 @@
             {
                 "name": "Clojure source",
                 "role": "Editor",
-                "ext": ["clj", "cljs"]
+                "ext": [
+                    "clj",
+                    "cljs"
+                ]
             },
             {
                 "name": "Comma separated values",
@@ -140,12 +180,20 @@
             {
                 "name": "CGI script",
                 "role": "Editor",
-                "ext": ["cgi", "fcgi"]
+                "ext": [
+                    "cgi",
+                    "fcgi"
+                ]
             },
             {
                 "name": "Configuration file",
                 "role": "Editor",
-                "ext": ["cfg", "conf", "config", "htaccess"]
+                "ext": [
+                    "cfg",
+                    "conf",
+                    "config",
+                    "htaccess"
+                ]
             },
             {
                 "name": "Cascading style sheet",
@@ -170,7 +218,10 @@
             {
                 "name": "Erlang source",
                 "role": "Editor",
-                "ext": ["erl", "hrl"]
+                "ext": [
+                    "erl",
+                    "hrl"
+                ]
             },
             {
                 "name": "F-Script source",
@@ -180,17 +231,32 @@
             {
                 "name": "Fortran source",
                 "role": "Editor",
-                "ext": ["f", "for", "fpp", "f77", "f90", "f95"]
+                "ext": [
+                    "f",
+                    "for",
+                    "fpp",
+                    "f77",
+                    "f90",
+                    "f95"
+                ]
             },
             {
                 "name": "Header",
                 "role": "Editor",
-                "ext": ["h", "pch"]
+                "ext": [
+                    "h",
+                    "pch"
+                ]
             },
             {
                 "name": "C++ header",
                 "role": "Editor",
-                "ext": ["hh", "hpp", "hxx", "h++"]
+                "ext": [
+                    "hh",
+                    "hpp",
+                    "hxx",
+                    "h++"
+                ]
             },
             {
                 "name": "Go source",
@@ -200,17 +266,28 @@
             {
                 "name": "GTD document",
                 "role": "Editor",
-                "ext": ["gtd", "gtdlog"]
+                "ext": [
+                    "gtd",
+                    "gtdlog"
+                ]
             },
             {
                 "name": "Haskell source",
                 "role": "Editor",
-                "ext": ["hs", "lhs"]
+                "ext": [
+                    "hs",
+                    "lhs"
+                ]
             },
             {
                 "name": "HTML document",
                 "role": "Editor",
-                "ext": ["htm", "html", "phtml", "shtml"]
+                "ext": [
+                    "htm",
+                    "html",
+                    "phtml",
+                    "shtml"
+                ]
             },
             {
                 "name": "Include file",
@@ -250,7 +327,10 @@
             {
                 "name": "JavaScript source",
                 "role": "Editor",
-                "ext": ["js", "htc"]
+                "ext": [
+                    "js",
+                    "htc"
+                ]
             },
             {
                 "name": "Java Server Page",
@@ -275,7 +355,14 @@
             {
                 "name": "Lisp source",
                 "role": "Editor",
-                "ext": ["lisp", "cl", "l", "lsp", "mud", "el"]
+                "ext": [
+                    "lisp",
+                    "cl",
+                    "l",
+                    "lsp",
+                    "mud",
+                    "el"
+                ]
             },
             {
                 "name": "Log file",
@@ -295,7 +382,12 @@
             {
                 "name": "Markdown document",
                 "role": "Editor",
-                "ext": ["markdown", "mdown", "markdn", "md"]
+                "ext": [
+                    "markdown",
+                    "mdown",
+                    "markdn",
+                    "md"
+                ]
             },
             {
                 "name": "Makefile source",
@@ -305,17 +397,29 @@
             {
                 "name": "Mediawiki document",
                 "role": "Editor",
-                "ext": ["wiki", "wikipedia", "mediawiki"]
+                "ext": [
+                    "wiki",
+                    "wikipedia",
+                    "mediawiki"
+                ]
             },
             {
                 "name": "MIPS assembler source",
                 "role": "Editor",
-                "ext": ["s", "mips", "spim", "asm"]
+                "ext": [
+                    "s",
+                    "mips",
+                    "spim",
+                    "asm"
+                ]
             },
             {
                 "name": "Modula-3 source",
                 "role": "Editor",
-                "ext": ["m3", "cm3"]
+                "ext": [
+                    "m3",
+                    "cm3"
+                ]
             },
             {
                 "name": "MoinMoin document",
@@ -335,17 +439,28 @@
             {
                 "name": "OCaml source",
                 "role": "Editor",
-                "ext": ["ml", "mli", "mll", "mly"]
+                "ext": [
+                    "ml",
+                    "mli",
+                    "mll",
+                    "mly"
+                ]
             },
             {
                 "name": "Mustache document",
                 "role": "Editor",
-                "ext": ["mustache", "hbs"]
+                "ext": [
+                    "mustache",
+                    "hbs"
+                ]
             },
             {
                 "name": "Pascal source",
                 "role": "Editor",
-                "ext": ["pas", "p"]
+                "ext": [
+                    "pas",
+                    "p"
+                ]
             },
             {
                 "name": "Patch file",
@@ -355,7 +470,11 @@
             {
                 "name": "Perl source",
                 "role": "Editor",
-                "ext": ["pl", "pod", "perl"]
+                "ext": [
+                    "pl",
+                    "pod",
+                    "perl"
+                ]
             },
             {
                 "name": "Perl module",
@@ -365,47 +484,80 @@
             {
                 "name": "PHP source",
                 "role": "Editor",
-                "ext": ["php", "php3", "php4", "php5"]
+                "ext": [
+                    "php",
+                    "php3",
+                    "php4",
+                    "php5"
+                ]
             },
             {
                 "name": "PostScript source",
                 "role": "Editor",
-                "ext": ["ps", "eps"]
+                "ext": [
+                    "ps",
+                    "eps"
+                ]
             },
             {
                 "name": "Property list",
                 "role": "Editor",
-                "ext": ["dict", "plist", "scriptSuite", "scriptTerminology"]
+                "ext": [
+                    "dict",
+                    "plist",
+                    "scriptSuite",
+                    "scriptTerminology"
+                ]
             },
             {
                 "name": "Python source",
                 "role": "Editor",
-                "ext": ["py", "rpy", "cpy", "python"]
+                "ext": [
+                    "py",
+                    "rpy",
+                    "cpy",
+                    "python"
+                ]
             },
             {
                 "name": "R source",
                 "role": "Editor",
-                "ext": ["r", "s"]
+                "ext": [
+                    "r",
+                    "s"
+                ]
             },
             {
                 "name": "Ragel source",
                 "role": "Editor",
-                "ext": ["rl", "ragel"]
+                "ext": [
+                    "rl",
+                    "ragel"
+                ]
             },
             {
                 "name": "Remind document",
                 "role": "Editor",
-                "ext": ["rem", "remind"]
+                "ext": [
+                    "rem",
+                    "remind"
+                ]
             },
             {
                 "name": "reStructuredText document",
                 "role": "Editor",
-                "ext": ["rst", "rest"]
+                "ext": [
+                    "rst",
+                    "rest"
+                ]
             },
             {
                 "name": "HTML with embedded Ruby",
                 "role": "Editor",
-                "ext": ["rhtml", "erb"]
+                "ext": [
+                    "rhtml",
+                    "erb"
+                ]
             },
             {
                 "name": "SQL with embedded Ruby",
@@ -415,17 +567,28 @@
             {
                 "name": "Ruby source",
                 "role": "Editor",
-                "ext": ["rb", "rbx", "rjs", "rxml"]
+                "ext": [
+                    "rb",
+                    "rbx",
+                    "rjs",
+                    "rxml"
+                ]
             },
             {
                 "name": "Sass source",
                 "role": "Editor",
-                "ext": ["sass", "scss"]
+                "ext": [
+                    "sass",
+                    "scss"
+                ]
             },
             {
                 "name": "Scheme source",
                 "role": "Editor",
-                "ext": ["scm", "sch"]
+                "ext": [
+                    "scm",
+                    "sch"
+                ]
             },
             {
                 "name": "Setext document",
@@ -473,7 +636,10 @@
             {
                 "name": "SWIG source",
                 "role": "Editor",
-                "ext": ["i", "swg"]
+                "ext": [
+                    "i",
+                    "swg"
+                ]
             },
             {
                 "name": "Tcl source",
@@ -483,12 +649,20 @@
             {
                 "name": "TeX document",
                 "role": "Editor",
-                "ext": ["tex", "sty", "cls"]
+                "ext": [
+                    "tex",
+                    "sty",
+                    "cls"
+                ]
             },
             {
                 "name": "Plain text document",
                 "role": "Editor",
-                "ext": ["text", "txt", "utf8"]
+                "ext": [
+                    "text",
+                    "txt",
+                    "utf8"
+                ]
             },
             {
                 "name": "Textile document",
@@ -508,17 +682,32 @@
             {
                 "name": "XML document",
                 "role": "Editor",
-                "ext": ["xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml"]
+                "ext": [
+                    "xml",
+                    "xsd",
+                    "xib",
+                    "rss",
+                    "tld",
+                    "pt",
+                    "cpt",
+                    "dtml"
+                ]
             },
             {
                 "name": "XSL stylesheet",
                 "role": "Editor",
-                "ext": ["xsl", "xslt"]
+                "ext": [
+                    "xsl",
+                    "xslt"
+                ]
             },
             {
                 "name": "Electronic business card",
                 "role": "Editor",
-                "ext": ["vcf", "vcard"]
+                "ext": [
+                    "vcf",
+                    "vcard"
+                ]
             },
             {
                 "name": "Visual Basic source",
@@ -528,7 +717,10 @@
             {
                 "name": "YAML document",
                 "role": "Editor",
-                "ext": ["yaml", "yml"]
+                "ext": [
+                    "yaml",
+                    "yml"
+                ]
             },
             {
                 "name": "Text document",
@@ -590,95 +782,65 @@
     "scripts": {
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
-        "build":
-            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
-        "build-debug":
-            "yarn run build:browser-debug && yarn run build:main && yarn run build:plugins",
+        "build": "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
+        "build-debug": "yarn run build:browser-debug && yarn run build:main && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
         "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
         "build:main": "cd main && tsc -p tsconfig.json",
-        "build:plugins":
-            "yarn run build:plugin:oni-plugin-typescript && yarn run build:plugin:oni-plugin-markdown-preview",
+        "build:plugins": "yarn run build:plugin:oni-plugin-typescript && yarn run build:plugin:oni-plugin-markdown-preview",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
-        "build:plugin:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn run build",
+        "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:test": "yarn run build:test:unit && yarn run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "yarn run build:test:unit:browser && yarn run build:test:unit:main",
-        "build:test:unit:browser":
-            "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit:browser": "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
         "build:test:unit:main": "rimraf lib_test/main && cd main && tsc -p tsconfig.test.json",
         "build:webview_preload": "cd webview_preload && tsc -p tsconfig.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
-        "debug:test:unit:browser":
-            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "demo:screenshot":
-            "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
-        "demo:video":
-            "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
-        "dist:win:x86":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-        "dist:win:x64":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
-        "pack:win":
-            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo:screenshot": "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
+        "demo:video": "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
+        "dist:win:x86": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "dist:win:x64": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
+        "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "yarn run test:unit && yarn run test:integration",
-        "test:integration":
-            "yarn run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
+        "test:integration": "yarn run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:react": "jest --config ./jest.config.js ./ui-tests",
         "test:react:watch": "jest --config ./jest.config.js ./ui-tests --watch",
         "test:react:coverage": "jest --config ./jest.config.js ./ui-tests --coverage",
-        "test:unit:browser":
-            "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "test:unit:browser": "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
         "test:unit": "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:react",
-        "test:unit:main":
-            "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
+        "test:unit:main": "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
         "upload:dist": "node build/script/UploadDistributionBuildsToAzure",
         "fix-lint": "yarn run fix-lint:browser && yarn run fix-lint:main && yarn run fix-lint:test",
-        "fix-lint:browser":
-            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
         "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
         "lint": "yarn run lint:browser && yarn run lint:main && yarn run lint:test",
-        "lint:browser":
-            "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-        "lint:test":
-            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "ccov:instrument":
-            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-        "ccov:test:browser":
-            "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
-        "ccov:remap:browser:html":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
-        "ccov:remap:browser:lcov":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
+        "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser": "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
+        "ccov:remap:browser:html": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
+        "ccov:remap:browser:lcov": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
         "ccov:clean": "rimraf coverage",
         "ccov:upload": "codecov",
         "launch": "electron lib/main/src/main.js",
-        "start":
-            "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
-        "start-hot":
-            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start": "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
+        "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
         "start-not-dev": "cross-env electron main.js",
-        "watch:browser":
-            "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
-        "watch:plugins":
-            "yarn run watch:plugins:oni-plugin-typescript && yarn run watch:plugins:oni-plugin-markdown-preview",
+        "watch:browser": "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
+        "watch:plugins": "yarn run watch:plugins:oni-plugin-typescript && yarn run watch:plugins:oni-plugin-markdown-preview",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-        "watch:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
-        "install:plugins":
-            "yarn run install:plugins:oni-plugin-markdown-preview && yarn run install:plugins:oni-plugin-prettier",
-        "install:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
-        "install:plugins:oni-plugin-prettier":
-            "cd extensions/oni-plugin-prettier && yarn install --prod",
+        "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "install:plugins": "yarn run install:plugins:oni-plugin-markdown-preview && yarn run install:plugins:oni-plugin-prettier",
+        "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-prettier": "cd extensions/oni-plugin-prettier && yarn install --prod",
         "postinstall": "yarn run install:plugins && electron-rebuild && opencollective postinstall",
-        "profile:webpack":
-            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
+        "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
     "repository": {
         "type": "git",
@@ -710,6 +872,7 @@
         "shell-env": "^0.3.0",
         "shelljs": "0.7.7",
         "styled-components": "^3.2.6",
+        "trash": "^4.3.0",
         "typescript": "^2.8.1",
         "vscode-css-languageserver-bin": "^1.2.1",
         "vscode-html-languageserver-bin": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,16 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@sindresorhus/df@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-1.0.1.tgz#c69b66f52f6fcdd287c807df210305dbaf78500d"
+
+"@sindresorhus/df@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-2.1.0.tgz#d208cf27e06f0bb476d14d7deccd7d726e9aa389"
+  dependencies:
+    execa "^0.2.2"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -2741,6 +2751,13 @@ cross-env@3.1.3:
   dependencies:
     cross-spawn "^3.0.1"
 
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
+
 cross-spawn@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -3171,6 +3188,13 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -3692,6 +3716,10 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
+escape-string-applescript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-applescript/-/escape-string-applescript-2.0.0.tgz#760bca838668e408fe5ee52ce42caf7cb46c5273"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -3794,6 +3822,16 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.2.2.tgz#e2ead472c2c31aad6f73f1ac956eef45e12320cb"
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    npm-run-path "^1.0.0"
+    object-assign "^4.0.1"
+    path-key "^1.0.0"
+    strip-eof "^1.0.0"
 
 execa@^0.5.0:
   version "0.5.1"
@@ -4533,6 +4571,17 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 globule@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.0.tgz#1dc49c6822dd9e8a2fa00ba2a295006e8664bd09"
@@ -4983,6 +5032,10 @@ ieee754@1.1.8, ieee754@^1.1.4, ieee754@^1.1.8:
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
+
+ignore@^3.3.5:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
 ignore@^3.3.7:
   version "3.3.7"
@@ -6480,6 +6533,13 @@ lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
+lru-cache@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -6830,6 +6890,14 @@ moment@^2.11.2:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
 
+mount-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mount-point/-/mount-point-3.0.0.tgz#665cb9edebe80d110e658db56c31d0aef51a8f97"
+  dependencies:
+    "@sindresorhus/df" "^1.0.1"
+    pify "^2.3.0"
+    pinkie-promise "^2.0.1"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -7117,6 +7185,12 @@ normalize-url@^1.4.0:
 npm-install-package@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/npm-install-package/-/npm-install-package-2.1.0.tgz#d7efe3cfcd7ab00614b896ea53119dc9ab259125"
+
+npm-run-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
+  dependencies:
+    path-key "^1.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -7497,7 +7571,7 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
-p-map@^1.1.1:
+p-map@^1.1.1, p-map@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
@@ -7516,6 +7590,10 @@ p-timeout@^2.0.1:
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
   dependencies:
     p-finally "^1.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
 package-json@^4.0.0:
   version "4.0.1"
@@ -7630,6 +7708,10 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-key@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
+
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -7682,7 +7764,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -7690,7 +7772,7 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
-pinkie-promise@^2.0.0:
+pinkie-promise@^2.0.0, pinkie-promise@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
   dependencies:
@@ -8886,6 +8968,12 @@ rst-selector-parser@^2.2.3:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
 
+run-applescript@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-3.1.0.tgz#58865edbcc92b9644a330c4bfadedf5e26588c5d"
+  dependencies:
+    execa "^0.8.0"
+
 run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -9939,6 +10027,20 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+trash@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/trash/-/trash-4.3.0.tgz#6ebeecdea4d666b06e389b47d135ea88e1de5075"
+  dependencies:
+    escape-string-applescript "^2.0.0"
+    fs-extra "^0.30.0"
+    globby "^7.1.1"
+    p-map "^1.2.0"
+    p-try "^1.0.0"
+    pify "^3.0.0"
+    run-applescript "^3.0.0"
+    uuid "^3.1.0"
+    xdg-trashdir "^2.1.1"
+
 tree-kill@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
@@ -10272,6 +10374,12 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
     kind-of "^6.0.2"
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  dependencies:
+    os-homedir "^1.0.0"
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"
@@ -10768,7 +10876,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.1.1, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@1, which@^1.1.1, which@^1.2.12, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -10843,9 +10951,25 @@ ws@^4.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
+xdg-basedir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
+  dependencies:
+    os-homedir "^1.0.0"
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
+xdg-trashdir@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/xdg-trashdir/-/xdg-trashdir-2.1.1.tgz#59a60aaf8e6f9240c1daed9a0944b2f514c27d8e"
+  dependencies:
+    "@sindresorhus/df" "^2.1.0"
+    mount-point "^3.0.0"
+    pify "^2.2.0"
+    user-home "^2.0.0"
+    xdg-basedir "^2.0.0"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
As raised in #2213 currently the explorer deletes files/folders and despite being undoable, the backup dir is cleared on oni startup essentially taking the users opportunity to manually recover the files.

This PR aims to fix #2213 by adding
- [ ] a configuration option that a user can specify re the `backupStrategy`
allowing a user to delete to a specific dir or move to the `trashDir` or to oni's undoable backup dir
- [ ] add a notification to prompt a user before delete (this might have to come as different PR as it would require a slight rework of the delete functionality)