### PR TITLE
Refactoring: Move 'asObservable' from oni-types to oni core

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -75,7 +75,7 @@ import NeovimSurface from "./NeovimSurface"
 
 import { ContextMenuManager } from "./../../Services/ContextMenu"
 
-import { normalizePath, sleep } from "./../../Utility"
+import { normalizePath, sleep, asObservable } from "./../../Utility"
 
 import * as VimConfigurationSynchronizer from "./../../Services/VimConfigurationSynchronizer"
 
@@ -574,25 +574,25 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         // TODO: Does any disposal need to happen for the observables?
-        this._cursorMoved$ = this._neovimInstance.autoCommands.onCursorMoved
-            .asObservable()
-            .map((evt): Oni.Cursor => ({
+        this._cursorMoved$ = asObservable(this._neovimInstance.autoCommands.onCursorMoved).map(
+            (evt): Oni.Cursor => ({
                 line: evt.line - 1,
                 column: evt.column - 1,
-            }))
+            }),
+        )
 
-        this._cursorMovedI$ = this._neovimInstance.autoCommands.onCursorMovedI
-            .asObservable()
-            .map((evt): Oni.Cursor => ({
+        this._cursorMovedI$ = asObservable(this._neovimInstance.autoCommands.onCursorMovedI).map(
+            (evt): Oni.Cursor => ({
                 line: evt.line - 1,
                 column: evt.column - 1,
-            }))
+            }),
+        )
 
         Observable.merge(this._cursorMoved$, this._cursorMovedI$).subscribe(cursorMoved => {
             this.notifyCursorMoved(cursorMoved)
         })
 
-        this._modeChanged$ = this._neovimInstance.onModeChanged.asObservable()
+        this._modeChanged$ = asObservable(this._neovimInstance.onModeChanged)
 
         this.trackDisposable(
             this._neovimInstance.onModeChanged.subscribe(newMode => this._onModeChanged(newMode)),

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -75,7 +75,7 @@ import NeovimSurface from "./NeovimSurface"
 
 import { ContextMenuManager } from "./../../Services/ContextMenu"
 
-import { normalizePath, sleep, asObservable } from "./../../Utility"
+import { asObservable, normalizePath, sleep } from "./../../Utility"
 
 import * as VimConfigurationSynchronizer from "./../../Services/VimConfigurationSynchronizer"
 

--- a/browser/src/Editor/NeovimEditor/Symbols.ts
+++ b/browser/src/Editor/NeovimEditor/Symbols.ts
@@ -14,6 +14,7 @@ import { LanguageManager } from "./../../Services/Language"
 import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
 import { Definition } from "./Definition"
+import { asObservable } from "./../../Utility"
 
 export class Symbols {
     constructor(
@@ -34,7 +35,7 @@ export class Symbols {
         ])
         menu.setLoading(true)
 
-        const filterTextChanged$ = menu.onFilterTextChanged.asObservable()
+        const filterTextChanged$ = asObservable(menu.onFilterTextChanged)
 
         menu.onItemSelected.subscribe((selectedItem: Oni.Menu.MenuOption) => {
             const key = selectedItem.label + selectedItem.detail

--- a/browser/src/Editor/NeovimEditor/Symbols.ts
+++ b/browser/src/Editor/NeovimEditor/Symbols.ts
@@ -13,8 +13,8 @@ import { LanguageManager } from "./../../Services/Language"
 
 import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
-import { Definition } from "./Definition"
 import { asObservable } from "./../../Utility"
+import { Definition } from "./Definition"
 
 export class Symbols {
     constructor(

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -16,7 +16,7 @@ import { Observable } from "rxjs/Observable"
 import { Subject } from "rxjs/Subject"
 
 import * as JSON5 from "json5"
-import { IDisposable } from "oni-types"
+import { IDisposable, IEvent } from "oni-types"
 
 import * as types from "vscode-languageserver-types"
 
@@ -39,6 +39,14 @@ export class Disposable implements IDisposable {
     protected trackDisposable(disposable: IDisposable) {
         this._disposables.push(disposable)
     }
+}
+
+export const asObservable = <T>(event: IEvent<T>): Observable<T> => {
+    const subject = new Subject<T>()
+
+    event.subscribe((val: T) => subject.next(val))
+
+    return subject
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
     "homepage": "https://www.onivim.io",
     "version": "0.3.5",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
-    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
+    "keywords": [
+        "vim",
+        "neovim",
+        "text",
+        "editor",
+        "ide",
+        "vim"
+    ],
     "main": "./lib/main/src/main.js",
     "bin": {
         "oni": "./cli/oni",
@@ -44,23 +51,39 @@
         "mac": {
             "artifactName": "${productName}-${version}-osx.${ext}",
             "category": "public.app-category.developer-tools",
-            "target": ["dmg"],
-            "files": ["bin/osx/**/*"]
+            "target": [
+                "dmg"
+            ],
+            "files": [
+                "bin/osx/**/*"
+            ]
         },
         "linux": {
             "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
             "maintainer": "bryphe@outlook.com",
-            "target": ["tar.gz", "deb", "rpm"]
+            "target": [
+                "tar.gz",
+                "deb",
+                "rpm"
+            ]
         },
         "win": {
-            "target": ["zip", "dir"],
-            "files": ["bin/x86/**/*"]
+            "target": [
+                "zip",
+                "dir"
+            ],
+            "files": [
+                "bin/x86/**/*"
+            ]
         },
         "fileAssociations": [
             {
                 "name": "ADA source",
                 "role": "Editor",
-                "ext": ["adb", "ads"]
+                "ext": [
+                    "adb",
+                    "ads"
+                ]
             },
             {
                 "name": "Compiled AppleScript",
@@ -80,12 +103,20 @@
             {
                 "name": "ASP document",
                 "role": "Editor",
-                "ext": ["asp", "asa"]
+                "ext": [
+                    "asp",
+                    "asa"
+                ]
             },
             {
                 "name": "ASP.NET document",
                 "role": "Editor",
-                "ext": ["aspx", "ascx", "asmx", "ashx"]
+                "ext": [
+                    "aspx",
+                    "ascx",
+                    "asmx",
+                    "ashx"
+                ]
             },
             {
                 "name": "BibTeX bibliography",
@@ -100,7 +131,13 @@
             {
                 "name": "C++ source",
                 "role": "Editor",
-                "ext": ["cc", "cp", "cpp", "cxx", "c++"]
+                "ext": [
+                    "cc",
+                    "cp",
+                    "cpp",
+                    "cxx",
+                    "c++"
+                ]
             },
             {
                 "name": "C# source",
@@ -125,7 +162,10 @@
             {
                 "name": "Clojure source",
                 "role": "Editor",
-                "ext": ["clj", "cljs"]
+                "ext": [
+                    "clj",
+                    "cljs"
+                ]
             },
             {
                 "name": "Comma separated values",
@@ -140,12 +180,20 @@
             {
                 "name": "CGI script",
                 "role": "Editor",
-                "ext": ["cgi", "fcgi"]
+                "ext": [
+                    "cgi",
+                    "fcgi"
+                ]
             },
             {
                 "name": "Configuration file",
                 "role": "Editor",
-                "ext": ["cfg", "conf", "config", "htaccess"]
+                "ext": [
+                    "cfg",
+                    "conf",
+                    "config",
+                    "htaccess"
+                ]
             },
             {
                 "name": "Cascading style sheet",
@@ -170,7 +218,10 @@
             {
                 "name": "Erlang source",
                 "role": "Editor",
-                "ext": ["erl", "hrl"]
+                "ext": [
+                    "erl",
+                    "hrl"
+                ]
             },
             {
                 "name": "F-Script source",
@@ -180,17 +231,32 @@
             {
                 "name": "Fortran source",
                 "role": "Editor",
-                "ext": ["f", "for", "fpp", "f77", "f90", "f95"]
+                "ext": [
+                    "f",
+                    "for",
+                    "fpp",
+                    "f77",
+                    "f90",
+                    "f95"
+                ]
             },
             {
                 "name": "Header",
                 "role": "Editor",
-                "ext": ["h", "pch"]
+                "ext": [
+                    "h",
+                    "pch"
+                ]
             },
             {
                 "name": "C++ header",
                 "role": "Editor",
-                "ext": ["hh", "hpp", "hxx", "h++"]
+                "ext": [
+                    "hh",
+                    "hpp",
+                    "hxx",
+                    "h++"
+                ]
             },
             {
                 "name": "Go source",
@@ -200,17 +266,28 @@
             {
                 "name": "GTD document",
                 "role": "Editor",
-                "ext": ["gtd", "gtdlog"]
+                "ext": [
+                    "gtd",
+                    "gtdlog"
+                ]
             },
             {
                 "name": "Haskell source",
                 "role": "Editor",
-                "ext": ["hs", "lhs"]
+                "ext": [
+                    "hs",
+                    "lhs"
+                ]
             },
             {
                 "name": "HTML document",
                 "role": "Editor",
-                "ext": ["htm", "html", "phtml", "shtml"]
+                "ext": [
+                    "htm",
+                    "html",
+                    "phtml",
+                    "shtml"
+                ]
             },
             {
                 "name": "Include file",
@@ -250,7 +327,10 @@
             {
                 "name": "JavaScript source",
                 "role": "Editor",
-                "ext": ["js", "htc"]
+                "ext": [
+                    "js",
+                    "htc"
+                ]
             },
             {
                 "name": "Java Server Page",
@@ -275,7 +355,14 @@
             {
                 "name": "Lisp source",
                 "role": "Editor",
-                "ext": ["lisp", "cl", "l", "lsp", "mud", "el"]
+                "ext": [
+                    "lisp",
+                    "cl",
+                    "l",
+                    "lsp",
+                    "mud",
+                    "el"
+                ]
             },
             {
                 "name": "Log file",
@@ -295,7 +382,12 @@
             {
                 "name": "Markdown document",
                 "role": "Editor",
-                "ext": ["markdown", "mdown", "markdn", "md"]
+                "ext": [
+                    "markdown",
+                    "mdown",
+                    "markdn",
+                    "md"
+                ]
             },
             {
                 "name": "Makefile source",
@@ -305,17 +397,29 @@
             {
                 "name": "Mediawiki document",
                 "role": "Editor",
-                "ext": ["wiki", "wikipedia", "mediawiki"]
+                "ext": [
+                    "wiki",
+                    "wikipedia",
+                    "mediawiki"
+                ]
             },
             {
                 "name": "MIPS assembler source",
                 "role": "Editor",
-                "ext": ["s", "mips", "spim", "asm"]
+                "ext": [
+                    "s",
+                    "mips",
+                    "spim",
+                    "asm"
+                ]
             },
             {
                 "name": "Modula-3 source",
                 "role": "Editor",
-                "ext": ["m3", "cm3"]
+                "ext": [
+                    "m3",
+                    "cm3"
+                ]
             },
             {
                 "name": "MoinMoin document",
@@ -335,17 +439,28 @@
             {
                 "name": "OCaml source",
                 "role": "Editor",
-                "ext": ["ml", "mli", "mll", "mly"]
+                "ext": [
+                    "ml",
+                    "mli",
+                    "mll",
+                    "mly"
+                ]
             },
             {
                 "name": "Mustache document",
                 "role": "Editor",
-                "ext": ["mustache", "hbs"]
+                "ext": [
+                    "mustache",
+                    "hbs"
+                ]
             },
             {
                 "name": "Pascal source",
                 "role": "Editor",
-                "ext": ["pas", "p"]
+                "ext": [
+                    "pas",
+                    "p"
+                ]
             },
             {
                 "name": "Patch file",
@@ -355,7 +470,11 @@
             {
                 "name": "Perl source",
                 "role": "Editor",
-                "ext": ["pl", "pod", "perl"]
+                "ext": [
+                    "pl",
+                    "pod",
+                    "perl"
+                ]
             },
             {
                 "name": "Perl module",
@@ -365,47 +484,80 @@
             {
                 "name": "PHP source",
                 "role": "Editor",
-                "ext": ["php", "php3", "php4", "php5"]
+                "ext": [
+                    "php",
+                    "php3",
+                    "php4",
+                    "php5"
+                ]
             },
             {
                 "name": "PostScript source",
                 "role": "Editor",
-                "ext": ["ps", "eps"]
+                "ext": [
+                    "ps",
+                    "eps"
+                ]
             },
             {
                 "name": "Property list",
                 "role": "Editor",
-                "ext": ["dict", "plist", "scriptSuite", "scriptTerminology"]
+                "ext": [
+                    "dict",
+                    "plist",
+                    "scriptSuite",
+                    "scriptTerminology"
+                ]
             },
             {
                 "name": "Python source",
                 "role": "Editor",
-                "ext": ["py", "rpy", "cpy", "python"]
+                "ext": [
+                    "py",
+                    "rpy",
+                    "cpy",
+                    "python"
+                ]
             },
             {
                 "name": "R source",
                 "role": "Editor",
-                "ext": ["r", "s"]
+                "ext": [
+                    "r",
+                    "s"
+                ]
             },
             {
                 "name": "Ragel source",
                 "role": "Editor",
-                "ext": ["rl", "ragel"]
+                "ext": [
+                    "rl",
+                    "ragel"
+                ]
             },
             {
                 "name": "Remind document",
                 "role": "Editor",
-                "ext": ["rem", "remind"]
+                "ext": [
+                    "rem",
+                    "remind"
+                ]
             },
             {
                 "name": "reStructuredText document",
                 "role": "Editor",
-                "ext": ["rst", "rest"]
+                "ext": [
+                    "rst",
+                    "rest"
+                ]
             },
             {
                 "name": "HTML with embedded Ruby",
                 "role": "Editor",
-                "ext": ["rhtml", "erb"]
+                "ext": [
+                    "rhtml",
+                    "erb"
+                ]
             },
             {
                 "name": "SQL with embedded Ruby",
@@ -415,17 +567,28 @@
             {
                 "name": "Ruby source",
                 "role": "Editor",
-                "ext": ["rb", "rbx", "rjs", "rxml"]
+                "ext": [
+                    "rb",
+                    "rbx",
+                    "rjs",
+                    "rxml"
+                ]
             },
             {
                 "name": "Sass source",
                 "role": "Editor",
-                "ext": ["sass", "scss"]
+                "ext": [
+                    "sass",
+                    "scss"
+                ]
             },
             {
                 "name": "Scheme source",
                 "role": "Editor",
-                "ext": ["scm", "sch"]
+                "ext": [
+                    "scm",
+                    "sch"
+                ]
             },
             {
                 "name": "Setext document",
@@ -473,7 +636,10 @@
             {
                 "name": "SWIG source",
                 "role": "Editor",
-                "ext": ["i", "swg"]
+                "ext": [
+                    "i",
+                    "swg"
+                ]
             },
             {
                 "name": "Tcl source",
@@ -483,12 +649,20 @@
             {
                 "name": "TeX document",
                 "role": "Editor",
-                "ext": ["tex", "sty", "cls"]
+                "ext": [
+                    "tex",
+                    "sty",
+                    "cls"
+                ]
             },
             {
                 "name": "Plain text document",
                 "role": "Editor",
-                "ext": ["text", "txt", "utf8"]
+                "ext": [
+                    "text",
+                    "txt",
+                    "utf8"
+                ]
             },
             {
                 "name": "Textile document",
@@ -508,17 +682,32 @@
             {
                 "name": "XML document",
                 "role": "Editor",
-                "ext": ["xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml"]
+                "ext": [
+                    "xml",
+                    "xsd",
+                    "xib",
+                    "rss",
+                    "tld",
+                    "pt",
+                    "cpt",
+                    "dtml"
+                ]
             },
             {
                 "name": "XSL stylesheet",
                 "role": "Editor",
-                "ext": ["xsl", "xslt"]
+                "ext": [
+                    "xsl",
+                    "xslt"
+                ]
             },
             {
                 "name": "Electronic business card",
                 "role": "Editor",
-                "ext": ["vcf", "vcard"]
+                "ext": [
+                    "vcf",
+                    "vcard"
+                ]
             },
             {
                 "name": "Visual Basic source",
@@ -528,7 +717,10 @@
             {
                 "name": "YAML document",
                 "role": "Editor",
-                "ext": ["yaml", "yml"]
+                "ext": [
+                    "yaml",
+                    "yml"
+                ]
             },
             {
                 "name": "Text document",
@@ -590,95 +782,65 @@
     "scripts": {
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
-        "build":
-            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
-        "build-debug":
-            "yarn run build:browser-debug && yarn run build:main && yarn run build:plugins",
+        "build": "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
+        "build-debug": "yarn run build:browser-debug && yarn run build:main && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
         "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
         "build:main": "cd main && tsc -p tsconfig.json",
-        "build:plugins":
-            "yarn run build:plugin:oni-plugin-typescript && yarn run build:plugin:oni-plugin-markdown-preview",
+        "build:plugins": "yarn run build:plugin:oni-plugin-typescript && yarn run build:plugin:oni-plugin-markdown-preview",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
-        "build:plugin:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn run build",
+        "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:test": "yarn run build:test:unit && yarn run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "yarn run build:test:unit:browser && yarn run build:test:unit:main",
-        "build:test:unit:browser":
-            "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit:browser": "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
         "build:test:unit:main": "rimraf lib_test/main && cd main && tsc -p tsconfig.test.json",
         "build:webview_preload": "cd webview_preload && tsc -p tsconfig.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
-        "debug:test:unit:browser":
-            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "demo:screenshot":
-            "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
-        "demo:video":
-            "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
-        "dist:win:x86":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-        "dist:win:x64":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
-        "pack:win":
-            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo:screenshot": "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
+        "demo:video": "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
+        "dist:win:x86": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "dist:win:x64": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
+        "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "yarn run test:unit && yarn run test:integration",
-        "test:integration":
-            "yarn run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
+        "test:integration": "yarn run build:test && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:react": "jest --config ./jest.config.js ./ui-tests",
         "test:react:watch": "jest --config ./jest.config.js ./ui-tests --watch",
         "test:react:coverage": "jest --config ./jest.config.js ./ui-tests --coverage",
-        "test:unit:browser":
-            "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "test:unit:browser": "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
         "test:unit": "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:react",
-        "test:unit:main":
-            "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
+        "test:unit:main": "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
         "upload:dist": "node build/script/UploadDistributionBuildsToAzure",
         "fix-lint": "yarn run fix-lint:browser && yarn run fix-lint:main && yarn run fix-lint:test",
-        "fix-lint:browser":
-            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
         "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
         "lint": "yarn run lint:browser && yarn run lint:main && yarn run lint:test",
-        "lint:browser":
-            "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-        "lint:test":
-            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "ccov:instrument":
-            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-        "ccov:test:browser":
-            "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
-        "ccov:remap:browser:html":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
-        "ccov:remap:browser:lcov":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
+        "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser": "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
+        "ccov:remap:browser:html": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
+        "ccov:remap:browser:lcov": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
         "ccov:clean": "rimraf coverage",
         "ccov:upload": "codecov",
         "launch": "electron lib/main/src/main.js",
-        "start":
-            "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
-        "start-hot":
-            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start": "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
+        "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
         "start-not-dev": "cross-env electron main.js",
-        "watch:browser":
-            "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
-        "watch:plugins":
-            "yarn run watch:plugins:oni-plugin-typescript && yarn run watch:plugins:oni-plugin-markdown-preview",
+        "watch:browser": "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
+        "watch:plugins": "yarn run watch:plugins:oni-plugin-typescript && yarn run watch:plugins:oni-plugin-markdown-preview",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-        "watch:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
-        "install:plugins":
-            "yarn run install:plugins:oni-plugin-markdown-preview && yarn run install:plugins:oni-plugin-prettier",
-        "install:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
-        "install:plugins:oni-plugin-prettier":
-            "cd extensions/oni-plugin-prettier && yarn install --prod",
+        "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "install:plugins": "yarn run install:plugins:oni-plugin-markdown-preview && yarn run install:plugins:oni-plugin-prettier",
+        "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-prettier": "cd extensions/oni-plugin-prettier && yarn install --prod",
         "postinstall": "yarn run install:plugins && electron-rebuild && opencollective postinstall",
-        "profile:webpack":
-            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
+        "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
     "repository": {
         "type": "git",
@@ -701,7 +863,7 @@
         "oni-api": "^0.0.42",
         "oni-neovim-binaries": "0.1.1",
         "oni-ripgrep": "0.0.4",
-        "oni-types": "0.0.4",
+        "oni-types": "^0.0.8",
         "react": "16.0.0",
         "react-dnd": "^2.5.4",
         "react-dnd-html5-backend": "^2.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7348,9 +7348,9 @@ oni-ripgrep@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/oni-ripgrep/-/oni-ripgrep-0.0.4.tgz#8eb52383f4a3f92b8b5d8fe29d52e9d728a46b50"
 
-oni-types@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/oni-types/-/oni-types-0.0.4.tgz#97bc435565d5f4c3bdc50bd1700fd24dd5b6704b"
+oni-types@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/oni-types/-/oni-types-0.0.8.tgz#1dfe97eda3f2b97dfcb94609af25fc2e4172fa33"
 
 oniguruma@^6.0.1:
   version "6.2.1"


### PR DESCRIPTION
__Issue:__ `rxjs` is a heavyweight dependency in `oni-types`, and is only used for an `asObservable` method.

__Fix:__ Port `asObservable` to core for now.