### PR TITLE
Fix WebGL renderer for non-integer `devicePixelRatio`

### DIFF
--- a/browser/src/Renderer/WebGL/WebGLRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLRenderer.ts
@@ -76,7 +76,7 @@ export class WebGLRenderer implements INeovimRenderer {
         fontSize,
     }: IScreen) {
         const devicePixelRatio = window.devicePixelRatio
-        const offsetGlyphVariantCount = Math.max(4 / devicePixelRatio, 1)
+        const offsetGlyphVariantCount = Math.max(Math.ceil(4 / devicePixelRatio), 1)
         const atlasOptions = {
             fontFamily,
             fontSize,


### PR DESCRIPTION
This should fix #2220.

*Issue:*
The WebGL renderer is configured to render up to 4 different instances of any glyph into the atlas texture, each offset by another fraction of a pixel. This is done to ensure proper kerning for low-DPI screens; without it, each character would always start at a full pixel boundary.
The formula for determining how many different versions should be rendered previously worked like this:
`offsetGlyphVariantCount = Math.max(4 / devicePixelRatio, 1)`
For a non-integer `devicePixelRatio`, this results in a non-integer value for a variable that should determine a count, which makes no sense of course. The consequence was an error when this number was used as the length of an array.

*Fix:*
Just ensure that the count is an integer by using:
`offsetGlyphVariantCount = Math.max(Math.ceil(4 / devicePixelRatio), 1)`