### PR TITLE
WebGLRenderer: Lazily (re)initialize the glyph buffer with sufficient size

### DIFF
--- a/browser/src/Renderer/WebGL/WebGLSolidRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLSolidRenderer.ts
@@ -6,8 +6,6 @@ import {
     createUnitQuadVerticesBuffer,
 } from "./WebGLUtilities"
 
-// tslint:disable-next-line:no-bitwise
-const maxCellInstances = 1 << 14 // TODO find a reasonable way of determining this
 const solidInstanceFieldCount = 8
 const solidInstanceSizeInBytes = solidInstanceFieldCount * Float32Array.BYTES_PER_ELEMENT
 
@@ -81,6 +79,8 @@ export class WebGLSolidRenderer {
         viewportScaleX: number,
         viewportScaleY: number,
     ) {
+        const cellCount = columnCount * rowCount
+        this.recreateSolidInstancesArrayIfRequired(cellCount)
         const solidInstanceCount = this.populateSolidInstances(
             columnCount,
             rowCount,
@@ -95,7 +95,6 @@ export class WebGLSolidRenderer {
     private createBuffers() {
         this._unitQuadVerticesBuffer = createUnitQuadVerticesBuffer(this._gl)
         this._unitQuadElementIndicesBuffer = createUnitQuadElementIndicesBuffer(this._gl)
-        this._solidInstances = new Float32Array(maxCellInstances * solidInstanceFieldCount)
         this._solidInstancesBuffer = this._gl.createBuffer()
     }
 
@@ -150,6 +149,13 @@ export class WebGLSolidRenderer {
             4 * Float32Array.BYTES_PER_ELEMENT,
         )
         this._gl.vertexAttribDivisor(vertexShaderAttributes.colorRGBA, 1)
+    }
+
+    private recreateSolidInstancesArrayIfRequired(cellCount: number) {
+        const requiredArrayLength = cellCount * solidInstanceFieldCount
+        if (!this._solidInstances || this._solidInstances.length < requiredArrayLength) {
+            this._solidInstances = new Float32Array(requiredArrayLength)
+        }
     }
 
     private populateSolidInstances(

--- a/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
@@ -266,9 +266,9 @@ export class WebGlTextRenderer {
     }
 
     private recreateGlyphInstancesArrayIfRequired(cellCount: number) {
-        const requiredBufferLength = cellCount * glyphInstanceFieldCount
-        if (!this._glyphInstances || this._glyphInstances.length < requiredBufferLength) {
-            this._glyphInstances = new Float32Array(requiredBufferLength)
+        const requiredArrayLength = cellCount * glyphInstanceFieldCount
+        if (!this._glyphInstances || this._glyphInstances.length < requiredArrayLength) {
+            this._glyphInstances = new Float32Array(requiredArrayLength)
         }
     }
 

--- a/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
+++ b/browser/src/Renderer/WebGL/WebGLTextRenderer.ts
@@ -7,8 +7,6 @@ import {
     createUnitQuadVerticesBuffer,
 } from "./WebGLUtilities"
 
-// tslint:disable-next-line:no-bitwise
-const maxGlyphInstances = 1 << 14 // TODO find a reasonable way of determining this
 const glyphInstanceFieldCount = 13
 const glyphInstanceSizeInBytes = glyphInstanceFieldCount * Float32Array.BYTES_PER_ELEMENT
 
@@ -162,6 +160,8 @@ export class WebGlTextRenderer {
         viewportScaleX: number,
         viewportScaleY: number,
     ) {
+        const cellCount = columnCount * rowCount
+        this.recreateGlyphInstancesArrayIfRequired(cellCount)
         const glyphInstanceCount = this.populateGlyphInstances(
             columnCount,
             rowCount,
@@ -176,7 +176,6 @@ export class WebGlTextRenderer {
     private createBuffers() {
         this._unitQuadVerticesBuffer = createUnitQuadVerticesBuffer(this._gl)
         this._unitQuadElementIndicesBuffer = createUnitQuadElementIndicesBuffer(this._gl)
-        this._glyphInstances = new Float32Array(maxGlyphInstances * glyphInstanceFieldCount)
         this._glyphInstancesBuffer = this._gl.createBuffer()
     }
 
@@ -264,6 +263,13 @@ export class WebGlTextRenderer {
             11 * Float32Array.BYTES_PER_ELEMENT,
         )
         this._gl.vertexAttribDivisor(vertexShaderAttributes.atlasSize, 1)
+    }
+
+    private recreateGlyphInstancesArrayIfRequired(cellCount: number) {
+        const requiredBufferLength = cellCount * glyphInstanceFieldCount
+        if (!this._glyphInstances || this._glyphInstances.length < requiredBufferLength) {
+            this._glyphInstances = new Float32Array(requiredBufferLength)
+        }
     }
 
     private populateGlyphInstances(


### PR DESCRIPTION
@CrossR reported an issue with the `webgl` rendering strategy on his huge screen: When opening a file that completely filled the screen with characters, the renderer went blank.

*Issue:*
Up until now, we initialized the buffer where we put the glyph information for the GPU with a fixed size of `1 << 14`, i.e. `2^14` or 16384 glyphs.
With a sufficiently large screen, this limit could be exceeded. I was able to reproduce it with a viewport of 257x66 code cells (16191 cells + some more for the line numbers).

*Fix:*
Before each render, we check if the buffer length is sufficient for containing a screen that is completely filled with characters and re-initialize it with a sufficient length if not.