### PR TITLE
Add missing import for the RxJS `debounceTime` operator

### DIFF
--- a/browser/src/Services/Configuration/FileConfigurationProvider.ts
+++ b/browser/src/Services/Configuration/FileConfigurationProvider.ts
@@ -9,6 +9,7 @@ import * as isError from "lodash/isError"
 import * as mkdirp from "mkdirp"
 import * as path from "path"
 
+import "rxjs/add/operator/debounceTime"
 import { Subject } from "rxjs/Subject"
 
 import * as Oni from "oni-api"


### PR DESCRIPTION
The debug build on master is currently broken, at least for @CrossR and me. The error is described as a side note in #2220.

*Issue:*
Somewhere in the complete bundle, someone must have cleaned up our RxJS imports, which is a good thing. As a side effect however it now shows that the usage of `debounceTime` in `FileConfigurationProvider.ts` was not correctly implemented because the import of `rxjs/add/operator/debounceTime` was missing. The reason why it worked until now could be that we previously imported that impure module or even the complete `RxJS` library at a different position in the project.

*Fix:*
Add the import.