### PR TITLE
bugfix/ fix parsing issues in ui-test tabs

### DIFF
--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -9,9 +9,12 @@ import { Sneakable } from "../browser/src/UI/components/Sneakable"
 
 import { Tab, Tabs } from "../browser/src/UI/components/Tabs"
 
+const MockFileIcon = FileIcon as jest.Mock<{}>
+const MockSneakable = Sneakable as jest.Mock<Sneakable>
+
 describe("<Tabs /> Tests", () => {
-    FileIcon.mockImplementation(() => ({ render: jest.fn() }))
-    Sneakable.mockImplementation((props) => ({
+    MockFileIcon.mockImplementation(() => ({ render: jest.fn() }))
+    MockSneakable.mockImplementation(props => ({
         render: () => props.children,
     }))
 
@@ -177,12 +180,12 @@ describe("<Tabs /> Tests", () => {
         expect(sneakable.props().tag).toEqual(tab.props().name)
 
         wrapper.unmount()
-    });
+    })
 
     it("should call onTabSelect callback as Sneakable callback", () => {
-        Sneakable.mockImplementationOnce((props) => {
+        MockSneakable.mockImplementationOnce(props => {
             props.callback()
-        }
+        })
 
         const wrapper = mount(TabsContainingSingleTab)
         const sneakableTab = wrapper.find(Tab)
@@ -190,7 +193,7 @@ describe("<Tabs /> Tests", () => {
         expect(tabSelectFunction).toHaveBeenCalledWith(sneakableTab.props().id)
 
         wrapper.unmount()
-    });
+    })
 
     it("should pass tab icon file name as FileIcon fileName property ", () => {
         const wrapper = mount(TabsContainingSingleTab)
@@ -200,5 +203,5 @@ describe("<Tabs /> Tests", () => {
         expect(fileIcon.props().fileName).toEqual(tab.props().iconFileName)
 
         wrapper.unmount()
-    });
+    })
 })


### PR DESCRIPTION
Incredibly unusually somehow this file in `master` has a parsing error but this seems neither to have tripped up the tests nor failed to build in `ts` in merging this file into #1308, trying to commit fails as prettier suddenly *realises* its unable to parse this file.

It seems to have been failing silently previously which allowed for the semicolons (aka our prettier commit hook would ordinarily have removed them,
Also on `line 188` a parens was missing which should have thrown an error not entirely sure how/why it didn't till I tried merging it in. Also added some types as the `tss` complaining as the jest mocking unfortunately doesnt automatically replace the types for imported modules which are subsequently mocked with `jest.mock`