### PR TITLE
Bugfix/ remove call to clear the oni-backup dir on oni startup

### DIFF
--- a/browser/src/Services/Explorer/ExplorerFileSystem.ts
+++ b/browser/src/Services/Explorer/ExplorerFileSystem.ts
@@ -5,7 +5,7 @@
  */
 
 import * as fs from "fs"
-import { emptyDirSync, ensureDirSync, mkdirp, move, pathExists, remove, writeFile } from "fs-extra"
+import { ensureDirSync, mkdirp, move, pathExists, remove, writeFile } from "fs-extra"
 import * as os from "os"
 import * as path from "path"
 import { promisify } from "util"
@@ -53,7 +53,6 @@ export class FileSystem implements IFileSystem {
 
     public init = () => {
         ensureDirSync(this._backupDirectory)
-        emptyDirSync(this._backupDirectory)
     }
 
     public async readdir(directoryPath: string): Promise<FolderOrFile[]> {


### PR DESCRIPTION
A partial fix for #2213 and is a small part of #2214 but is a crucial fix that will stop the backup directory saved to the `tmp` dir from being deleted every time `oni` starts up (which was defeated the point of saving to the tmp dir where a user could potentially recover a any deleted files)