### PR TITLE
Config: add "editor.fontWeight"

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -1205,10 +1205,11 @@ export class NeovimEditor extends Editor implements IEditor {
     private _onConfigChanged(newValues: Partial<IConfigurationValues>): void {
         const fontFamily = this._configuration.getValue("editor.fontFamily")
         const fontSize = addDefaultUnitIfNeeded(this._configuration.getValue("editor.fontSize"))
+        const fontWeight = this._configuration.getValue("editor.fontWeight")
         const linePadding = this._configuration.getValue("editor.linePadding")
 
-        this._actions.setFont(fontFamily, fontSize)
-        this._neovimInstance.setFont(fontFamily, fontSize, linePadding)
+        this._actions.setFont(fontFamily, fontSize, fontWeight)
+        this._neovimInstance.setFont(fontFamily, fontSize, fontWeight, linePadding)
 
         Object.keys(newValues).forEach(key => {
             const value = newValues[key]

--- a/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorActions.ts
@@ -142,6 +142,7 @@ export interface ISetFont {
     payload: {
         fontFamily: string
         fontSize: string
+        fontWeight: string
     }
 }
 
@@ -493,11 +494,12 @@ export const setImeActive = (imeActive: boolean) => ({
     },
 })
 
-export const setFont = (fontFamily: string, fontSize: string) => ({
+export const setFont = (fontFamily: string, fontSize: string, fontWeight: string) => ({
     type: "SET_FONT",
     payload: {
         fontFamily,
         fontSize,
+        fontWeight,
     },
 })
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorReducer.ts
@@ -77,6 +77,7 @@ export function reducer<K extends keyof IConfigurationValues>(
                 ...s,
                 fontFamily: a.payload.fontFamily,
                 fontSize: a.payload.fontSize,
+                fontWeight: a.payload.fontWeight,
             }
         case "SET_MODE":
             return { ...s, ...{ mode: a.payload.mode } }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorStore.ts
@@ -58,6 +58,7 @@ export interface IState {
     fontPixelHeight: number
     fontFamily: string
     fontSize: string
+    fontWeight: string
     hasFocus: boolean
     mode: string
     definition: null | IDefinition
@@ -189,6 +190,7 @@ export const createDefaultState = (): IState => ({
     fontPixelHeight: 10,
     fontFamily: "",
     fontSize: "",
+    fontWeight: "",
     hasFocus: false,
     imeActive: false,
     mode: "normal",

--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -6,7 +6,12 @@ export interface IFontMeasurement {
     height: number
 }
 
-export function measureFont(fontFamily: string, fontSize: string, characterToTest = "H") {
+export function measureFont(
+    fontFamily: string,
+    fontSize: string,
+    fontWeight: string,
+    characterToTest = "H",
+) {
     const div = document.createElement("div")
 
     div.style.position = "absolute"
@@ -18,6 +23,7 @@ export function measureFont(fontFamily: string, fontSize: string, characterToTes
     div.textContent = characterToTest
     div.style.fontFamily = `${fontFamily},${FallbackFonts}`
     div.style.fontSize = fontSize
+    div.style.fontWeight = fontWeight
 
     const isItalicAvailable = isStyleAvailable(fontFamily, "italic", fontSize)
     const isBoldAvailable = isStyleAvailable(fontFamily, "bold", fontSize)

--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -123,13 +123,16 @@ export class CanvasRenderer implements INeovimRenderer {
     public _draw(screenInfo: IScreen, modifiedCells: IPosition[]): void {
         Performance.mark("CanvasRenderer.update.start")
 
-        this._canvasContext.font = screenInfo.fontSize + " " + screenInfo.fontFamily
+        this._canvasContext.font = `${screenInfo.fontWeight} ${screenInfo.fontSize} ${
+            screenInfo.fontFamily
+        }`
         this._canvasContext.textBaseline = "top"
         this._canvasContext.setTransform(this._devicePixelRatio, 0, 0, this._devicePixelRatio, 0, 0)
         this._canvasContext.imageSmoothingEnabled = false
 
         this._editorElement.style.fontFamily = screenInfo.fontFamily
         this._editorElement.style.fontSize = screenInfo.fontSize
+        this._editorElement.style.fontWeight = screenInfo.fontWeight
 
         const rowsToEdit = getSpansToEdit(this._grid, modifiedCells)
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -104,6 +104,7 @@ const BaseConfiguration: IConfigurationValues = {
 
     "editor.fontLigatures": true,
     "editor.fontSize": "12px",
+    "editor.fontWeight": "normal",
     "editor.fontFamily": "",
 
     "editor.linePadding": 2,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -153,6 +153,7 @@ export interface IConfigurationValues {
     // If true (default), ligatures are enabled
     "editor.fontLigatures": boolean
     "editor.fontSize": string
+    "editor.fontWeight": string
     "editor.fontFamily": string // Platform specific
 
     // Additional padding between lines

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -182,7 +182,7 @@ export interface INeovimInstance {
     // - Refactor remaining events into strongly typed events, as part of the interface
     on(event: string, handler: NeovimEventHandler): void
 
-    setFont(fontFamily: string, fontSize: string, linePadding: number): void
+    setFont(fontFamily: string, fontSize: string, fontWeight: string, linePadding: number): void
 
     getBufferIds(): Promise<number[]>
 
@@ -209,6 +209,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private _fontFamily: string
     private _fontSize: string
+    private _fontWeight: string
     private _fontWidthInPixels: number
     private _fontHeightInPixels: number
 
@@ -369,6 +370,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this._configuration = configuration
         this._fontFamily = this._configuration.getValue("editor.fontFamily")
         this._fontSize = addDefaultUnitIfNeeded(this._configuration.getValue("editor.fontSize"))
+        this._fontWeight = this._configuration.getValue("editor.fontWeight")
 
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
@@ -518,13 +520,20 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         return ret
     }
 
-    public setFont(fontFamily: string, fontSize: string, linePadding: number): void {
+    public setFont(
+        fontFamily: string,
+        fontSize: string,
+        fontWeight: string,
+        linePadding: number,
+    ): void {
         this._fontFamily = fontFamily
         this._fontSize = fontSize
+        this._fontWeight = fontWeight
 
         const { width, height, isBoldAvailable, isItalicAvailable } = measureFont(
             this._fontFamily,
             this._fontSize,
+            this._fontWeight,
         )
 
         this._fontWidthInPixels = width
@@ -535,6 +544,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             Actions.setFont({
                 fontFamily,
                 fontSize,
+                fontWeight,
                 fontWidthInPixels: width,
                 fontHeightInPixels: height + linePadding,
                 linePaddingInPixels: linePadding,

--- a/browser/src/neovim/Screen.ts
+++ b/browser/src/neovim/Screen.ts
@@ -27,6 +27,7 @@ export interface IScreen {
     fontFamily: null | string
     fontHeightInPixels: number
     fontSize: null | string
+    fontWeight: null | string
     fontWidthInPixels: number
     foregroundColor: string
     height: number
@@ -84,6 +85,7 @@ export class NeovimScreen implements IScreen {
     private _fontFamily: null | string = null
     private _fontHeightInPixels: number
     private _fontSize: null | string = null
+    private _fontWeight: null | string = null
     private _fontWidthInPixels: number
     private _foregroundColor: string = "#000000"
     private _grid: Grid<ICell> = new Grid<ICell>()
@@ -107,6 +109,10 @@ export class NeovimScreen implements IScreen {
 
     public get fontSize(): null | string {
         return this._fontSize
+    }
+
+    public get fontWeight(): null | string {
+        return this._fontWeight
     }
 
     public get fontWidthInPixels(): number {
@@ -249,6 +255,7 @@ export class NeovimScreen implements IScreen {
             case Actions.SET_FONT:
                 this._fontFamily = action.fontFamily
                 this._fontSize = action.fontSize
+                this._fontWeight = action.fontWeight
                 this._fontWidthInPixels = action.fontWidthInPixels
                 this._fontHeightInPixels = action.fontHeightInPixels
                 this._linePaddingInPixels = action.linePaddingInPixels

--- a/browser/src/neovim/actions.ts
+++ b/browser/src/neovim/actions.ts
@@ -42,6 +42,7 @@ export interface IKeyboardInputAction extends IAction {
 interface ISetFontArguments {
     fontFamily: string
     fontSize: string
+    fontWeight: string
     fontWidthInPixels: number
     fontHeightInPixels: number
     linePaddingInPixels: number
@@ -52,6 +53,7 @@ interface ISetFontArguments {
 export interface ISetFontAction extends IAction {
     fontFamily: string
     fontSize: string
+    fontWeight: string
     fontWidthInPixels: number
     fontHeightInPixels: number
     linePaddingInPixels: number
@@ -204,6 +206,7 @@ export function changeMode(mode: string): IChangeModeAction {
 export function setFont({
     fontFamily,
     fontSize,
+    fontWeight,
     fontWidthInPixels,
     fontHeightInPixels,
     linePaddingInPixels,
@@ -214,6 +217,7 @@ export function setFont({
         type: SET_FONT,
         fontFamily,
         fontSize,
+        fontWeight,
         fontWidthInPixels,
         fontHeightInPixels,
         linePaddingInPixels,

--- a/browser/test/Mocks/neovim.ts
+++ b/browser/test/Mocks/neovim.ts
@@ -34,6 +34,9 @@ export class MockScreen implements Neovim.IScreen {
     public get fontSize(): null | string {
         return null
     }
+    public get fontWeight(): null | string {
+        return null
+    }
     public get fontWidthInPixels(): number {
         return null
     }


### PR DESCRIPTION
This is response to #2161.

In some situations such as live coding, increasing font-weight is valuable.
This PR partially supports "editor.fontWeight".
Currently it works only in CanvasRenderer (not in WebGLRenderer).

Thanks

#### weight normal
![weight_normal](https://user-images.githubusercontent.com/9415800/40278600-0379f9ce-5c6f-11e8-9dcc-4a9bb181b408.png)

#### weight bold
![weight_bold](https://user-images.githubusercontent.com/9415800/40278606-1269f11e-5c6f-11e8-92b3-2dd0b5c20eb3.png)
