### PR TITLE
Allow for completions filter to be case insensitive

### DIFF
--- a/browser/src/Services/Completion/CompletionSelectors.ts
+++ b/browser/src/Services/Completion/CompletionSelectors.ts
@@ -4,6 +4,7 @@
  * Selectors are functions that take a state and derive a value from it.
  */
 
+import { configuration } from "./../Configuration"
 import { ICompletionState } from "./CompletionState"
 
 import * as types from "vscode-languageserver-types"
@@ -72,11 +73,24 @@ export const filterCompletionOptions = (
         return null
     }
 
-    const filterRegEx = new RegExp("^" + searchText.split("").join(".*") + ".*")
+    const shouldFilterBeCaseSensitive = configuration.getValue("editor.completions.caseSensitive")
+
+    const filterRegEx = shouldFilterBeCaseSensitive
+        ? new RegExp("^" + searchText.split("").join(".*") + ".*")
+        : new RegExp(
+              "^" +
+                  searchText
+                      .toLowerCase()
+                      .split("")
+                      .join(".*") +
+                  ".*",
+          )
 
     const filteredOptions = items.filter(f => {
         const textToFilterOn = f.filterText || f.label
-        return textToFilterOn.match(filterRegEx)
+        return shouldFilterBeCaseSensitive
+            ? textToFilterOn.match(filterRegEx)
+            : textToFilterOn.toLowerCase().match(filterRegEx)
     })
 
     return filteredOptions.sort((itemA, itemB) => {

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -99,6 +99,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.quickInfo.delay": 500,
 
     "editor.completions.mode": "oni",
+    "editor.completions.caseSensitive": true,
     "editor.errors.slideOnFocus": true,
     "editor.formatting.formatOnSwitchToNormalMode": false,
 
@@ -459,7 +460,9 @@ const LinuxConfigOverrides: Partial<IConfigurationValues> = {
 
 const PlatformConfigOverride = Platform.isWindows()
     ? WindowsConfigOverrides
-    : Platform.isLinux() ? LinuxConfigOverrides : MacConfigOverrides
+    : Platform.isLinux()
+        ? LinuxConfigOverrides
+        : MacConfigOverrides
 
 export const DefaultConfiguration = {
     ...BaseConfiguration,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -150,6 +150,9 @@ export interface IConfigurationValues {
     // a custom init.vim, as that may cause problematic behavior
     "editor.completions.mode": string
 
+    // Decide whether or not the completion matching should be case sensitive
+    "editor.completions.caseSensitive": boolean
+
     // If true (default), ligatures are enabled
     "editor.fontLigatures": boolean
     "editor.fontSize": string


### PR DESCRIPTION
I created an issue about this [#2230](https://github.com/onivim/oni/issues/2230). This change will just allow users to change the completion filter to not be case sensitive.

The setting "editor.completions.caseSensitive" can be set to `true` or `false` (`true` by default) and will tell the completion filter to be case sensitive or not.