### PR TITLE
Use same colors as other status line items for prettier plugin

### DIFF
--- a/extensions/oni-plugin-prettier/index.js
+++ b/extensions/oni-plugin-prettier/index.js
@@ -147,8 +147,6 @@ const activate = async Oni => {
 function createPrettierComponent(Oni, onClick) {
     const { React } = Oni.dependencies
 
-    const background = Oni.colors.getColor("highlight.mode.normal.background")
-    const foreground = Oni.colors.getColor("highlight.mode.normal.foreground")
     const style = {
         width: "100%",
         height: "100%",
@@ -157,8 +155,8 @@ function createPrettierComponent(Oni, onClick) {
         justifyContent: "center",
         paddingLeft: "8px",
         paddingRight: "8px",
-        color: "white",
-        backgroundColor: foreground,
+        backgroundColor: "rgb(35, 35, 35)",
+        color: "rgb(200, 200, 200)",
     }
 
     const prettierIcon = (type = "magic") =>


### PR DESCRIPTION
This is quick hack to fix this glaring issue.

There are some better approaches that can be made, but require some discussion before proceeding.

- Use a general higher order component for status bar items that shares the same style
- Allow each status line component to define it's own style, but define or use a theme color
- Continue as it is

Fixes #2157 