### PR TITLE
Automation: Improve assert logging for automation

### DIFF
--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -189,10 +189,21 @@ export class Automation implements OniApi.Automation.Api {
             this._getOrCreateTestContainer("automated-test-container"),
         )
 
-        resultElement.textContent = JSON.stringify({
-            passed,
-            exception: exception || null,
-        })
+        if (exception && exception.code && exception.code === "ERR_ASSERTION") {
+            resultElement.textContent = JSON.stringify({
+                passed,
+                exception: exception,
+                expected: exception.expected,
+                actual: exception.actual,
+                message: exception.message,
+                operator: exception.operator,
+            })
+        } else {
+            resultElement.textContent = JSON.stringify({
+                passed,
+                exception: exception || null,
+            })
+        }
     }
 
     private _createElement(className: string, parentElement: HTMLElement): HTMLDivElement {

--- a/browser/src/Services/Automation.ts
+++ b/browser/src/Services/Automation.ts
@@ -192,7 +192,7 @@ export class Automation implements OniApi.Automation.Api {
         if (exception && exception.code && exception.code === "ERR_ASSERTION") {
             resultElement.textContent = JSON.stringify({
                 passed,
-                exception: exception,
+                exception,
                 expected: exception.expected,
                 actual: exception.actual,
                 message: exception.message,


### PR DESCRIPTION
__Issue:__ We don't log the message when an assert fails, which is confusing.

__Fix:__ If the exception is an assertion error, log out extra details so we have context when logging.

As part of the work to extract the test framework in `oni-test`: https://github.com/onivim/oni-test/, I'm writing test cases for the framework itself. In particular, we should get correct error messages for asserts: https://github.com/onivim/oni-test/blob/7a90235fad1594645129707bd693a43c20ff9745/test/FailureTests.ts#L29

That test is blocked by this behavior, since we don't do a good job today bubbling this up from the 'in-proc' test to the outside world.
