### PR TITLE
Implement setTextOptions for Editor

### DIFF
--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -86,6 +86,10 @@ export class Editor extends Disposable implements Oni.Editor {
         return Promise.reject("Not implemented")
     }
 
+    public setTextOptions(options: Oni.EditorTextOptions): Promise<void> {
+        return Promise.reject("Not implemented")
+    }
+
     protected setMode(mode: Oni.Vim.Mode): void {
         if (mode !== this._currentMode) {
             this._currentMode = mode

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -866,6 +866,19 @@ export class NeovimEditor extends Editor implements IEditor {
         await this._neovimInstance.request("nvim_call_atomic", [atomicCalls])
     }
 
+    public async setTextOptions(textOptions: Oni.EditorTextOptions): Promise<void> {
+        const { insertSpacesForTab, tabSize } = textOptions
+        if (insertSpacesForTab) {
+            await this._neovimInstance.command("set expandtab")
+        } else {
+            await this._neovimInstance.command("set noexpandtab")
+        }
+
+        await this._neovimInstance.command(
+            `set tabstop=${tabSize} shiftwidth=${tabSize} softtabstop=${tabSize}`,
+        )
+    }
+
     public async openFile(
         file: string,
         openOptions: Oni.FileOpenOptions = Oni.DefaultFileOpenOptions,

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -246,6 +246,10 @@ export class OniEditor extends Utility.Disposable implements IEditor {
         return this._neovimEditor.setSelection(range)
     }
 
+    public async setTextOptions(textOptions: Oni.EditorTextOptions): Promise<void> {
+        return this._neovimEditor.setTextOptions(textOptions)
+    }
+
     public async blockInput(
         inputFunction: (input: Oni.InputCallbackFunction) => Promise<void>,
     ): Promise<void> {

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -177,6 +177,10 @@ class AnyEditorProxy implements Oni.Editor {
         return this._activeEditor.getBuffers()
     }
 
+    public setTextOptions(options: Oni.EditorTextOptions): Promise<void> {
+        return this._activeEditor.setTextOptions(options)
+    }
+
     /**
      * Internal methods
      */

--- a/package.json
+++ b/package.json
@@ -860,7 +860,7 @@
         "minimist": "1.2.0",
         "msgpack-lite": "0.1.26",
         "ocaml-language-server": "^1.0.27",
-        "oni-api": "^0.0.44",
+        "oni-api": "^0.0.45",
         "oni-neovim-binaries": "0.1.1",
         "oni-ripgrep": "0.0.4",
         "oni-types": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7323,9 +7323,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@^0.0.44:
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.44.tgz#26e4999ba5da0be0e7f25b6705c2d5412fe4eb23"
+oni-api@^0.0.45:
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.45.tgz#e9191fbc5069e01b3cbea644bc697be9aaf1d699"
 
 oni-neovim-binaries@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
This upgrades to `oni-api@0.0.45` and implements the `setTextOptions` method (which sets tabbing/indentation options). This isn't used in this PR, but will be for #1288 