### PR TITLE
Fix #2163 - Override persisted workspace if folder passed in

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -6,6 +6,7 @@
 
 import { ipcRenderer } from "electron"
 import * as minimist from "minimist"
+import * as fs from "fs"
 import * as path from "path"
 
 import { IDisposable } from "oni-types"
@@ -100,9 +101,26 @@ export const start = async (args: string[]): Promise<void> => {
 
     const parsedArgs = minimist(args)
     const currentWorkingDirectory = process.cwd()
-    const filesToOpen = parsedArgs._.map(
+    const normalizedFiles = parsedArgs._.map(
         arg => (path.isAbsolute(arg) ? arg : path.join(currentWorkingDirectory, arg)),
     )
+
+    const filesToOpen = normalizedFiles.filter(f => fs.existsSync(f) && fs.statSync(f).isFile())
+    const foldersToOpen = normalizedFiles.filter(
+        f => fs.existsSync(f) && fs.statSync(f).isDirectory(),
+    )
+
+    console.log("Files to open: " + JSON.stringify(filesToOpen))
+    console.log("Folders to open: " + JSON.stringify(foldersToOpen))
+
+    let workspaceToLoad = null
+
+    // If a folder has been specified, we'll change directory to it
+    if (foldersToOpen.length > 0) {
+        workspaceToLoad = foldersToOpen[0]
+    } else if (filesToOpen.length > 0) {
+        workspaceToLoad = path.dirname(filesToOpen[0])
+    }
 
     // Helper for debugging:
     Performance.startMeasure("Oni.Start.Config")
@@ -167,7 +185,7 @@ export const start = async (args: string[]): Promise<void> => {
     const { editorManager } = await editorManagerPromise
 
     const Workspace = await workspacePromise
-    Workspace.activate(configuration, editorManager)
+    Workspace.activate(configuration, editorManager, workspaceToLoad)
     const workspace = Workspace.getInstance()
 
     const WindowManager = await windowManagerPromise

--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -5,8 +5,8 @@
  */
 
 import { ipcRenderer } from "electron"
-import * as minimist from "minimist"
 import * as fs from "fs"
+import * as minimist from "minimist"
 import * as path from "path"
 
 import { IDisposable } from "oni-types"
@@ -110,8 +110,8 @@ export const start = async (args: string[]): Promise<void> => {
         f => fs.existsSync(f) && fs.statSync(f).isDirectory(),
     )
 
-    console.log("Files to open: " + JSON.stringify(filesToOpen))
-    console.log("Folders to open: " + JSON.stringify(foldersToOpen))
+    Log.info("Files to open: " + JSON.stringify(filesToOpen))
+    Log.info("Folders to open: " + JSON.stringify(foldersToOpen))
 
     let workspaceToLoad = null
 

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -183,12 +183,16 @@ export class Workspace implements IWorkspace {
 let _workspace: Workspace = null
 let _workspaceConfiguration: WorkspaceConfiguration = null
 
-export const activate = (configuration: Configuration, editorManager: EditorManager): void => {
+export const activate = (
+    configuration: Configuration,
+    editorManager: EditorManager,
+    workspaceToLoad?: string,
+): void => {
     _workspace = new Workspace(editorManager, configuration)
 
     _workspaceConfiguration = new WorkspaceConfiguration(configuration, _workspace)
 
-    const defaultWorkspace = configuration.getValue("workspace.defaultWorkspace")
+    const defaultWorkspace = workspaceToLoad || configuration.getValue("workspace.defaultWorkspace")
 
     if (defaultWorkspace) {
         _workspace.changeDirectory(defaultWorkspace)


### PR DESCRIPTION
__Issue:__ As described in #2163 - if you run `oni <dir>`, Oni doesn't open the directory as expected - it always loads a persisted workspace.

__Defect:__ Workspace activation would always grab the latest persisted workspace, and wouldn't care about the arguments passed in.

__Fix:__ Implement the logic proposed by @badosu - if a folder is passed as an argument, we'll use that, and explicitly set the workspace. If a file is passed in, we'll use the file's directory as the workspace. Otherwise, we'll defer to the persisted workspace.

Unfortunately, our current CiTest framework doesn't support an easy way to automate these cases - but this something I'd like to address in the next version of our automation - https://github.com/onivim/oni-test It should be easy to pass parameters to automated tests 😄 