### PR TITLE
Fix #2185 - Remove call to set scrollbind

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -214,7 +214,6 @@ export class Buffer implements IBuffer {
             ["nvim_command", ["setlocal noswapfile"]],
             ["nvim_command", ["setlocal nobuflisted"]],
             ["nvim_command", ["setlocal nomodifiable"]],
-            ["nvim_command", ["windo set scrollbind!"]],
         ]
 
         const [result, error] = await this._neovimInstance.request<any[] | NvimError>(


### PR DESCRIPTION
This PR removes the scroll binding of the reference buffer, fixes #2185. This is the only point in the app where we call `scrollbind` so removing it should resolve this issue.