### PR TITLE
Fix empty item in QuickOpen

### DIFF
--- a/browser/src/Services/QuickOpen/FinderProcess.ts
+++ b/browser/src/Services/QuickOpen/FinderProcess.ts
@@ -63,6 +63,8 @@ export class FinderProcess {
 
             if (!isCleanEnd) {
                 this._lastData = splitData.pop()
+            } else {
+                splitData.splice(-1, 1)
             }
 
             this._onData.dispatch(splitData)

--- a/browser/src/Services/QuickOpen/FinderProcess.ts
+++ b/browser/src/Services/QuickOpen/FinderProcess.ts
@@ -48,24 +48,17 @@ export class FinderProcess {
             cwd: this._workspace.activeWorkspace,
         })
         this._process.stdout.on("data", data => {
-            if (!data) {
+            const { didExtract, remnant, splitData } = extractSplitData(
+                data,
+                this._splitCharacter,
+                this._lastData,
+            )
+
+            if (!didExtract) {
                 return
             }
 
-            const dataString = data.toString()
-            const isCleanEnd = dataString.endsWith(this._splitCharacter)
-            const splitData = dataString.split(this._splitCharacter)
-
-            if (this._lastData && splitData.length > 0) {
-                splitData[0] = this._lastData + splitData[0]
-                this._lastData = ""
-            }
-
-            if (!isCleanEnd) {
-                this._lastData = splitData.pop()
-            } else {
-                splitData.splice(-1, 1)
-            }
+            this._lastData = remnant
 
             this._onData.dispatch(splitData)
         })
@@ -82,4 +75,33 @@ export class FinderProcess {
     public stop(): void {
         this._process.kill()
     }
+}
+
+export const extractSplitData = (
+    data: string | Buffer,
+    splitCharacter: string,
+    lastRemnant: string,
+) => {
+    if (!data) {
+        return {
+            didExtract: false,
+            remnant: "",
+            splitData: [],
+        }
+    }
+
+    const dataString = lastRemnant + data.toString()
+    const isCleanEnd = dataString.endsWith(splitCharacter)
+    const splitData = dataString.split(splitCharacter)
+
+    let remnant = ""
+
+    if (!isCleanEnd) {
+        remnant = splitData.pop()
+    } else {
+        // split leaves behind an empty string in the array if the string to split ends with the delimiter
+        splitData.splice(-1, 1)
+    }
+
+    return { didExtract: true, remnant, splitData }
 }

--- a/browser/test/Services/QuickOpen/FinderProcessTests.ts
+++ b/browser/test/Services/QuickOpen/FinderProcessTests.ts
@@ -1,0 +1,60 @@
+/**
+ * FinderProcessTests.ts
+ */
+
+import * as assert from "assert"
+import { extractSplitData } from "../../../src/Services/QuickOpen/FinderProcess"
+
+describe("extractSplitData", () => {
+    it("Splits the data by the delimiter", () => {
+        const data = "file1\nfile2\nfile3\n"
+        const delimiter = "\n"
+        const lastRemnant = ""
+
+        const { splitData } = extractSplitData(data, delimiter, lastRemnant)
+
+        assert.equal(splitData.length, 3)
+    })
+
+    it("Ignores empty input", () => {
+        const data = ""
+        const delimiter = "\n"
+        const lastRemnant = ""
+
+        const { didExtract } = extractSplitData(data, delimiter, lastRemnant)
+
+        assert.equal(didExtract, false)
+    })
+
+    it("Returns a remnant if the data doesn't end with the delimiter", () => {
+        const data = "file1\nfile2"
+        const delimiter = "\n"
+        const lastRemnant = ""
+
+        const { remnant, splitData } = extractSplitData(data, delimiter, lastRemnant)
+
+        assert.equal(remnant, "file2")
+        assert.equal(splitData.length, 1)
+    })
+
+    it("Returns an empty remnant if the data does end with the delimiter", () => {
+        const data = "file1\nfile2\n"
+        const delimiter = "\n"
+        const lastRemnant = ""
+
+        const { remnant } = extractSplitData(data, delimiter, lastRemnant)
+
+        assert.equal(remnant, "")
+    })
+
+    it("Prepends the last remnant if there was one", () => {
+        const data = "e1\nfile2\n"
+        const delimiter = "\n"
+        const lastRemnant = "fil"
+
+        const { splitData } = extractSplitData(data, delimiter, lastRemnant)
+
+        assert.equal(splitData.length, 2)
+        assert.equal(splitData[0], "file1")
+    })
+})


### PR DESCRIPTION
I've been seeing this empty item in my QuickOpen:
![image](https://user-images.githubusercontent.com/3701912/40873256-e1830318-6611-11e8-8265-5da03f2ae9dc.png)

Turns out it was a small bug in `FinderProcess` where splitting the data returned from ripgrep was looking for strings ending in `\n`, but calling `split` on a string ending in a delimiter will return an array whose last element is the empty string.