### PR TITLE
Feature/ Add keyboard shortcut to edit oni config

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -47,6 +47,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<m-h>", "oni.editor.hide")
         input.bind("<c-tab>", "buffer.toggle")
         input.bind("<m-s-f>", "search.searchAllFiles")
+        input.bind("<m-,>", "oni.config.openConfigJs")
 
         if (config.getValue("editor.clipboard.enabled")) {
             input.bind("<m-c>", "editor.clipboard.yank", isVisualMode)
@@ -66,6 +67,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         input.bind("<s-c-t>", "language.symbols.document")
         input.bind("<c-tab>", "buffer.toggle")
         input.bind("<s-c-f>", "search.searchAllFiles")
+        input.bind("<c-,>", "oni.config.openConfigJs")
 
         if (config.getValue("editor.clipboard.enabled")) {
             input.bind("<c-c>", "editor.clipboard.yank", isVisualMode)

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -67,6 +67,7 @@ export const buildMenu = (mainWindow, loadInit) => {
         submenu: [
             {
                 label: "Edit Oni config",
+                accelerator: "CmdOrCtrl+,",
                 click(item, focusedWindow) {
                     executeOniCommand(focusedWindow, "oni.config.openConfigJs")
                 },
@@ -77,6 +78,7 @@ export const buildMenu = (mainWindow, loadInit) => {
     if (loadInit) {
         preferences.submenu.push({
             label: "Edit Neovim config",
+            accelerator: null,
             click(item, focusedWindow) {
                 executeOniCommand(focusedWindow, "oni.config.openInitVim")
             },


### PR DESCRIPTION
Issue #2276
This change allows pressing `CMD+,` (Mac) to open oni config file.  Keystroke is `CTRL+,` on Windows and Linux platforms. 
<img width="495" alt="screen shot 2018-06-02 at 5 13 32 pm" src="https://user-images.githubusercontent.com/9834975/40880969-321c9434-6689-11e8-83bf-dc9bc98de48d.png">
![open config](https://user-images.githubusercontent.com/9834975/40880978-5de4bb96-6689-11e8-9bf5-51b2b4433b45.gif)