### PR TITLE
Allow explorer root to toggle

### DIFF
--- a/browser/src/Services/Explorer/ExplorerSelectors.ts
+++ b/browser/src/Services/Explorer/ExplorerSelectors.ts
@@ -80,7 +80,7 @@ export const mapStateToNodeList = (state: IExplorerState): ExplorerNode[] => {
     ret.push({
         id: "explorer",
         type: "container",
-        expanded: true,
+        expanded: !!state.expandedFolders[state.rootFolder.fullPath],
         name: state.rootFolder.fullPath,
     })
 

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -112,7 +112,9 @@ export class ExplorerSplit {
     }
 
     private _inputInProgress = () => {
-        const { register: { rename, create } } = this._store.getState()
+        const {
+            register: { rename, create },
+        } = this._store.getState()
         return rename.active || create.active
     }
 
@@ -239,18 +241,16 @@ export class ExplorerSplit {
                 // Should be being called with an ID not an active editor
                 windowManager.focusSplit("oni.window.0")
                 return
+            case "container":
             case "folder":
-                const isDirectoryExpanded = ExplorerSelectors.isPathExpanded(
-                    state,
-                    selectedItem.folderPath,
-                )
+                const directoryPath =
+                    selectedItem.type === "container" ? selectedItem.name : selectedItem.folderPath
+                const isDirectoryExpanded = ExplorerSelectors.isPathExpanded(state, directoryPath)
                 this._store.dispatch({
                     type: isDirectoryExpanded ? "COLLAPSE_DIRECTORY" : "EXPAND_DIRECTORY",
-                    directoryPath: selectedItem.folderPath,
+                    directoryPath,
                 })
                 return
-            default:
-                alert("Not implemented yet.") // tslint:disable-line
         }
     }
 
@@ -337,7 +337,9 @@ export class ExplorerSplit {
     }
 
     private _onUndoItem(): void {
-        const { register: { undo } } = this._store.getState()
+        const {
+            register: { undo },
+        } = this._store.getState()
         if (undo.length) {
             this._store.dispatch({ type: "UNDO" })
         }
@@ -349,7 +351,9 @@ export class ExplorerSplit {
             return
         }
 
-        const { register: { yank } } = this._store.getState()
+        const {
+            register: { yank },
+        } = this._store.getState()
         const inYankRegister = yank.some(({ id }) => id === selectedItem.id)
 
         if (!inYankRegister) {
@@ -365,7 +369,9 @@ export class ExplorerSplit {
             return
         }
 
-        const { register: { yank } } = this._store.getState()
+        const {
+            register: { yank },
+        } = this._store.getState()
 
         if (yank.length && pasteTarget) {
             const sources = yank.map(

--- a/browser/test/Services/Explorer/ExplorerSelectorsTests.ts
+++ b/browser/test/Services/Explorer/ExplorerSelectorsTests.ts
@@ -88,4 +88,41 @@ describe("ExplorerSelectors", () => {
             assert.deepEqual(result, expectedResult)
         })
     })
+
+    describe("mapStateToNodeList", () => {
+        it("expands the root container", () => {
+            const state: ExplorerState.IExplorerState = {
+                ...ExplorerState.DefaultExplorerState,
+                rootFolder: {
+                    type: "folder",
+                    fullPath: "rootPath",
+                },
+                expandedFolders: {
+                    rootPath: [],
+                },
+            }
+
+            const result = ExplorerSelectors.mapStateToNodeList(state)
+
+            const container = result[0] as ExplorerSelectors.IContainerNode
+            assert.strictEqual(container.type, "container")
+            assert.strictEqual(container.expanded, true)
+        })
+
+        it("collapses the root container", () => {
+            const state: ExplorerState.IExplorerState = {
+                ...ExplorerState.DefaultExplorerState,
+                rootFolder: {
+                    type: "folder",
+                    fullPath: "rootPath",
+                },
+                expandedFolders: {},
+            }
+            const result = ExplorerSelectors.mapStateToNodeList(state)
+
+            const container = result[0] as ExplorerSelectors.IContainerNode
+            assert.strictEqual(container.type, "container")
+            assert.strictEqual(container.expanded, false)
+        })
+    })
 })


### PR DESCRIPTION
This lets the user expand/collapse the root folder in the explorer by clicking on it, the same way that non-root folders can be expanded/collapsed. Sure, this is not immensely useful, but it's less alarming than a ‘Not implemented yet’ alert.