### PR TITLE
Fix clipboard content trimming

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -4,6 +4,7 @@
  * IEditor implementation for Neovim
  */
 
+import * as os from "os"
 import * as React from "react"
 
 import "rxjs/add/observable/defer"
@@ -420,7 +421,9 @@ export class NeovimEditor extends Editor implements IEditor {
                     const isAllowed = isYankAndAllowed || isDeleteAndAllowed
 
                     if (isAllowed) {
-                        clipboard.writeText(yankInfo.regcontents.join(require("os").EOL))
+                        const content = yankInfo.regcontents.join(os.EOL)
+                        const postfix = yankInfo.regtype === "V" ? os.EOL : ""
+                        clipboard.writeText(content + postfix)
                     }
                 }
             }),


### PR DESCRIPTION
Tested on Ubuntu, will appreciate another tester or scenarios.

**Cases tested:**
 
1. Copy a line and paste a few lines below (using `yy` and `p`).
2. Copy a line without the line termination and paste it between other characters (`v$hy`)

Also tried copy-pasting back and forth between Oni and a non-Vim-ish text editor.