### PR TITLE
Make FileSystem.readdir more robust

### DIFF
--- a/browser/src/Services/Explorer/ExplorerFileSystem.ts
+++ b/browser/src/Services/Explorer/ExplorerFileSystem.ts
@@ -60,8 +60,11 @@ export class FileSystem implements IFileSystem {
 
         const filesAndFolders = files.map(async f => {
             const fullPath = path.join(directoryPath, f)
-            const stat = await this._fs.stat(fullPath)
-            if (stat.isDirectory()) {
+            const isDirectory = await this._fs
+                .stat(fullPath)
+                .then(stat => stat.isDirectory())
+                .catch(() => false)
+            if (isDirectory) {
                 return {
                     type: "folder",
                     fullPath,


### PR DESCRIPTION
This specific change is motivated by a broken symlink on Linux, which
will show up in an fs.readdir but will cause an error with fs.stat. If
there are other situations where fs.stat will produce an error on a
result returned from fs.readdir, this is probably the right thing to do
in those as well.