### PR TITLE
[WIP] Skip CI for commits that only contain markdown changes.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,12 @@ branches:
     - master
     - /^release.*/
 
+# Skip CI build if the changes match these rules exactly.
+# Ie, if the BACKERS.md file is changed, we don't need to build.
+skip_commits:
+  files:
+    - '**/*.md'
+
 cache:
     - .oni_build_cache -> package.json 
 


### PR DESCRIPTION
This should speed up the AppVeyor build queue, since currently each time a backer is added, it uses 40 mins of build time, for no changes to the code!

Unfortunately, it looks like the same functionality isn't available on Travis: https://github.com/travis-ci/travis-ci/issues/6301

I've left this PR as [WIP] for now, as I might make a few other changes to the CI and its easier than creating lots of little PRs, especially if I end up undoing it.