### PR TITLE
[GrammarLoader] Properly check if key is in cache, #1940 fix

### DIFF
--- a/browser/src/Services/SyntaxHighlighting/GrammarLoader.ts
+++ b/browser/src/Services/SyntaxHighlighting/GrammarLoader.ts
@@ -38,7 +38,7 @@ export class GrammarLoader implements IGrammarLoader {
             return null
         }
 
-        if (this._grammarCache[language]) {
+        if (language in this._grammarCache) {
             return this._grammarCache[language]
         }
 


### PR DESCRIPTION
The current check will invalidate the grammar cache if the previous run returned null.
This is because the key is in the cache but the value is null.
I think this was not intended since it forces a sync expensive function to be re-run every time `getGrammarForLanguage` is called resulting in really bad performance and making the app unusable.
_For example when scrolling this method is called hundreds of times._

Also I cannot think of a situation the grammar is going to be found in the next call if the previous failed.
This also fixes #1940