### PR TITLE
Add hidden option to Menu bar.

### DIFF
--- a/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
+++ b/browser/src/Services/BrowserWindowConfigurationSynchronizer.ts
@@ -45,9 +45,13 @@ export const activate = (configuration: Configuration, colors: Colors) => {
             document.body.style["-webkit-font-smoothing"] = fontSmoothing
         }
 
-        const hideMenu: boolean = configuration.getValue("oni.hideMenu")
-        browserWindow.setAutoHideMenuBar(hideMenu)
-        browserWindow.setMenuBarVisibility(!hideMenu)
+        const hideMenu: boolean | "hidden" = configuration.getValue("oni.hideMenu")
+        if (hideMenu === "hidden") {
+            browserWindow.setMenu(null)
+        } else {
+            browserWindow.setAutoHideMenuBar(hideMenu)
+            browserWindow.setMenuBarVisibility(!hideMenu)
+        }
 
         const loadInit: boolean = configuration.getValue("oni.loadInitVim")
         if (loadInit !== loadInitVim) {

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -93,7 +93,8 @@ export interface IConfigurationValues {
 
     // If true, hide Menu bar by default
     // (can still be activated by pressing 'Alt')
-    "oni.hideMenu": boolean
+    // If hidden, menu bar is hidden entirely.
+    "oni.hideMenu": boolean | "hidden"
 
     // glob pattern of files to exclude from fuzzy finder (Ctrl-P)
     "oni.exclude": string[]


### PR DESCRIPTION
This adds an option to hide the menu bar entirely, so alt does not trigger it at all.

Fixes #2336 and I seem to think possibly other issues.

One point I am not quite sure on is if there should be/is a need to have some other way of toggling the menu bar, like a command? That way a user could still toggle it with a command in the `Ctrl-Shift-P` menu etc.

If that is the case, then it would instead need to be hidden and have alt unbound from it, since the currently strategy  removes the menu entirely.