### PR TITLE
Show full modifier key names in KeyDisplayer

### DIFF
--- a/browser/src/Input/KeyParser.ts
+++ b/browser/src/Input/KeyParser.ts
@@ -84,3 +84,35 @@ export const parseKey = (key: string): IKey => {
         meta: hasMeta,
     }
 }
+
+export const parseChordParts = (keys: string): string[] => {
+    const parsedKeys = parseKeysFromVimString(keys)
+
+    if (!parsedKeys || !parsedKeys.chord || parsedKeys.chord.length === 0) {
+        return null
+    }
+
+    const firstChord = parsedKeys.chord[0]
+
+    const chordParts: string[] = []
+
+    if (firstChord.meta) {
+        chordParts.push("meta")
+    }
+
+    if (firstChord.control) {
+        chordParts.push("control")
+    }
+
+    if (firstChord.alt) {
+        chordParts.push("alt")
+    }
+
+    if (firstChord.shift) {
+        chordParts.push("shift")
+    }
+
+    chordParts.push(firstChord.character)
+
+    return chordParts
+}

--- a/browser/src/Input/KeyParser.ts
+++ b/browser/src/Input/KeyParser.ts
@@ -85,6 +85,8 @@ export const parseKey = (key: string): IKey => {
     }
 }
 
+// Parse a chord string (e.g. <c-s-p>) into textual descriptions of the relevant keys
+// <c-s-p> -> ["control", "shift", "p"]
 export const parseChordParts = (keys: string): string[] => {
     const parsedKeys = parseKeysFromVimString(keys)
 

--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -145,6 +145,38 @@ export class InputManager implements Oni.Input.InputManager {
         return parseKeysFromVimString(keys)
     }
 
+    public getChordParts(keys: string): string[] {
+        const parsedKeys = inputManager.parseKeys(keys)
+
+        if (!parsedKeys || !parsedKeys.chord || parsedKeys.chord.length === 0) {
+            return null
+        }
+
+        const firstChord = parsedKeys.chord[0]
+
+        const chordParts: string[] = []
+
+        if (firstChord.meta) {
+            chordParts.push("meta")
+        }
+
+        if (firstChord.control) {
+            chordParts.push("control")
+        }
+
+        if (firstChord.alt) {
+            chordParts.push("alt")
+        }
+
+        if (firstChord.shift) {
+            chordParts.push("shift")
+        }
+
+        chordParts.push(firstChord.character)
+
+        return chordParts
+    }
+
     /**
      * Internal Methods
      */

--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -8,8 +8,6 @@ export type ActionOrCommand = string | ActionFunction
 
 export type FilterFunction = () => boolean
 
-import { IKeyChord, parseKeysFromVimString } from "./../Input/KeyParser"
-
 export interface KeyBinding {
     action: ActionOrCommand
     filter?: FilterFunction
@@ -139,42 +137,6 @@ export class InputManager implements Oni.Input.InputManager {
             },
             [] as string[],
         )
-    }
-
-    public parseKeys(keys: string): IKeyChord {
-        return parseKeysFromVimString(keys)
-    }
-
-    public getChordParts(keys: string): string[] {
-        const parsedKeys = inputManager.parseKeys(keys)
-
-        if (!parsedKeys || !parsedKeys.chord || parsedKeys.chord.length === 0) {
-            return null
-        }
-
-        const firstChord = parsedKeys.chord[0]
-
-        const chordParts: string[] = []
-
-        if (firstChord.meta) {
-            chordParts.push("meta")
-        }
-
-        if (firstChord.control) {
-            chordParts.push("control")
-        }
-
-        if (firstChord.alt) {
-            chordParts.push("alt")
-        }
-
-        if (firstChord.shift) {
-            chordParts.push("shift")
-        }
-
-        chordParts.push(firstChord.character)
-
-        return chordParts
     }
 
     /**

--- a/browser/src/Services/KeyDisplayer/KeyDisplayer.tsx
+++ b/browser/src/Services/KeyDisplayer/KeyDisplayer.tsx
@@ -14,6 +14,7 @@ import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 import { InputManager } from "./../InputManager"
 import { Overlay, OverlayManager } from "./../Overlay"
+import { parseChordParts } from "./../../Input/KeyParser"
 
 import { createStore, KeyDisplayerState } from "./KeyDisplayerStore"
 import { KeyDisplayerContainer } from "./KeyDisplayerView"
@@ -53,7 +54,7 @@ export class KeyDisplayer {
 
                 this._store.dispatch({
                     type: "ADD_KEY",
-                    key: this._inputManager.getChordParts(resolution).join("+"),
+                    key: parseChordParts(resolution).join("+"),
                     timeInMilliseconds: new Date().getTime(),
                 })
 

--- a/browser/src/Services/KeyDisplayer/KeyDisplayer.tsx
+++ b/browser/src/Services/KeyDisplayer/KeyDisplayer.tsx
@@ -53,7 +53,7 @@ export class KeyDisplayer {
 
                 this._store.dispatch({
                     type: "ADD_KEY",
-                    key: resolution,
+                    key: this._inputManager.getChordParts(resolution).join("+"),
                     timeInMilliseconds: new Date().getTime(),
                 })
 

--- a/browser/src/Services/KeyDisplayer/KeyDisplayer.tsx
+++ b/browser/src/Services/KeyDisplayer/KeyDisplayer.tsx
@@ -10,11 +10,11 @@ import { Store } from "redux"
 
 import { IDisposable } from "oni-types"
 
+import { parseChordParts } from "./../../Input/KeyParser"
 import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 import { InputManager } from "./../InputManager"
 import { Overlay, OverlayManager } from "./../Overlay"
-import { parseChordParts } from "./../../Input/KeyParser"
 
 import { createStore, KeyDisplayerState } from "./KeyDisplayerStore"
 import { KeyDisplayerContainer } from "./KeyDisplayerView"

--- a/browser/src/Services/KeyDisplayer/KeyDisplayerView.tsx
+++ b/browser/src/Services/KeyDisplayer/KeyDisplayerView.tsx
@@ -33,7 +33,7 @@ export class KeyDisplayerView extends React.PureComponent<IKeyDisplayerViewProps
     public render(): JSX.Element {
         const keyElements = this.props.groupedKeys.map((k, idx) => (
             <KeyWrapper style={{ bottom: KeyHeight + (KeyHeight + Margin) * idx + "px" }}>
-                {k.map(keyPress => keyPress.key).join("")}
+                {k.map(keyPress => keyPress.key).join(" ")}
             </KeyWrapper>
         ))
 

--- a/browser/src/Services/KeyDisplayer/KeyDisplayerView.tsx
+++ b/browser/src/Services/KeyDisplayer/KeyDisplayerView.tsx
@@ -29,22 +29,11 @@ export interface IKeyDisplayerViewProps {
     groupedKeys: IKeyPressInfo[][]
 }
 
-const getStringForKey = (key: string) => {
-    if (key === "<space>") {
-        return " "
-    }
-
-    return key
-}
-
 export class KeyDisplayerView extends React.PureComponent<IKeyDisplayerViewProps, {}> {
     public render(): JSX.Element {
         const keyElements = this.props.groupedKeys.map((k, idx) => (
             <KeyWrapper style={{ bottom: KeyHeight + (KeyHeight + Margin) * idx + "px" }}>
-                {k.reduce<string>(
-                    (prev: string, cur: IKeyPressInfo) => prev + getStringForKey(cur.key),
-                    "",
-                )}
+                {k.map(keyPress => keyPress.key).join("")}
             </KeyWrapper>
         ))
 

--- a/browser/src/UI/components/KeyBindingInfo.tsx
+++ b/browser/src/UI/components/KeyBindingInfo.tsx
@@ -40,7 +40,7 @@ export class KeyBindingInfo extends React.PureComponent<IKeyBindingInfoProps, {}
                 {parseChordParts(boundKeys[0])
                     .reduce((acc, chordKey) => acc.concat(chordKey, "+"), [])
                     .slice(0, -1)
-                    .map(chordPart => <KeyWrapper>{chordPart}</KeyWrapper>)}
+                    .map((chordPart, index) => <KeyWrapper key={index}>{chordPart}</KeyWrapper>)}
             </span>
         )
     }

--- a/browser/src/UI/components/KeyBindingInfo.tsx
+++ b/browser/src/UI/components/KeyBindingInfo.tsx
@@ -9,6 +9,7 @@ import styled from "styled-components"
 import * as React from "react"
 
 import { inputManager } from "./../../Services/InputManager"
+import { parseChordParts } from "./../../Input/KeyParser"
 
 export interface IKeyBindingInfoProps {
     command: string
@@ -36,8 +37,7 @@ export class KeyBindingInfo extends React.PureComponent<IKeyBindingInfoProps, {}
         // 3. Create KeyWrappers for each segment
         return (
             <span>
-                {inputManager
-                    .getChordParts(boundKeys[0])
+                {parseChordParts(boundKeys[0])
                     .reduce((acc, chordKey) => acc.concat(chordKey, "+"), [])
                     .slice(0, -1)
                     .map(chordPart => <KeyWrapper>{chordPart}</KeyWrapper>)}

--- a/browser/src/UI/components/KeyBindingInfo.tsx
+++ b/browser/src/UI/components/KeyBindingInfo.tsx
@@ -8,8 +8,8 @@ import styled from "styled-components"
 
 import * as React from "react"
 
-import { inputManager } from "./../../Services/InputManager"
 import { parseChordParts } from "./../../Input/KeyParser"
+import { inputManager } from "./../../Services/InputManager"
 
 export interface IKeyBindingInfoProps {
     command: string

--- a/browser/src/UI/components/KeyBindingInfo.tsx
+++ b/browser/src/UI/components/KeyBindingInfo.tsx
@@ -31,39 +31,18 @@ export class KeyBindingInfo extends React.PureComponent<IKeyBindingInfoProps, {}
             return null
         }
 
-        const parsedKeys = inputManager.parseKeys(boundKeys[0])
-
-        if (!parsedKeys || !parsedKeys.chord || !parsedKeys.chord.length) {
-            return null
-        }
-
-        const firstChord = parsedKeys.chord[0]
-
-        const elems: JSX.Element[] = []
-
-        if (firstChord.meta) {
-            elems.push(<KeyWrapper>{"meta"}</KeyWrapper>)
-            elems.push(<KeyWrapper>{"+"}</KeyWrapper>)
-        }
-
-        if (firstChord.control) {
-            elems.push(<KeyWrapper>{"control"}</KeyWrapper>)
-            elems.push(<KeyWrapper>{"+"}</KeyWrapper>)
-        }
-
-        if (firstChord.alt) {
-            elems.push(<KeyWrapper>{"alt"}</KeyWrapper>)
-            elems.push(<KeyWrapper>{"+"}</KeyWrapper>)
-        }
-
-        if (firstChord.shift) {
-            elems.push(<KeyWrapper>{"shift"}</KeyWrapper>)
-            elems.push(<KeyWrapper>{"+"}</KeyWrapper>)
-        }
-
-        elems.push(<KeyWrapper>{firstChord.character}</KeyWrapper>)
-
-        return <span>{elems}</span>
+        // 1. Get the key(s) in the chord binding
+        // 2. Intersperse with "+"
+        // 3. Create KeyWrappers for each segment
+        return (
+            <span>
+                {inputManager
+                    .getChordParts(boundKeys[0])
+                    .reduce((acc, chordKey) => acc.concat(chordKey, "+"), [])
+                    .slice(0, -1)
+                    .map(chordPart => <KeyWrapper>{chordPart}</KeyWrapper>)}
+            </span>
+        )
     }
 }
 

--- a/browser/test/Input/KeyParserTests.ts
+++ b/browser/test/Input/KeyParserTests.ts
@@ -34,7 +34,7 @@ describe("KeyParser", () => {
 
     describe("parseChordParts", () => {
         it("parses modifier keys", () => {
-            const tests: [string, string[]][] = [
+            const tests: Array<[string, string[]]> = [
                 ["a", ["a"]],
                 ["<c-a>", ["control", "a"]],
                 ["<m-a>", ["meta", "a"]],

--- a/browser/test/Input/KeyParserTests.ts
+++ b/browser/test/Input/KeyParserTests.ts
@@ -31,4 +31,26 @@ describe("KeyParser", () => {
             ])
         })
     })
+
+    describe("parseChordParts", () => {
+        it("parses modifier keys", () => {
+            const tests: [string, string[]][] = [
+                ["a", ["a"]],
+                ["<c-a>", ["control", "a"]],
+                ["<m-a>", ["meta", "a"]],
+                ["<a-a>", ["alt", "a"]],
+                ["<s-a>", ["shift", "a"]],
+                ["<m-c-a-s-a>", ["meta", "control", "alt", "shift", "a"]],
+            ]
+
+            tests.forEach(test => {
+                assert.deepEqual(KeyParser.parseChordParts(test[0]), test[1])
+            })
+        })
+
+        it("ignores keys beyond the first chord", () => {
+            const result = KeyParser.parseChordParts("<c-a>b")
+            assert.deepEqual(result, ["control", "a"])
+        })
+    })
 })


### PR DESCRIPTION
`<c-s-p>` -> `control-shift-p`

There was some discussion in Discord about having the `KeyDisplayer` (which is what shows keystrokes when you enable "Input: Show key presses" from the command palette) show better key names. This change takes the chord parsing strategy from `KeyBindingInfo` (which is used to show Key Bindings in the command palette). This hopefully improves the clarity of Oni screen recordings (like the one on the main site), especially for newer users who may be unfamiliar with the comparatively arcane syntax of chords presented like `<c-s-p>`.