### PR TITLE
Fix a first character problem in IME with autoClosingPairs.enabled

### DIFF
--- a/browser/src/UI/Shell/ShellView.tsx
+++ b/browser/src/UI/Shell/ShellView.tsx
@@ -83,8 +83,16 @@ export class ShellView extends React.PureComponent<IShellViewComponentProps, ISh
     }
 
     private _onRootKeyDown(evt: React.KeyboardEvent<HTMLElement>): void {
+        // onCompositionStart can't detect composing mode for the first character
+        // because it is fired after onKeyDown.
+        // keyCode is deprecated but it seems this is the only method to detect
+        // composing mode for the first character for now.
+        let isComposing = false
+        if (evt.keyCode === 229) {
+            isComposing = true
+        }
         const vimKey = inputManager.resolvers.resolveKeyEvent(evt.nativeEvent)
-        if (!this.state.isComposing && inputManager.handleKey(vimKey)) {
+        if (!this.state.isComposing && !isComposing && inputManager.handleKey(vimKey)) {
             evt.stopPropagation()
             evt.preventDefault()
         } else {


### PR DESCRIPTION
1. With autoClosingPairs.enabled (default)
2. In IME, enter "「" (for instance)
3. Wrong braces appear around the input.

#2338 doesn't fix this case. This PR fixes it.