### PR TITLE
CI Server Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
   - os: osx # OSX 10.11
     node_js: 8
     osx_image: xcode8
+  allow_failures:
+    - osx_image: xcode8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,11 @@ matrix:
     sudo: required
     dist: trusty
     node_js: 8
-  - os: osx
+  - os: osx # OSX 10.12
     node_js: 8
+  - os: osx # OSX 10.11
+    node_js: 8
+    osx_image: xcode8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 sudo: required
 dist: trusty
 language: node_js
+
 branches:
   only:
   - master
   - /^release.*/
+
 cache:
   directories:
   - .oni_build_cache
+
 matrix:
   include:
   - os: linux
@@ -16,6 +19,7 @@ matrix:
     node_js: 8
   - os: osx
     node_js: 8
+
 addons:
   apt:
     packages:
@@ -26,15 +30,30 @@ addons:
     - xz-utils
     - rpm
     - bsdtar
+
+before_install:
+- |
+    # Get the files modified in this commit, and check there is
+    # actual code changes made. If there isn't, stop the build.
+    MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+
+    if ! echo ${MODIFIED_FILES} | grep -qvE '(\.md$)/'; then
+      echo "Only documents were updated, stopping..."
+      exit
+    fi
+
+
 install:
 - npm install -g yarn
 - yarn install
+
 script:
 - npm run check-cached-binaries
 - ./build/script/install-reason.sh
 - ./build/script/travis-build.sh
 - travis_wait ./build/script/travis-pack.sh
 - ./build/script/travis-test.sh
+
 deploy:
     - provider: s3
       access_key_id: AKIAIYMATI2CEFTHPBOQ

--- a/build/script/CheckBinariesForBuild.js
+++ b/build/script/CheckBinariesForBuild.js
@@ -15,7 +15,7 @@ const rootPath = path.join(__dirname, "..", "..")
 const cachePath = path.join(rootPath, ".oni_build_cache")
 
 const modulesToCheck =
-    os.platform() === "darwin" ? ["oni-neovim-binaries", "oni-ripgrep"] : ["oni-ripgrep"]
+    os.platform() !== "linux" ? ["oni-neovim-binaries", "oni-ripgrep"] : ["oni-ripgrep"]
 
 const isAuthenticated = !!process.env["GITHUB_TOKEN"]
 

--- a/build/script/appveyor-test.ps1
+++ b/build/script/appveyor-test.ps1
@@ -31,7 +31,13 @@ npm run pack:win ; exitIfFailed
 
 # Run integration tests
 npm run test:integration ; exitIfFailed
-npm run demo:screenshot ; exitIfFailed
+
+# Build up demo screenshot for commits that aren't PRs.
+$prNumber = (Get-Item env:APPVEYOR_PULL_REQUEST_NUMBER).value
+
+if ($prNumber -eq "") {
+    npm run demo:screenshot ; exitIfFailed
+}
 
 # Upload bits to azure
 npm run upload:dist ; exitIfFailed

--- a/build/script/travis-test.sh
+++ b/build/script/travis-test.sh
@@ -23,7 +23,7 @@ fi
 
 echo Using neovim path: "$ONI_NEOVIM_PATH"
 
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+if [[ "$TRAVIS_OS_NAME" == "osx" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
    npm run demo:screenshot
 fi
 

--- a/build/script/travis-test.sh
+++ b/build/script/travis-test.sh
@@ -13,7 +13,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   sleep 3
 
   # Install Neovim
-  curl -LO https://github.com/neovim/neovim/releases/download/v0.2.2/nvim.appimage
+  curl -LO https://github.com/neovim/neovim/releases/download/v0.3.0/nvim.appimage
   chmod u+x nvim.appimage
   ./nvim.appimage --version
   ONI_NEOVIM_PATH="$(cd "$(dirname "$1")"; pwd)/nvim.appimage"

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -151,6 +151,7 @@ export class Oni {
                 if (!didStop) {
                     log("- Attemping to force close processes:")
                     await ensureProcessNotRunning("nvim")
+                    await ensureProcessNotRunning("oni")
                     log("- Force close complete")
                 }
 

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -19,7 +19,7 @@ const isCiBuild = () => {
     return ciBuild
 }
 
-const getWindowsExcutablePathOnCiMachine = () => {
+const getWindowsExecutablePathOnCiMachine = () => {
     switch (process.env.PLATFORM) {
         case "x86":
             return path.join(__dirname, "..", "..", "..", "dist", "win-ia32-unpacked", "Oni.exe")
@@ -33,7 +33,7 @@ const getWindowsExcutablePathOnCiMachine = () => {
 const getExecutablePathOnCiMachine = () => {
     switch (process.platform) {
         case "win32":
-            return getWindowsExcutablePathOnCiMachine()
+            return getWindowsExecutablePathOnCiMachine()
         case "darwin":
             return path.join(
                 __dirname,
@@ -149,7 +149,7 @@ export class Oni {
                 log("- Race complete. didStop: " + didStop)
 
                 if (!didStop) {
-                    log("- Attemping to force close processes:")
+                    log("- Attempting to force close processes:")
                     await ensureProcessNotRunning("nvim")
                     await ensureProcessNotRunning("oni")
                     log("- Force close complete")

--- a/test/common/Oni.ts
+++ b/test/common/Oni.ts
@@ -152,6 +152,7 @@ export class Oni {
                     log("- Attempting to force close processes:")
                     await ensureProcessNotRunning("nvim")
                     await ensureProcessNotRunning("oni")
+                    await ensureProcessNotRunning("chromedriver")
                     log("- Force close complete")
                 }
 

--- a/test/common/ensureProcessNotRunning.ts
+++ b/test/common/ensureProcessNotRunning.ts
@@ -18,11 +18,10 @@ export const ensureProcessNotRunning = async (processName: string) => {
     while (attempts < maxAttempts) {
         console.log(`${attempts}/${maxAttempts} Active Processes:`)
 
-        const nvimProcessGone = await tryToKillProcess(processName)
-        const oniProcessGone = await tryToKillProcess(processName)
+        const targetProcessGone = await tryToKillProcess(processName)
 
-        if (nvimProcessGone && oniProcessGone) {
-            console.log("All processes gone!")
+        if (targetProcessGone) {
+            console.log(`All ${processName} processes gone!`)
             return
         }
 
@@ -30,22 +29,26 @@ export const ensureProcessNotRunning = async (processName: string) => {
     }
 }
 
-const tryToKillProcess = async (name: string): Promise<boolean> => {
-    const oniProcesses = await findProcess("name", "oni")
-    oniProcesses.forEach(processInfo => {
+const tryToKillProcess = async (processName: string): Promise<boolean> => {
+    const targetProcesses = await findProcess("name", processName)
+
+    targetProcesses.forEach(processInfo => {
         console.log(` - Name: ${processInfo.name} PID: ${processInfo.pid}`)
     })
-    const isOniProcess = processInfo => processInfo.name.toLowerCase().indexOf(name) >= 0
-    const filteredProcesses = oniProcesses.filter(isOniProcess)
-    console.log(`- Found ${filteredProcesses.length} processes with name:  ${name}`)
+
+    const isValidTargetProcess = processInfo =>
+        processInfo.name.toLowerCase().indexOf(processName) >= 0
+    const filteredProcesses = targetProcesses.filter(isValidTargetProcess)
+
+    console.log(`- Found ${filteredProcesses.length} processes with name:  ${processName}`)
 
     if (filteredProcesses.length === 0) {
-        console.log("No Oni processes found - leaving.")
+        console.log(`No ${processName} processes found - leaving.`)
         return true
     }
 
     filteredProcesses.forEach(processInfo => {
-        console.log("Attemping to kill pid: " + processInfo.pid)
+        console.log("Attempting to kill pid: " + processInfo.pid)
         // Sometimes, there can be a race condition here. For example,
         // the process may have closed between when we queried above
         // and when we try to kill it. So we'll wrap it in a try/catch.

--- a/test/common/runInProcTest.ts
+++ b/test/common/runInProcTest.ts
@@ -145,7 +145,7 @@ export const runInProcTest = (
             oni.client.execute("Oni.automation.runTest('" + testCase.testPath + "')")
 
             logWithTimeStamp("Waiting for result...") // tslint:disable-line
-            const value = await oni.client.waitForExist(".automated-test-result", 300000)
+            const value = await oni.client.waitForExist(".automated-test-result", 120000)
             logWithTimeStamp("waitForExist for 'automated-test-result' complete: " + value)
 
             console.log("Retrieving logs...")


### PR DESCRIPTION
Updated ensureProcessNotRunning to run on both Nvim and Oni processes.

May help with the CI server issues on Mac (or at least killing the processes, won't change whatever bug/weirdness is causing it).

EDIT:

- Additionally, I added a skip to travis for MD only files.
- I also updated the CheckBinariesForBuild script to check for nvim binaries on Windows.
- Skip screenshots for PRs (Its failed a few times and seems unnecessary to me for a PR)
- Use Neovim 0.3.0 on Linux.
- Add mac OS 10.11 build (currently fails)
