### PR TITLE
Empty Workspace fixes

### DIFF
--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -296,7 +296,7 @@ export class QuickOpen {
                     : (getFileIcon(file) as any)
 
             return {
-                icon: icon,
+                icon,
                 label: file,
                 detail: folder,
                 pinned,

--- a/browser/src/Services/QuickOpen/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen/QuickOpen.ts
@@ -290,9 +290,13 @@ export class QuickOpen {
             const file = path.basename(f)
             const folder = path.dirname(f)
             const pinned = this._seenItems.indexOf(f) >= 0
+            const icon =
+                QuickOpenItem.convertIconToType(qitem.icon) !== QuickOpenType.file
+                    ? qitem.icon
+                    : (getFileIcon(file) as any)
 
             return {
-                icon: getFileIcon(file) as any,
+                icon: icon,
                 label: file,
                 detail: folder,
                 pinned,

--- a/browser/src/Services/QuickOpen/QuickOpenItem.ts
+++ b/browser/src/Services/QuickOpen/QuickOpenItem.ts
@@ -8,6 +8,7 @@ export enum QuickOpenType {
     folder,
     folderHelp,
     bufferLine,
+    unknown,
 }
 
 // Wrapper around quick open items, this not only allows us to show multiple icons
@@ -30,6 +31,25 @@ export class QuickOpenItem {
                 return "angle-right"
             default:
                 return "question-circle-o"
+        }
+    }
+
+    public static convertIconToType(icon: string): QuickOpenType {
+        switch (icon) {
+            case "star-o":
+                return QuickOpenType.bookmark
+            case "info":
+                return QuickOpenType.bookmarkHelp
+            case "file-text-o":
+                return QuickOpenType.file
+            case "folder-o":
+                return QuickOpenType.folder
+            case "folder-open-o":
+                return QuickOpenType.folderHelp
+            case "angle-right":
+                return QuickOpenType.bufferLine
+            default:
+                return QuickOpenType.unknown
         }
     }
 

--- a/browser/src/Services/Workspace/WorkspaceCommands.ts
+++ b/browser/src/Services/Workspace/WorkspaceCommands.ts
@@ -69,6 +69,11 @@ export const activateCommands = (
             return null
         }
 
+        // If we have no active workspace, we don't know where test files live.
+        if (!workspace.activeWorkspace) {
+            return null
+        }
+
         const currentEditor = editorManager.activeEditor
 
         if (!currentEditor || !currentEditor.activeBuffer) {


### PR DESCRIPTION
2 quick fixes for an error + bug when you have an empty workspace.

1) An empty workspace caused the test file finding code to fail due to trying to concat a `null`, causing the command pallete to never open.
2) The changes to file icons in the fuzzy finder broke the "Open Folder" and "Open Bookmarks" functionality. Swapped the file icon code to only apply to items that have an icon of type "file" now instead.

Neither of these happen very often, since we now set the workspace a lot more, but still awkward when they are hit.