### PR TITLE
Pass event names to all Event constructors

### DIFF
--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -24,13 +24,17 @@ export interface IEditor extends Oni.Editor {
  */
 export class Editor extends Disposable implements Oni.Editor {
     private _currentMode: string
-    private _onBufferEnterEvent = new Event<Oni.EditorBufferEventArgs>()
-    private _onBufferLeaveEvent = new Event<Oni.EditorBufferEventArgs>()
-    private _onBufferChangedEvent = new Event<Oni.EditorBufferChangedEventArgs>()
-    private _onBufferSavedEvent = new Event<Oni.EditorBufferEventArgs>()
-    private _onBufferScrolledEvent = new Event<Oni.EditorBufferScrolledEventArgs>()
-    private _onCursorMoved = new Event<Oni.Cursor>()
-    private _onModeChangedEvent = new Event<Oni.Vim.Mode>()
+    private _onBufferEnterEvent = new Event<Oni.EditorBufferEventArgs>("Editor::onBufferEnterEvent")
+    private _onBufferLeaveEvent = new Event<Oni.EditorBufferEventArgs>("Editor::onBufferLeaveEvent")
+    private _onBufferChangedEvent = new Event<Oni.EditorBufferChangedEventArgs>(
+        "Editor::onBufferChangedEvent",
+    )
+    private _onBufferSavedEvent = new Event<Oni.EditorBufferEventArgs>("Editor::onBufferSavedEvent")
+    private _onBufferScrolledEvent = new Event<Oni.EditorBufferScrolledEventArgs>(
+        "Editor::onBufferScrolledEvent",
+    )
+    private _onCursorMoved = new Event<Oni.Cursor>("Editor::onCursorMoved")
+    private _onModeChangedEvent = new Event<Oni.Vim.Mode>("Editor::onModeChangedEvent")
 
     public get mode(): string {
         return this._currentMode

--- a/browser/src/Editor/NeovimEditor/CompletionMenu.ts
+++ b/browser/src/Editor/NeovimEditor/CompletionMenu.ts
@@ -15,8 +15,12 @@ import { ContextMenu } from "./../../Services/ContextMenu"
 import * as CompletionUtility from "./../../Services/Completion/CompletionUtility"
 
 export class CompletionMenu {
-    private _onItemFocusedEvent: Event<types.CompletionItem> = new Event<types.CompletionItem>()
-    private _onItemSelectedEvent: Event<types.CompletionItem> = new Event<types.CompletionItem>()
+    private _onItemFocusedEvent: Event<types.CompletionItem> = new Event<types.CompletionItem>(
+        "CompletionMenu::onItemFocusedEvent",
+    )
+    private _onItemSelectedEvent: Event<types.CompletionItem> = new Event<types.CompletionItem>(
+        "CompletionMenu::onItemSelectedEvent",
+    )
 
     public get onItemFocused(): IEvent<types.CompletionItem> {
         return this._onItemFocusedEvent

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -113,7 +113,7 @@ export class NeovimEditor extends Editor implements IEditor {
 
     private _pendingAnimationFrame: boolean = false
 
-    private _onEnterEvent: Event<void> = new Event<void>()
+    private _onEnterEvent: Event<void> = new Event<void>("NeovimEditor::onEnterEvent")
 
     private _modeChanged$: Observable<Oni.Vim.Mode>
     private _cursorMoved$: Observable<Oni.Cursor>
@@ -142,7 +142,7 @@ export class NeovimEditor extends Editor implements IEditor {
     private _externalMenuOverlay: Overlay
     private _bufferLayerManager: BufferLayerManager
 
-    private _onNeovimQuit: Event<void> = new Event<void>()
+    private _onNeovimQuit: Event<void> = new Event<void>("NeovimEditor::onNeovimQuit")
 
     private _autoFocus: boolean = true
 

--- a/browser/src/Input/Keyboard/KeyboardLayout.ts
+++ b/browser/src/Input/Keyboard/KeyboardLayout.ts
@@ -33,7 +33,7 @@ const augmentKeyMap = (keyMap: IKeyMap, language: string): IKeyMap => {
 
 export class KeyboardLayoutManager {
     private _keyMap: IKeyMap = null
-    private _onKeyMapChanged: Event<void> = new Event<void>()
+    private _onKeyMapChanged: Event<void> = new Event<void>("KeyboardLayout::onKeyMapChanged")
 
     /**
      * Event that is triggered when the keymap is changed,

--- a/browser/src/Plugins/PluginInstaller.ts
+++ b/browser/src/Plugins/PluginInstaller.ts
@@ -44,9 +44,15 @@ export interface IPluginInstaller {
 }
 
 export class YarnPluginInstaller implements IPluginInstaller {
-    private _onOperationStarted = new Event<IPluginInstallerOperationEvent>()
-    private _onOperationCompleted = new Event<IPluginInstallerOperationEvent>()
-    private _onOperationError = new Event<IPluginInstallerOperationEvent>()
+    private _onOperationStarted = new Event<IPluginInstallerOperationEvent>(
+        "PluginInstaller::onOperationStarted",
+    )
+    private _onOperationCompleted = new Event<IPluginInstallerOperationEvent>(
+        "PluginInstaller::onOperationCompleted",
+    )
+    private _onOperationError = new Event<IPluginInstallerOperationEvent>(
+        "PluginInstaller::onOperationError",
+    )
 
     public get onOperationStarted(): IEvent<IPluginInstallerOperationEvent> {
         return this._onOperationStarted

--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -69,8 +69,8 @@ export class PluginSidebarItemView extends React.PureComponent<PluginSidebarItem
 }
 
 export class PluginsSidebarPane implements SidebarPane {
-    private _onEnter = new Event<void>()
-    private _onLeave = new Event<void>()
+    private _onEnter = new Event<void>("PluginSidebarPane::onEnter")
+    private _onLeave = new Event<void>("PluginSidebarPane::onLeave")
 
     public get id(): string {
         return "oni.sidebar.plugins"

--- a/browser/src/Services/Bookmarks/BookmarksPane.tsx
+++ b/browser/src/Services/Bookmarks/BookmarksPane.tsx
@@ -20,8 +20,8 @@ import { SidebarContainerView, SidebarItemView } from "./../../UI/components/Sid
 import { VimNavigator } from "./../../UI/components/VimNavigator"
 
 export class BookmarksPane implements SidebarPane {
-    private _onEnter = new Event<void>()
-    private _onLeave = new Event<void>()
+    private _onEnter = new Event<void>("BookmarksPane::onEnter")
+    private _onLeave = new Event<void>("BookmarksPane::onLeave")
 
     constructor(private _bookmarksProvider: IBookmarksProvider) {}
 

--- a/browser/src/Services/Bookmarks/index.ts
+++ b/browser/src/Services/Bookmarks/index.ts
@@ -32,7 +32,7 @@ const marksToBookmarks = (mark: INeovimMarkInfo): IBookmark => ({
 
 export class NeovimBookmarksProvider implements IBookmarksProvider {
     private _lastBookmarks: IBookmark[] = []
-    private _onBookmarksUpdated = new Event<void>()
+    private _onBookmarksUpdated = new Event<void>("Bookmarks::onBookmarksUpdated")
 
     public get bookmarks(): IBookmark[] {
         return this._lastBookmarks

--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -24,14 +24,14 @@ import {
 import { BrowserView } from "./BrowserView"
 
 export class BrowserLayer implements Oni.BufferLayer {
-    private _debugEvent = new Event<void>()
-    private _goBackEvent = new Event<void>()
-    private _goForwardEvent = new Event<void>()
-    private _reloadEvent = new Event<void>()
-    private _scrollUpEvent = new Event<void>()
-    private _scrollDownEvent = new Event<void>()
-    private _scrollRightEvent = new Event<void>()
-    private _scrollLeftEvent = new Event<void>()
+    private _debugEvent = new Event<void>("Browser::debugEvent")
+    private _goBackEvent = new Event<void>("Browser::goBackEvent")
+    private _goForwardEvent = new Event<void>("Browser::goForwardEvent")
+    private _reloadEvent = new Event<void>("Browser::reloadEvent")
+    private _scrollUpEvent = new Event<void>("Browser::scrollUpEvent")
+    private _scrollDownEvent = new Event<void>("Browser::scrollDownEvent")
+    private _scrollRightEvent = new Event<void>("Browser::scrollRightEvent")
+    private _scrollLeftEvent = new Event<void>("Browser::scrollLeftEvent")
 
     private _webview: WebviewTag | null = null
     private _activeTagName: string | null = null

--- a/browser/src/Services/Colors.ts
+++ b/browser/src/Services/Colors.ts
@@ -36,7 +36,7 @@ export interface IColors extends OniApi.IColors {
 export class Colors implements OniApi.IColors, IDisposable {
     private _subscriptions: IDisposable[] = []
     private _colors: ColorsDictionary = {}
-    private _onColorsChangedEvent: Event<void> = new Event<void>()
+    private _onColorsChangedEvent: Event<void> = new Event<void>("Colors::onColorsChangedEvent")
 
     public get onColorsChanged(): IEvent<void> {
         return this._onColorsChangedEvent

--- a/browser/src/Services/Completion/Completion.ts
+++ b/browser/src/Services/Completion/Completion.ts
@@ -33,8 +33,10 @@ export class Completion implements IDisposable {
 
     private _onShowCompletionItemsEvent: Event<ICompletionShowEventArgs> = new Event<
         ICompletionShowEventArgs
-    >()
-    private _onHideCompletionItemsEvent: Event<void> = new Event<void>()
+    >("Completion::onShowCompletionItemsEvent")
+    private _onHideCompletionItemsEvent: Event<void> = new Event<void>(
+        "Completion::onHideCompletionItemsEvent",
+    )
 
     public get onShowCompletionItems(): IEvent<ICompletionShowEventArgs> {
         return this._onShowCompletionItemsEvent

--- a/browser/src/Services/Configuration/Configuration.ts
+++ b/browser/src/Services/Configuration/Configuration.ts
@@ -96,10 +96,14 @@ export class Configuration implements Oni.Configuration {
     private _configurationProviders: IConfigurationProvider[] = []
     private _onConfigurationChangedEvent: Event<Partial<IConfigurationValues>> = new Event<
         Partial<IConfigurationValues>
-    >()
-    private _onConfigurationErrorEvent: Event<Error> = new Event<Error>()
+    >("Configuration::onConfigurationChangedEvent")
+    private _onConfigurationErrorEvent: Event<Error> = new Event<Error>(
+        "Configuration::onConfigurationErrorEvent",
+    )
 
-    private _onConfigurationUpdatedEvent = new Event<IConfigurationUpdateEvent>()
+    private _onConfigurationUpdatedEvent = new Event<IConfigurationUpdateEvent>(
+        "Configuration::onConfigurationUpdatedEvent",
+    )
 
     private _oniApi: Oni.Plugin.Api = null
     private _config: GenericConfigurationValues = {}
@@ -158,7 +162,9 @@ export class Configuration implements Oni.Configuration {
             this.setValue(name, options.defaultValue)
         }
 
-        const newEvent = new Event<IConfigurationSettingValueChangedEvent<any>>()
+        const newEvent = new Event<IConfigurationSettingValueChangedEvent<any>>(
+            "Configuration::newEvent",
+        )
         const subs: Array<Event<IConfigurationSettingValueChangedEvent<any>>> =
             this._subscriptions[name] || []
         this._subscriptions[name] = [...subs, newEvent]

--- a/browser/src/Services/Configuration/FileConfigurationProvider.ts
+++ b/browser/src/Services/Configuration/FileConfigurationProvider.ts
@@ -26,8 +26,12 @@ const CONFIG_UPDATE_DEBOUNCE_TIME = 100 /*ms */
 export class FileConfigurationProvider implements IConfigurationProvider {
     private _configurationFilePath: string
     private _containingFolder: string
-    private _configurationChangedEvent = new Event<void>()
-    private _configurationErrorEvent = new Event<Error>()
+    private _configurationChangedEvent = new Event<void>(
+        "FileConfigurationProvider::configurationChangedEvent",
+    )
+    private _configurationErrorEvent = new Event<Error>(
+        "FileConfigurationProvider::configurationErrorEvent",
+    )
     private _latestConfiguration: Partial<IConfigurationValues> = null
     private _lastError: Error | null = null
     private _configEverHadValue: boolean = false

--- a/browser/src/Services/ContextMenu/ContextMenu.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenu.tsx
@@ -80,10 +80,10 @@ export class ContextMenuManager {
 }
 
 export class ContextMenu {
-    private _onItemSelected = new Event<any>()
-    private _onFilterTextChanged = new Event<string>()
-    private _onHide = new Event<void>()
-    private _onSelectedItemChanged = new Event<any>()
+    private _onItemSelected = new Event<any>("ContextMenu::onItemSelected")
+    private _onFilterTextChanged = new Event<string>("ContextMenu::onFilterTextChanged")
+    private _onHide = new Event<void>("ContextMenu::onHide")
+    private _onSelectedItemChanged = new Event<any>("ContextMenu::onSelectedItemChanged")
 
     private _lastItems: any = null
 

--- a/browser/src/Services/Diagnostics.ts
+++ b/browser/src/Services/Diagnostics.ts
@@ -65,7 +65,7 @@ export const getAllErrorsForFile = (fileName: string, errors: Errors): types.Dia
 
 export class DiagnosticsDataSource {
     private _errors: Errors = {}
-    private _onErrorsChangedEvent = new Event<void>()
+    private _onErrorsChangedEvent = new Event<void>("Diagnostics::onErrorsChangedEvent")
 
     public get onErrorsChanged(): IEvent<void> {
         return this._onErrorsChangedEvent

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -17,7 +17,9 @@ export class EditorManager implements Oni.EditorManager {
     private _allEditors: Oni.Editor[] = []
     private _activeEditor: Oni.Editor = null
     private _anyEditorProxy: AnyEditorProxy = new AnyEditorProxy()
-    private _onActiveEditorChanged: Event<Oni.Editor> = new Event<Oni.Editor>()
+    private _onActiveEditorChanged: Event<Oni.Editor> = new Event<Oni.Editor>(
+        "EditorManager::onActiveEditorChanged",
+    )
 
     private _closeWhenNoEditors: boolean = true
 
@@ -95,13 +97,17 @@ class AnyEditorProxy implements Oni.Editor {
     private _activeEditor: Oni.Editor
     private _subscriptions: IDisposable[] = []
 
-    private _onModeChanged = new Event<Oni.Vim.Mode>()
-    private _onBufferEnter = new Event<Oni.EditorBufferEventArgs>()
-    private _onBufferLeave = new Event<Oni.EditorBufferEventArgs>()
-    private _onBufferChanged = new Event<Oni.EditorBufferChangedEventArgs>()
-    private _onBufferSaved = new Event<Oni.EditorBufferEventArgs>()
-    private _onBufferScrolled = new Event<Oni.EditorBufferScrolledEventArgs>()
-    private _onCursorMoved = new Event<Oni.Cursor>()
+    private _onModeChanged = new Event<Oni.Vim.Mode>("EditorManager::onModeChanged")
+    private _onBufferEnter = new Event<Oni.EditorBufferEventArgs>("EditorManager::onBufferEnter")
+    private _onBufferLeave = new Event<Oni.EditorBufferEventArgs>("EditorManager::onBufferLeave")
+    private _onBufferChanged = new Event<Oni.EditorBufferChangedEventArgs>(
+        "EditorManager::onBufferChanged",
+    )
+    private _onBufferSaved = new Event<Oni.EditorBufferEventArgs>("EditorManager::onBufferSaved")
+    private _onBufferScrolled = new Event<Oni.EditorBufferScrolledEventArgs>(
+        "EditorManager::onBufferScrolled",
+    )
+    private _onCursorMoved = new Event<Oni.Cursor>("EditorManager::onCursorMoved")
 
     /**
      * API Methods

--- a/browser/src/Services/Explorer/ExplorerSplit.tsx
+++ b/browser/src/Services/Explorer/ExplorerSplit.tsx
@@ -26,7 +26,7 @@ import { Explorer } from "./ExplorerView"
 type Node = ExplorerSelectors.ExplorerNode
 
 export class ExplorerSplit {
-    private _onEnterEvent: Event<void> = new Event<void>()
+    private _onEnterEvent: Event<void> = new Event<void>("ExplorerSplit::onEnterEvent")
     private _selectedId: string = null
     private _store: Store<IExplorerState>
     private _watcher: FileSystemWatcher = null

--- a/browser/src/Services/FileSystemWatcher/index.ts
+++ b/browser/src/Services/FileSystemWatcher/index.ts
@@ -23,12 +23,12 @@ interface IStatsChangeEvent {
 export class FileSystemWatcher {
     private _watcher: chokidar.FSWatcher
 
-    private _onAdd = new Event<IFileChangeEvent>()
-    private _onAddDir = new Event<IStatsChangeEvent>()
-    private _onDelete = new Event<IFileChangeEvent>()
-    private _onDeleteDir = new Event<IFileChangeEvent>()
-    private _onMove = new Event<IFileChangeEvent>()
-    private _onChange = new Event<IFileChangeEvent>()
+    private _onAdd = new Event<IFileChangeEvent>("FileSystemWatcher::onAdd")
+    private _onAddDir = new Event<IStatsChangeEvent>("FileSystemWatcher::onAddDir")
+    private _onDelete = new Event<IFileChangeEvent>("FileSystemWatcher::onDelete")
+    private _onDeleteDir = new Event<IFileChangeEvent>("FileSystemWatcher::onDeleteDir")
+    private _onMove = new Event<IFileChangeEvent>("FileSystemWatcher::onMove")
+    private _onChange = new Event<IFileChangeEvent>("FileSystemWatcher::onChange")
 
     constructor({ target, options }: IFSOptions) {
         this._watcher = chokidar.watch(target, options)

--- a/browser/src/Services/IconThemes/Icons.ts
+++ b/browser/src/Services/IconThemes/Icons.ts
@@ -72,7 +72,9 @@ export interface IIconTheme {
 
 export class Icons {
     private _activeIconTheme: IIconTheme = null
-    private _onIconThemeChangedEvent: Event<void> = new Event<void>()
+    private _onIconThemeChangedEvent: Event<void> = new Event<void>(
+        "Icons::onIconThemeChangedEvent",
+    )
 
     public get activeIconTheme(): IIconTheme {
         return this._activeIconTheme

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -62,7 +62,9 @@ export interface InitializationOptions {
 export class LanguageClientProcess {
     private _process: ChildProcess
     private _connection: rpc.MessageConnection
-    private _onConnectionChangedEvent = new Event<rpc.MessageConnection>()
+    private _onConnectionChangedEvent = new Event<rpc.MessageConnection>(
+        "LanguageClientProcess::onConnectionChangedEvent",
+    )
 
     private _lastWorkingDirectory: string = null
     private _lastRootPath: string = null

--- a/browser/src/Services/Language/LanguageEditorIntegration.ts
+++ b/browser/src/Services/Language/LanguageEditorIntegration.ts
@@ -32,11 +32,17 @@ export class LanguageEditorIntegration implements OniTypes.IDisposable {
 
     private _onShowDefinition: OniTypes.Event<IDefinitionResult> = new OniTypes.Event<
         IDefinitionResult
-    >()
-    private _onHideDefinition: OniTypes.Event<void> = new OniTypes.Event<void>()
+    >("LanguageEditorIntegration::onShowDefinition")
+    private _onHideDefinition: OniTypes.Event<void> = new OniTypes.Event<void>(
+        "LanguageEditorIntegration::onHideDefinition",
+    )
 
-    private _onShowHover: OniTypes.Event<IHoverResult> = new OniTypes.Event<IHoverResult>()
-    private _onHideHover: OniTypes.Event<void> = new OniTypes.Event<void>()
+    private _onShowHover: OniTypes.Event<IHoverResult> = new OniTypes.Event<IHoverResult>(
+        "LanguageEditorIntegration::onShowHover",
+    )
+    private _onHideHover: OniTypes.Event<void> = new OniTypes.Event<void>(
+        "LanguageEditorIntegration::onHideHover",
+    )
 
     public get onShowDefinition(): OniTypes.IEvent<IDefinitionResult> {
         return this._onShowDefinition

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -273,7 +273,7 @@ export class LanguageManager {
         const currentSubscription = this._notificationSubscriptions[protocolMessage]
 
         if (!currentSubscription) {
-            const evt = new Event<any>()
+            const evt = new Event<any>("LanguageManager::evt")
             this._notificationSubscriptions[protocolMessage] = evt
 
             const languageClients = Object.values(this._languageServerInfo)

--- a/browser/src/Services/Learning/Achievements/AchievementsManager.ts
+++ b/browser/src/Services/Learning/Achievements/AchievementsManager.ts
@@ -41,7 +41,9 @@ export class AchievementsManager {
     private _enabled: boolean
 
     private _currentIdleCallback: number | null = null
-    private _onAchievementAccomplishedEvent = new Event<AchievementDefinition>()
+    private _onAchievementAccomplishedEvent = new Event<AchievementDefinition>(
+        "AchievementsManager::onAchievementAccomplishedEvent",
+    )
 
     public get enabled(): boolean {
         return this._enabled

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -24,8 +24,8 @@ import { ITutorialMetadataWithProgress, TutorialManager } from "./Tutorial/Tutor
 import { noop } from "./../../Utility"
 
 export class LearningPane implements SidebarPane {
-    private _onEnter = new Event<void>()
-    private _onLeave = new Event<void>()
+    private _onEnter = new Event<void>("LearningPane::onEnter")
+    private _onLeave = new Event<void>("LearningPane::onLeave")
 
     constructor(
         private _tutorialManager: TutorialManager,

--- a/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
+++ b/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
@@ -96,7 +96,7 @@ export class TutorialBufferLayer implements Oni.BufferLayer {
     private _gameTracker: GameTracker = new GameTracker()
     private _onStateChangedEvent: Event<ITutorialBufferLayerState> = new Event<
         ITutorialBufferLayerState
-    >()
+    >("TutorialBufferLayer::onStateChangedEvent")
 
     public get id(): string {
         return "oni.layer.tutorial"

--- a/browser/src/Services/Learning/Tutorial/TutorialGameplayManager.ts
+++ b/browser/src/Services/Learning/Tutorial/TutorialGameplayManager.ts
@@ -25,10 +25,10 @@ export const TICK_RATE = 50 /* 50 ms, or 20 times pers second */
 export class TutorialGameplayManager {
     private _activeTutorial: ITutorial
     private _currentStageIdx: number
-    private _onStateChanged = new Event<ITutorialState>()
-    private _onCompleted = new Event<boolean>()
+    private _onStateChanged = new Event<ITutorialState>("TutorialGameplayManager::onStateChanged")
+    private _onCompleted = new Event<boolean>("TutorialGameplayManager::onCompleted")
     private _currentState: ITutorialState = null
-    private _onTick = new Event<void>()
+    private _onTick = new Event<void>("TutorialGameplayManager::onTick")
 
     private _isTickInProgress: boolean = false
     private _buf: Oni.Buffer

--- a/browser/src/Services/Learning/Tutorial/TutorialManager.ts
+++ b/browser/src/Services/Learning/Tutorial/TutorialManager.ts
@@ -40,8 +40,12 @@ export class TutorialManager {
     private _initPromise: Promise<IPersistedTutorialState>
 
     private _persistedState: IPersistedTutorialState = { completionInfo: {} }
-    private _onTutorialCompletedEvent: Event<void> = new Event<void>()
-    private _onTutorialProgressChanged: Event<void> = new Event<void>()
+    private _onTutorialCompletedEvent: Event<void> = new Event<void>(
+        "TutorialManager::onTutorialCompletedEvent",
+    )
+    private _onTutorialProgressChanged: Event<void> = new Event<void>(
+        "TutorialManager::onTutorialProgressChanged",
+    )
 
     public get onTutorialCompletedEvent(): IEvent<void> {
         return this._onTutorialCompletedEvent

--- a/browser/src/Services/Menu/Menu.ts
+++ b/browser/src/Services/Menu/Menu.ts
@@ -106,10 +106,10 @@ export class MenuManager {
 }
 
 export class Menu implements Oni.Menu.MenuInstance {
-    private _onItemSelected = new Event<any>()
-    private _onSelectedItemChanged = new Event<Oni.Menu.MenuOption>()
-    private _onFilterTextChanged = new Event<string>()
-    private _onHide = new Event<void>()
+    private _onItemSelected = new Event<any>("Menu::onItemSelected")
+    private _onSelectedItemChanged = new Event<Oni.Menu.MenuOption>("Menu::onSelectedItemChanged")
+    private _onFilterTextChanged = new Event<string>("Menu::onFilterTextChanged")
+    private _onHide = new Event<void>("Menu::onHide")
     private _filterFunction = MenuFilter.fuseFilter
 
     public get onHide(): IEvent<void> {

--- a/browser/src/Services/Notifications/Notification.ts
+++ b/browser/src/Services/Notifications/Notification.ts
@@ -17,8 +17,8 @@ export class Notification {
     private _expirationTime: number
     private _level: NotificationLevel = "info"
 
-    private _onClickEvent = new Event<void>()
-    private _onCloseEvent = new Event<void>()
+    private _onClickEvent = new Event<void>("Notification::onClickEvent")
+    private _onCloseEvent = new Event<void>("Notification::onCloseEvent")
 
     public get onClick(): IEvent<void> {
         return this._onClickEvent

--- a/browser/src/Services/QuickOpen/FinderProcess.ts
+++ b/browser/src/Services/QuickOpen/FinderProcess.ts
@@ -16,9 +16,9 @@ export class FinderProcess {
 
     private _lastData: string = ""
 
-    private _onData = new Event<string[]>()
-    private _onError = new Event<string>()
-    private _onComplete = new Event<void>()
+    private _onData = new Event<string[]>("FinderProcess::onData")
+    private _onError = new Event<string>("FinderProcess::onError")
+    private _onComplete = new Event<void>("FinderProcess::onComplete")
     private _workspace = getInstance()
 
     public get onData(): IEvent<string[]> {

--- a/browser/src/Services/Search/SearchProvider.ts
+++ b/browser/src/Services/Search/SearchProvider.ts
@@ -91,8 +91,10 @@ export const ripGrepLineToSearchResultItem = (ripGrepResult: string): ISearchRes
 }
 
 export class RipGrepSearchQuery {
-    private _onSearchStartedEvent = new Event<void>()
-    private _onSearchCompletedEvent = new Event<ISearchResult>()
+    private _onSearchStartedEvent = new Event<void>("SearchProvider::onSearchStartedEvent")
+    private _onSearchCompletedEvent = new Event<ISearchResult>(
+        "SearchProvider::onSearchCompletedEvent",
+    )
     private _finderProcess: FinderProcess
 
     private _items: ISearchResultItem[] = []

--- a/browser/src/Services/Search/index.tsx
+++ b/browser/src/Services/Search/index.tsx
@@ -30,10 +30,10 @@ import { SearchPaneView } from "./SearchPaneView"
 import { SearchResultSpinnerView } from "./SearchResultsSpinnerView"
 
 export class SearchPane {
-    private _onEnter = new Event<void>()
-    private _onLeave = new Event<void>()
-    private _onSearchStarted = new Event<void>()
-    private _onSearchCompleted = new Event<void>()
+    private _onEnter = new Event<void>("Search::onEnter")
+    private _onLeave = new Event<void>("Search::onLeave")
+    private _onSearchStarted = new Event<void>("Search::onSearchStarted")
+    private _onSearchCompleted = new Event<void>("Search::onSearchCompleted")
     private _shouldFocusAutomatically: boolean = false
 
     private _searchProvider: ISearchProvider
@@ -131,7 +131,7 @@ export const activate = (
     sidebarManager: SidebarManager,
     workspace: Workspace,
 ) => {
-    const onFocusEvent = new Event<void>()
+    const onFocusEvent = new Event<void>("Search::onFocusEvent")
     sidebarManager.add("search", new SearchPane(editorManager, workspace, onFocusEvent))
 
     const searchAllFiles = () => {

--- a/browser/src/Services/Sidebar/SidebarContentSplit.tsx
+++ b/browser/src/Services/Sidebar/SidebarContentSplit.tsx
@@ -24,8 +24,8 @@ export const getActiveEntry = (state: ISidebarState): ISidebarEntry => {
  * Split that is the container for the active sidebar item
  */
 export class SidebarContentSplit {
-    private _onEnterEvent = new Event<void>()
-    private _onLeaveEvent = new Event<void>()
+    private _onEnterEvent = new Event<void>("SidebarContentSplit::onEnterEvent")
+    private _onLeaveEvent = new Event<void>("SidebarContentSplit::onLeaveEvent")
 
     public get activePane(): SidebarPane {
         const entry = getActiveEntry(this._sidebarManager.store.getState())

--- a/browser/src/Services/Sneak/Sneak.tsx
+++ b/browser/src/Services/Sneak/Sneak.tsx
@@ -26,7 +26,7 @@ export class Sneak {
     private _activeOverlay: Overlay
     private _providers: SneakProvider[] = []
     private _store: Store<ISneakState>
-    private _onSneakCompleted = new Event<ISneakInfo>()
+    private _onSneakCompleted = new Event<ISneakInfo>("Sneak::onSneakCompleted")
 
     public get onSneakCompleted(): IEvent<ISneakInfo> {
         return this._onSneakCompleted

--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -79,10 +79,10 @@ export class SnippetSession {
     private _buffer: IBuffer
     private _snippet: OniSnippet
     private _position: types.Position
-    private _onCancelEvent: Event<void> = new Event<void>()
+    private _onCancelEvent: Event<void> = new Event<void>("SnippetSession::onCancelEvent")
     private _onCursorMovedEvent: Event<IMirrorCursorUpdateEvent> = new Event<
         IMirrorCursorUpdateEvent
-    >()
+    >("SnippetSession::onCursorMovedEvent")
 
     // Get state of line where we inserted
     private _prefix: string

--- a/browser/src/Services/Themes/ThemeManager.ts
+++ b/browser/src/Services/Themes/ThemeManager.ts
@@ -303,7 +303,7 @@ export const DefaultTheme: IThemeMetadata = {
 }
 
 export class ThemeManager {
-    private _onThemeChangedEvent: Event<void> = new Event<void>()
+    private _onThemeChangedEvent: Event<void> = new Event<void>("ThemeManager::onThemeChangedEvent")
 
     private _activeTheme: IThemeMetadata = DefaultTheme
 

--- a/browser/src/Services/TokenColors.ts
+++ b/browser/src/Services/TokenColors.ts
@@ -27,7 +27,9 @@ import { ThemeManager } from "./Themes"
 export class TokenColors implements IDisposable {
     private _subscriptions: IDisposable[] = []
     private _tokenColors: TokenColor[] = []
-    private _onTokenColorsChangedEvent: Event<void> = new Event<void>()
+    private _onTokenColorsChangedEvent: Event<void> = new Event<void>(
+        "TokenColors::onTokenColorsChangedEvent",
+    )
 
     private _defaultTokenColors: TokenColor[] = []
 

--- a/browser/src/Services/TypingPredictionManager.ts
+++ b/browser/src/Services/TypingPredictionManager.ts
@@ -21,7 +21,9 @@ export interface ITypingPrediction {
 }
 
 export class TypingPredictionManager {
-    private _predictionsChanged: Event<ITypingPrediction> = new Event<ITypingPrediction>()
+    private _predictionsChanged: Event<ITypingPrediction> = new Event<ITypingPrediction>(
+        "TypingPredictionManager::predictionsChanged",
+    )
     private _predictions: IPredictedCharacter[] = []
     private _backgroundColor: string
     private _foregroundColor: string

--- a/browser/src/Services/UnhandledErrorMonitor.ts
+++ b/browser/src/Services/UnhandledErrorMonitor.ts
@@ -12,8 +12,12 @@ import { Notifications } from "./Notifications"
 import * as Log from "oni-core-logging"
 
 export class UnhandledErrorMonitor {
-    private _onUnhandledErrorEvent = new Event<Error>()
-    private _onUnhandledRejectionEvent = new Event<string>()
+    private _onUnhandledErrorEvent = new Event<Error>(
+        "UnhandledErrorMonitor::onUnhandledErrorEvent",
+    )
+    private _onUnhandledRejectionEvent = new Event<string>(
+        "UnhandledErrorMonitor::onUnhandledRejectionEvent",
+    )
 
     private _queuedErrors: Error[] = []
     private _queuedRejections: string[] = []

--- a/browser/src/Services/WindowManager/WindowManager.ts
+++ b/browser/src/Services/WindowManager/WindowManager.ts
@@ -109,7 +109,7 @@ export class WindowManager {
     private _lastId: number = 0
     private _idToSplit: { [key: string]: IAugmentedSplitInfo } = {}
 
-    private _onUnhandledMoveEvent = new Event<Direction>()
+    private _onUnhandledMoveEvent = new Event<Direction>("WindowManager::onUnhandledMoveEvent")
 
     private _leftDock: WindowDockNavigator = null
     private _primarySplit: LinearSplitProvider
@@ -125,7 +125,9 @@ export class WindowManager {
         return this._onUnhandledMoveEvent
     }
 
-    private _onFocusChanged = new Event<ISplitInfo<Oni.IWindowSplit>>()
+    private _onFocusChanged = new Event<ISplitInfo<Oni.IWindowSplit>>(
+        "WindowManager::onFocusChanged",
+    )
 
     public get onFocusChanged(): IEvent<ISplitInfo<Oni.IWindowSplit>> {
         return this._onFocusChanged

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -38,9 +38,9 @@ export interface IWorkspace extends Oni.Workspace.Api {
 }
 
 export class Workspace implements IWorkspace {
-    private _onDirectoryChangedEvent = new Event<string>()
-    private _onFocusGainedEvent = new Event<Oni.Buffer>()
-    private _onFocusLostEvent = new Event<Oni.Buffer>()
+    private _onDirectoryChangedEvent = new Event<string>("Workspace::onDirectoryChangedEvent")
+    private _onFocusGainedEvent = new Event<Oni.Buffer>("Workspace::onFocusGainedEvent")
+    private _onFocusLostEvent = new Event<Oni.Buffer>("Workspace::onFocusLostEvent")
     private _mainWindow = remote.getCurrentWindow()
     private _lastActiveBuffer: Oni.Buffer
     private _activeWorkspace: string

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -43,7 +43,7 @@ export interface IVimNavigatorState {
 
 export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNavigatorState> {
     private _activeBinding: IMenuBinding = null
-    private _activateEvent = new Event<void>()
+    private _activateEvent = new Event<void>("VimNavigator::activateEvent")
 
     constructor(props: IVimNavigatorProps) {
         super(props)

--- a/browser/src/neovim/NeovimAutoCommands.ts
+++ b/browser/src/neovim/NeovimAutoCommands.ts
@@ -30,17 +30,31 @@ export interface INeovimAutoCommands {
 export class NeovimAutoCommands {
     // Autocommand events
     private _nameToEvent: { [key: string]: Event<EventContext | BufferEventContext> }
-    private _onBufEnterEvent = new Event<BufferEventContext>()
-    private _onBufWritePostEvent = new Event<EventContext>()
-    private _onBufWipeoutEvent = new Event<BufferEventContext>()
-    private _onBufDeleteEvent = new Event<BufferEventContext>()
-    private _onBufUnloadEvent = new Event<BufferEventContext>()
-    private _onBufWinEnterEvent = new Event<BufferEventContext>()
-    private _onFileTypeChangedEvent = new Event<EventContext>()
-    private _onWinEnterEvent = new Event<EventContext>()
-    private _onCursorMovedEvent = new Event<EventContext>()
-    private _onCursorMovedIEvent = new Event<EventContext>()
-    private _onVimResizedEvent = new Event<EventContext>()
+    private _onBufEnterEvent = new Event<BufferEventContext>("NeovimAutoCommands::onBufEnterEvent")
+    private _onBufWritePostEvent = new Event<EventContext>(
+        "NeovimAutoCommands::onBufWritePostEvent",
+    )
+    private _onBufWipeoutEvent = new Event<BufferEventContext>(
+        "NeovimAutoCommands::onBufWipeoutEvent",
+    )
+    private _onBufDeleteEvent = new Event<BufferEventContext>(
+        "NeovimAutoCommands::onBufDeleteEvent",
+    )
+    private _onBufUnloadEvent = new Event<BufferEventContext>(
+        "NeovimAutoCommands::onBufUnloadEvent",
+    )
+    private _onBufWinEnterEvent = new Event<BufferEventContext>(
+        "NeovimAutoCommands::onBufWinEnterEvent",
+    )
+    private _onFileTypeChangedEvent = new Event<EventContext>(
+        "NeovimAutoCommands::onFileTypeChangedEvent",
+    )
+    private _onWinEnterEvent = new Event<EventContext>("NeovimAutoCommands::onWinEnterEvent")
+    private _onCursorMovedEvent = new Event<EventContext>("NeovimAutoCommands::onCursorMovedEvent")
+    private _onCursorMovedIEvent = new Event<EventContext>(
+        "NeovimAutoCommands::onCursorMovedIEvent",
+    )
+    private _onVimResizedEvent = new Event<EventContext>("NeovimAutoCommands::onVimResizedEvent")
 
     public get onBufEnter(): IEvent<BufferEventContext> {
         return this._onBufEnterEvent

--- a/browser/src/neovim/NeovimBufferUpdateManager.ts
+++ b/browser/src/neovim/NeovimBufferUpdateManager.ts
@@ -20,7 +20,9 @@ export interface INeovimBufferUpdate {
 }
 
 export class NeovimBufferUpdateManager {
-    private _onBufferUpdateEvent = new Event<INeovimBufferUpdate>()
+    private _onBufferUpdateEvent = new Event<INeovimBufferUpdate>(
+        "NeovimBufferUpdateManager::onBufferUpdateEvent",
+    )
     private _lastEventContext: EventContext
     private _lastMode: string
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -223,29 +223,37 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _marks: NeovimMarks
     private _initComplete: boolean
 
-    private _onDirectoryChanged = new Event<string>()
-    private _onErrorEvent = new Event<Error | string>()
-    private _onYank = new Event<INeovimYankInfo>()
-    private _onOniCommand = new Event<CommandContext>()
-    private _onRedrawComplete = new Event<void>()
-    private _onScroll = new Event<EventContext>()
-    private _onTitleChanged = new Event<string>()
-    private _onModeChanged = new Event<Oni.Vim.Mode>()
-    private _onHidePopupMenu = new Event<void>()
-    private _onShowPopupMenu = new Event<INeovimCompletionInfo>()
-    private _onSelectPopupMenu = new Event<number>()
-    private _onLeave = new Event<void>()
-    private _onMessage = new Event<IMessageInfo>()
+    private _onDirectoryChanged = new Event<string>("NeovimInstance::onDirectoryChanged")
+    private _onErrorEvent = new Event<Error | string>("NeovimInstance::onErrorEvent")
+    private _onYank = new Event<INeovimYankInfo>("NeovimInstance::onYank")
+    private _onOniCommand = new Event<CommandContext>("NeovimInstance::onOniCommand")
+    private _onRedrawComplete = new Event<void>("NeovimInstance::onRedrawComplete")
+    private _onScroll = new Event<EventContext>("NeovimInstance::onScroll")
+    private _onTitleChanged = new Event<string>("NeovimInstance::onTitleChanged")
+    private _onModeChanged = new Event<Oni.Vim.Mode>("NeovimInstance::onModeChanged")
+    private _onHidePopupMenu = new Event<void>("NeovimInstance::onHidePopupMenu")
+    private _onShowPopupMenu = new Event<INeovimCompletionInfo>("NeovimInstance::onShowPopupMenu")
+    private _onSelectPopupMenu = new Event<number>("NeovimInstance::onSelectPopupMenu")
+    private _onLeave = new Event<void>("NeovimInstance::onLeave")
+    private _onMessage = new Event<IMessageInfo>("NeovimInstance::onMessage")
 
-    private _onColorsChanged = new Event<void>()
+    private _onColorsChanged = new Event<void>("NeovimInstance::onColorsChanged")
 
-    private _onCommandLineShowEvent = new Event<INeovimCommandLineShowEvent>()
-    private _onCommandLineHideEvent = new Event<void>()
-    private _onCommandLineSetCursorPositionEvent = new Event<INeovimCommandLineSetCursorPosition>()
-    private _onVimEvent = new Event<INeovimEvent>()
-    private _onWildMenuHideEvent = new Event<void>()
-    private _onWildMenuSelectEvent = new Event<IWildMenuSelectEvent>()
-    private _onWildMenuShowEvent = new Event<IWildMenuShowEvent>()
+    private _onCommandLineShowEvent = new Event<INeovimCommandLineShowEvent>(
+        "NeovimInstance::onCommandLineShowEvent",
+    )
+    private _onCommandLineHideEvent = new Event<void>("NeovimInstance::onCommandLineHideEvent")
+    private _onCommandLineSetCursorPositionEvent = new Event<INeovimCommandLineSetCursorPosition>(
+        "NeovimInstance::onCommandLineSetCursorPositionEvent",
+    )
+    private _onVimEvent = new Event<INeovimEvent>("NeovimInstance::onVimEvent")
+    private _onWildMenuHideEvent = new Event<void>("NeovimInstance::onWildMenuHideEvent")
+    private _onWildMenuSelectEvent = new Event<IWildMenuSelectEvent>(
+        "NeovimInstance::onWildMenuSelectEvent",
+    )
+    private _onWildMenuShowEvent = new Event<IWildMenuShowEvent>(
+        "NeovimInstance::onWildMenuShowEvent",
+    )
     private _bufferUpdateManager: NeovimBufferUpdateManager
     private _tokenColorSynchronizer: NeovimTokenColorSynchronizer
 

--- a/browser/src/neovim/NeovimMarks.ts
+++ b/browser/src/neovim/NeovimMarks.ts
@@ -99,7 +99,7 @@ export const parseMarkLine = (markLine: string): INeovimMarkInfo => {
 }
 
 export class NeovimMarks {
-    private _onMarksUpdatedEvent = new Event<INeovimMarkInfo[]>()
+    private _onMarksUpdatedEvent = new Event<INeovimMarkInfo[]>("NeovimMarks::onMarksUpdatedEvent")
     private _isWatching: boolean = false
 
     public get onMarksUpdated(): IEvent<INeovimMarkInfo[]> {

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -54,7 +54,9 @@ export interface NeovimInactiveWindowState {
 export class NeovimWindowManager extends Utility.Disposable {
     private _scrollObservable: Subject<EventContext>
 
-    private _onWindowStateChangedEvent = new Event<NeovimTabPageState>()
+    private _onWindowStateChangedEvent = new Event<NeovimTabPageState>(
+        "NeovimWindowManager::onWindowStateChangedEvent",
+    )
 
     public get onWindowStateChanged(): IEvent<NeovimTabPageState> {
         return this._onWindowStateChangedEvent

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -35,7 +35,7 @@ export interface IMenuBinding extends IBinding {
 }
 
 export class Binding implements IBinding {
-    private _onReleasedEvent: Event<void> = new Event<void>()
+    private _onReleasedEvent: Event<void> = new Event<void>("SharedNeovimInstance::onReleasedEvent")
     private _subscriptions: IDisposable[] = []
 
     public get onReleased(): IEvent<void> {
@@ -68,7 +68,9 @@ export class Binding implements IBinding {
 export class MenuBinding extends Binding implements IMenuBinding {
     private _currentOptions: string[] = []
     private _currentId: string = null
-    private _onCursorMovedEvent: Event<string> = new Event<string>()
+    private _onCursorMovedEvent: Event<string> = new Event<string>(
+        "SharedNeovimInstance::onCursorMovedEvent",
+    )
     private _promiseQueue = new PromiseQueue()
 
     private _isUpdating: boolean = false

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -52,7 +52,7 @@ import { MockBuffer } from "./MockBuffer"
 
 export class MockConfiguration {
     private _currentConfigurationFiles: string[] = []
-    private _onConfigurationChanged = new Event<any>()
+    private _onConfigurationChanged = new Event<any>("Mocks::onConfigurationChanged")
 
     public get onConfigurationChanged(): IEvent<any> {
         return this._onConfigurationChanged
@@ -89,9 +89,9 @@ export class MockConfiguration {
 
 export class MockWorkspace implements IWorkspace {
     private _activeWorkspace: string = null
-    private _onDirectoryChangedEvent = new Event<string>()
-    private _onFocusGainedEvent = new Event<void>()
-    private _onFocusLostEvent = new Event<void>()
+    private _onDirectoryChangedEvent = new Event<string>("Mocks::onDirectoryChangedEvent")
+    private _onFocusGainedEvent = new Event<void>("Mocks::onFocusGainedEvent")
+    private _onFocusLostEvent = new Event<void>("Mocks::onFocusLostEvent")
 
     public get onDirectoryChanged(): IEvent<string> {
         return this._onDirectoryChangedEvent

--- a/browser/test/Services/Configuration/ConfigurationTests.ts
+++ b/browser/test/Services/Configuration/ConfigurationTests.ts
@@ -25,6 +25,7 @@ describe("Configuration", () => {
         configuration.addConfigurationProvider(configProvider)
 
         assert.strictEqual(configuration.getValue("test.config"), 2)
+        configuration.removeConfigurationProvider(configProvider)
     })
 
     it("triggers error event when provider has an error", () => {
@@ -41,6 +42,7 @@ describe("Configuration", () => {
         configProvider.simulateError(new Error("test error"))
 
         assert.strictEqual(errors.length, 1, "Validate an error was captured")
+        configuration.removeConfigurationProvider(configProvider)
     })
 
     it("triggers change event when provider has an update", () => {
@@ -62,6 +64,7 @@ describe("Configuration", () => {
             3,
             "Validate configuration was updated",
         )
+        configuration.removeConfigurationProvider(configProvider)
     })
 
     it("triggers updated event with requireReload true", () => {
@@ -310,8 +313,12 @@ export class MockPersistedConfiguration implements IPersistedConfiguration {
 }
 
 export class MockConfigurationProvider implements IConfigurationProvider {
-    private _onConfigurationChangedEvent = new Event<void>("ConfigurationTests::onConfigurationChangedEvent")
-    private _onConfigurationErrorEvent = new Event<Error>("ConfigurationTests::onConfigurationErrorEvent")
+    private _onConfigurationChangedEvent = new Event<void>(
+        "ConfigurationTests::onConfigurationChangedEvent",
+    )
+    private _onConfigurationErrorEvent = new Event<Error>(
+        "ConfigurationTests::onConfigurationErrorEvent",
+    )
 
     private _values: GenericConfigurationValues = {}
     private _lastError: Error | null = null

--- a/browser/test/Services/Configuration/ConfigurationTests.ts
+++ b/browser/test/Services/Configuration/ConfigurationTests.ts
@@ -310,8 +310,8 @@ export class MockPersistedConfiguration implements IPersistedConfiguration {
 }
 
 export class MockConfigurationProvider implements IConfigurationProvider {
-    private _onConfigurationChangedEvent = new Event<void>()
-    private _onConfigurationErrorEvent = new Event<Error>()
+    private _onConfigurationChangedEvent = new Event<void>("ConfigurationTests::onConfigurationChangedEvent")
+    private _onConfigurationErrorEvent = new Event<Error>("ConfigurationTests::onConfigurationErrorEvent")
 
     private _values: GenericConfigurationValues = {}
     private _lastError: Error | null = null

--- a/browser/test/Services/TokenColorsTests.ts
+++ b/browser/test/Services/TokenColorsTests.ts
@@ -31,16 +31,7 @@ describe("TokenColors", () => {
         await themeManager.setTheme("testTheme")
 
         assert.strictEqual(hitCount, 1, "Validate onTokenColorsChanged was fired")
-    })
-
-    it("if configuration is updated, but 'editor.tokenColors' isn't there, onTokenColorsChanged should not be triggered", () => {
-        const tokenColors = new TokenColors(mockConfiguration as any, themeManager)
-
-        let hitCount = 0
-        tokenColors.onTokenColorsChanged.subscribe(() => hitCount++)
-
-        mockConfiguration.simulateConfigurationChangedEvent({ someConfigValue: 2 })
-        assert.strictEqual(hitCount, 0, "Validate onTokenColorsChanged was fired")
+        tokenColors.dispose()
     })
 
     it("if 'editor.tokenColors' is updated from the config, onTokenColorsChanged event should be triggered", () => {
@@ -51,5 +42,17 @@ describe("TokenColors", () => {
 
         mockConfiguration.simulateConfigurationChangedEvent({ "editor.tokenColors": [] })
         assert.strictEqual(hitCount, 1, "Validate onTokenColorsChanged was fired")
+        tokenColors.dispose()
+    })
+
+    it("if configuration is updated, but 'editor.tokenColors' isn't there, onTokenColorsChanged should not be triggered", () => {
+        const tokenColors = new TokenColors(mockConfiguration as any, themeManager)
+
+        let hitCount = 0
+        tokenColors.onTokenColorsChanged.subscribe(() => hitCount++)
+
+        mockConfiguration.simulateConfigurationChangedEvent({ someConfigValue: 2 })
+        assert.strictEqual(hitCount, 0, "Validate onTokenColorsChanged was fired")
+        tokenColors.dispose()
     })
 })

--- a/ui-tests/BrowserView.test.tsx
+++ b/ui-tests/BrowserView.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "../browser/src/Services/Browser/BrowserView"
 import { Configuration } from "../browser/src/Services/Configuration"
 
-const mockEvent = new Event<void>()
+const mockEvent = new Event<void>("BrowserView::mockEvent")
 const dispatch = () => mockEvent.dispatch()
 
 const MockWebviewElement = (spy: (args?: any) => void) =>


### PR DESCRIPTION
Pass names to all event constructors, first step to fix #2323
Also properly dispose some Event Handlers in tests.