### PR TITLE
Expand word tutorial to include W, E, B

### DIFF
--- a/browser/src/Services/Learning/Tutorial/Notes.tsx
+++ b/browser/src/Services/Learning/Tutorial/Notes.tsx
@@ -199,6 +199,34 @@ export const EndKey = (): JSX.Element => {
         />
     )
 }
+export const BigWordKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="W"
+            description={
+                <span>Moves the cursor to the BEGINNING of the NEXT word by WHITESPACE.</span>
+            }
+        />
+    )
+}
+export const BigBeginningKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="B"
+            description={
+                <span>Moves the cursor to the BEGINNING of the PREVIOUS word by WHITESPACE.</span>
+            }
+        />
+    )
+}
+export const BigEndKey = (): JSX.Element => {
+    return (
+        <KeyWithDescription
+            keyCharacter="E"
+            description={<span>Moves the cursor to the END of the NEXT word by WHITESPACE.</span>}
+        />
+    )
+}
 export const SlashKey = (): JSX.Element => {
     return (
         <KeyWithDescription

--- a/browser/src/Services/Learning/Tutorial/Tutorials/WordMotionTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/WordMotionTutorial.tsx
@@ -13,6 +13,11 @@ import * as Stages from "./../Stages"
 const Line1 = "Use the w key to move to the BEGINNING of the NEXT word."
 const Line2 = "Use the e key to move to the END of the NEXT word."
 const Line3 = "Use the b key to move to the BEGINNING of the PREVIOUS word."
+const Empty = ""
+const Line4 = "Word boundaries are defined by characters like '\"[]().:"
+const Line5 = "Use the W, E, B keys to use WHITESPACE as the only word boundary"
+const Line6 = "Try moving over an IP address like 192.168.100.252 to see the behavior"
+const Line7 = "Move past this timestamp [1970-01-01_00:00:00,000] with a single key press"
 
 export class WordMotionTutorial implements ITutorial {
     private _stages: ITutorialStage[]
@@ -25,7 +30,7 @@ export class WordMotionTutorial implements ITutorial {
             new Stages.MoveToGoalStage("Use the `w` key to move to the next word", 0, 8),
             new Stages.MoveToGoalStage("Use the `w` key to move to the 'key' word", 0, 10),
             new Stages.SetBufferStage([Line1, Line2]),
-            new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 1, 10 /* todo */),
+            new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 1, 10),
             new Stages.MoveToGoalStage(
                 "Use the 'e' key to move to the end of the current word",
                 1,
@@ -42,7 +47,7 @@ export class WordMotionTutorial implements ITutorial {
                 20,
             ),
             new Stages.SetBufferStage([Line1, Line2, Line3]),
-            new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 2, 20 /* todo */),
+            new Stages.MoveToGoalStage("Use the 'j' key to move down a line", 2, 20),
             new Stages.MoveToGoalStage(
                 "Use the 'b' key to move to the beginning of the current word",
                 2,
@@ -58,6 +63,28 @@ export class WordMotionTutorial implements ITutorial {
                 2,
                 10,
             ),
+            new Stages.SetBufferStage([Line1, Line2, Line3, Empty, Line4, Line5, Line6]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 6, 35),
+            new Stages.MoveToGoalStage(
+                "Keep hitting 'w' until you move past the IP address",
+                6,
+                51,
+            ),
+            new Stages.MoveToGoalStage(
+                "Well that was annoying.  Now use 'B' to jump backwards by whitespace",
+                6,
+                35,
+            ),
+            new Stages.MoveToGoalStage(
+                "Use 'W' to jump to the next word by whitespace.  Much faster!",
+                6,
+                51,
+            ),
+            new Stages.SetBufferStage([Line1, Line2, Line3, Empty, Line4, Line5, Line6, Line7]),
+            new Stages.MoveToGoalStage("Move to the goal marker", 7, 25),
+            new Stages.MoveToGoalStage("Use 'W' to move to the word after the timestamp", 7, 51),
+            new Stages.MoveToGoalStage("Use 'B' to move to the beginning of the timestamp", 7, 25),
+            new Stages.MoveToGoalStage("Use 'E' to move to the end of the timestamp", 7, 49),
         ]
     }
 
@@ -76,6 +103,14 @@ export class WordMotionTutorial implements ITutorial {
     }
 
     public get notes(): JSX.Element[] {
-        return [<Notes.HJKLKeys />, <Notes.WordKey />, <Notes.EndKey />, <Notes.BeginningKey />]
+        return [
+            <Notes.HJKLKeys />,
+            <Notes.WordKey />,
+            <Notes.EndKey />,
+            <Notes.BeginningKey />,
+            <Notes.BigWordKey />,
+            <Notes.BigEndKey />,
+            <Notes.BigBeginningKey />,
+        ]
     }
 }


### PR DESCRIPTION
I had been debating if `W`, `E`, and `B` deserved their own tutorial but given that the existing word motion tutorial was so short I decided to just expand it to add these extra keys.  Besides, I think it helps reinforce `w`, `e`, and `b` in the process.