### PR TITLE
Display an icon on non-win32 machines

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -167,7 +167,8 @@ export function createWindow(
     }
 
     const rootPath = path.join(__dirname, "..", "..", "..")
-    const iconPath = path.join(rootPath, "images", "oni.ico")
+    const iconImage = process.platform === "win32" ? "oni.ico" : "256x256.png"
+    const iconPath = path.join(rootPath, "images", iconImage)
 
     const indexFileName = process.env.ONI_WEBPACK_LOAD ? "index.dev.html" : "index.html"
     const indexPath = path.join(rootPath, indexFileName + "?react_perf")


### PR DESCRIPTION
On Linux platforms, the icon needs to be a PNG file. On MacOS too
according to this page:

https://developer.apple.com/design/human-interface-guidelines/macos/icons-and-images/app-icon/

Notes:

* As I don't have a macos, I couldn't test that it works there
* I couldn't find a way to change the "Electron" into "Oni" in the application name