### PR TITLE
add slash back for cmdline search

### DIFF
--- a/browser/src/UI/components/CommandLine.tsx
+++ b/browser/src/UI/components/CommandLine.tsx
@@ -108,11 +108,13 @@ export class CommandLine extends React.PureComponent<ICommandLineRendererProps, 
                         iconName="arrow-right"
                         key={`${character}-arrow-right`}
                     />,
+                    character,
                 ]
             case "?":
                 return [
                     <CommandLineIcon iconName="search" key={`${character}-search`} />,
-                    <CommandLineIcon key={`${character}-arrow-left`} arrow iconName="arrow-left" />,
+                    <CommandLineIcon arrow iconName="arrow-left" key={`${character}-arrow-left`} />,
+                    character,
                 ]
             default:
                 return character


### PR DESCRIPTION
Hi,

vim has `//` syntax for last search. However, the Oni command line search will not display the first character like `/` or `?` .

This pull request is to restore the behavior. 