### PR TITLE
Bugfix - Regression: First run of Oni doesn't open a window

### DIFF
--- a/main/src/ProcessLifecycle.ts
+++ b/main/src/ProcessLifecycle.ts
@@ -11,4 +11,8 @@ export const makeSingleInstance = (options, callbackFunction) => {
     if (isSecondInstance) {
         app.quit()
     }
+
+    app.on("ready", () => {
+        callbackFunction(options)
+    })
 }


### PR DESCRIPTION
This is a regression of #2377 - the manifestation is that, when first launching Oni, nothing happens - it takes a second launch to actually see the window.

The issue is that, we call `makeSingleInstance`, and the callback for that gets fired _when any additional instance is opened_, however, we weren't handling the initial case - if `isSecondInstance` is false, than we need to kick off the window launch explicitly after the 'ready' event is fired.

Thanks @CrossR for catching this! 💯 