### PR TITLE
Workaround for devtools keyboard shortcuts not working on OSX

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -174,6 +174,26 @@ export function createWindow(
         width: windowState.bounds.width,
     })
 
+    // Workaround for cut/copy/paste/close keybindings not working in devtools window on OSX
+    if (process.platform === "darwin") {
+        currentWindow.webContents.on("devtools-opened", () => {
+            currentWindow.webContents.devToolsWebContents.executeJavaScript(`
+                window.addEventListener('keydown', function (e) {
+                    if (e.keyCode === 65 && e.metaKey) {
+                        document.execCommand('Select All');
+                    } else if (e.keyCode === 67 && e.metaKey) {
+                        document.execCommand('copy');
+                    } else if (e.keyCode === 86 && e.metaKey) {
+                        document.execCommand('paste');
+                    } else if (e.keyCode === 87 && e.metaKey) {
+                        window.close();
+                    } else if (e.keyCode === 88 && e.metaKey) {
+                        document.execCommand('cut');
+                    }
+                });`)
+        })
+    }
+
     if (windowState.isMaximized) {
         currentWindow.maximize()
     }


### PR DESCRIPTION
Fixes #2347 using the workaround suggested in [the Electron bug](https://github.com/electron/electron/issues/11998)