### PR TITLE
Add indents to every line in the snippet.

### DIFF
--- a/browser/src/Services/Snippets/SnippetSession.ts
+++ b/browser/src/Services/Snippets/SnippetSession.ts
@@ -4,6 +4,7 @@
  * Manages snippet integration
  */
 
+import * as detectIndent from "detect-indent"
 import * as types from "vscode-languageserver-types"
 
 import * as Oni from "oni-api"
@@ -145,6 +146,7 @@ export class SnippetSession {
         this._position = cursorPosition
 
         const [prefix, suffix] = splitLineAtPosition(currentLine, cursorPosition.character)
+        const currentIndent = detectIndent(currentLine)
 
         this._prefix = prefix
         this._suffix = suffix
@@ -154,7 +156,15 @@ export class SnippetSession {
         snippetLines[0] = this._prefix + snippetLines[0]
         snippetLines[lastIndex] = snippetLines[lastIndex] + this._suffix
 
-        await this._buffer.setLines(cursorPosition.line, cursorPosition.line + 1, snippetLines)
+        const indentedLines = snippetLines.map((line, index) => {
+            if (index === 0) {
+                return line
+            } else {
+                return currentIndent.indent + line
+            }
+        })
+
+        await this._buffer.setLines(cursorPosition.line, cursorPosition.line + 1, indentedLines)
 
         const placeholders = this._snippet.getPlaceholders()
 

--- a/browser/test/Services/Snippets/SnippetSessionTests.ts
+++ b/browser/test/Services/Snippets/SnippetSessionTests.ts
@@ -50,7 +50,7 @@ describe("SnippetSession", () => {
             assert.strictEqual(firstLine, "somefooline")
         })
 
-        it("matches existing whitespace - 2 spaces", async () => {
+        it("matches existing whitespace for first line - 2 spaces", async () => {
             snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
 
             const indentationInfo = {
@@ -66,7 +66,7 @@ describe("SnippetSession", () => {
             assert.strictEqual(firstLine, "    foo")
         })
 
-        it("matches existing whitespace - tabs", async () => {
+        it("matches existing whitespace for first line - tabs", async () => {
             snippetSession = new SnippetSession(mockEditor as any, "\t\tfoo")
 
             const indentationInfo = {
@@ -117,6 +117,54 @@ describe("SnippetSession", () => {
 
         assert.strictEqual(firstLine, "somefoo")
         assert.strictEqual(secondLine, "barline")
+    })
+
+    it("matches existing whitespace for whole snippet - 2 spaces", async () => {
+        snippetSession = new SnippetSession(mockEditor as any, "for {\n\tthing\n}")
+
+        const indentationInfo = {
+            type: "space",
+            amount: 2,
+            indent: "  ",
+        }
+
+        mockBuffer.setWhitespace(indentationInfo as any)
+
+        // Add a line, and move cursor to line
+        mockBuffer.setLinesSync(["  "])
+        mockBuffer.setCursorPosition(0, 2)
+
+        await snippetSession.start()
+
+        const [firstLine, secondLine, thirdLine] = await mockBuffer.getLines(0, 3)
+
+        assert.strictEqual(firstLine, "  for {")
+        assert.strictEqual(secondLine, "    thing")
+        assert.strictEqual(thirdLine, "  }")
+    })
+
+    it("matches existing whitespace for whole snippet  - tabs", async () => {
+        snippetSession = new SnippetSession(mockEditor as any, "for {\n\tthing\n}")
+
+        const indentationInfo = {
+            type: "tab",
+            amount: 0,
+            indent: "\t",
+        }
+
+        mockBuffer.setWhitespace(indentationInfo as any)
+
+        // Add a line, and move cursor to line
+        mockBuffer.setLinesSync(["\t"])
+        mockBuffer.setCursorPosition(0, 1)
+
+        await snippetSession.start()
+
+        const [firstLine, secondLine, thirdLine] = await mockBuffer.getLines(0, 3)
+
+        assert.strictEqual(firstLine, "\tfor {")
+        assert.strictEqual(secondLine, "\t\tthing")
+        assert.strictEqual(thirdLine, "\t}")
     })
 
     it("highlights first placeholder", async () => {


### PR DESCRIPTION
Fixes #2242.

Adds the correct indent level to every line in a snippet.

Is there any edge cases I'm missing where this could fall apart?