### PR TITLE
Fix: quit the application with Cmd + Q

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -4,7 +4,7 @@
  * Entry point for the Oni application - managing the overall lifecycle
  */
 
-import { ipcRenderer } from "electron"
+import { ipcRenderer, remote } from "electron"
 import * as fs from "fs"
 import * as minimist from "minimist"
 import * as path from "path"
@@ -47,6 +47,11 @@ export const quit = async (): Promise<void> => {
         Log.info("[App.quit] Quit hook completed successfully")
     })
     await Promise.all([promises])
+    // On mac we should quit the application when the user press Cmd + Q
+    if (process.platform === "darwin") {
+        Log.info("[App::quit] quitting app")
+        remote.app.quit()
+    }
     Log.info("[App::quit] completed")
 }
 

--- a/browser/test/AppTests.ts
+++ b/browser/test/AppTests.ts
@@ -1,0 +1,40 @@
+import * as assert from "assert"
+import { remote } from "electron"
+import * as sinon from "sinon"
+import { quit } from "../src/App"
+
+describe("App", () => {
+    describe("oni.quit", () => {
+        it("should invoke remote.app.quit() on Mac", async () => {
+            // Stub remote.app.quit() function
+            const originalQuit = remote.app.quit
+            const quitStub = sinon.stub()
+            remote.app.quit = quitStub
+            // Stub process.platform
+            const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")
+            Object.defineProperty(process, "platform", { value: "darwin" })
+            // Test quit()
+            await quit()
+            assert.ok(quitStub.called)
+            // Restore stubs
+            remote.app.quit = originalQuit
+            Object.defineProperty(process, "platform", originalPlatform)
+        })
+
+        it("shouldn't invoke remote.app.quit() except on Mac", async () => {
+            // Stub remote.app.quit() function
+            const originalQuit = remote.app.quit
+            const quitStub = sinon.stub()
+            remote.app.quit = quitStub
+            // Stub process.platform
+            const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")
+            Object.defineProperty(process, "platform", { value: "win32" })
+            // Test quit()
+            await quit()
+            assert.ok(quitStub.notCalled)
+            // Restore stubs
+            remote.app.quit = originalQuit
+            Object.defineProperty(process, "platform", originalPlatform)
+        })
+    })
+})


### PR DESCRIPTION
On mac we should quit the application when the user press Cmd + Q.
Currently we need to use Cmd + Q twice to quit the application.
This PR fixes it.