### PR TITLE
Allow toggling of the Plugins pane in the sidebar

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -400,7 +400,7 @@ export const start = async (args: string[]): Promise<void> => {
     Bookmarks.activate(configuration, editorManager, Sidebar.getInstance())
 
     const PluginsSidebarPane = await import("./Plugins/PluginSidebarPane")
-    PluginsSidebarPane.activate(configuration, pluginManager, sidebarManager)
+    PluginsSidebarPane.activate(commandManager, configuration, pluginManager, sidebarManager)
 
     const Terminal = await terminalPromise
     Terminal.activate(commandManager, configuration, editorManager)

--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -276,6 +276,6 @@ export const activate = (
         name: "Plugins: Toggle Visibility",
         detail: "Toggles the plugins pane in the sidebar",
         execute: togglePlugins,
-        enabled: () => configuration.getValue("sidebar.plugins.enabled")
+        enabled: () => configuration.getValue("sidebar.plugins.enabled"),
     })
 }

--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -8,6 +8,7 @@ import * as React from "react"
 
 import { Event, IDisposable, IEvent } from "oni-types"
 
+import { CommandManager } from "./../Services/CommandManager"
 import { Configuration } from "./../Services/Configuration"
 import { SidebarManager, SidebarPane } from "./../Services/Sidebar"
 
@@ -256,6 +257,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
 }
 
 export const activate = (
+    commandManager: CommandManager,
     configuration: Configuration,
     pluginManager: PluginManager,
     sidebarManager: SidebarManager,
@@ -264,4 +266,16 @@ export const activate = (
         const pane = new PluginsSidebarPane(pluginManager)
         sidebarManager.add("plug", pane)
     }
+
+    const togglePlugins = () => {
+        sidebarManager.toggleVisibilityById("oni.sidebar.plugins")
+    }
+
+    commandManager.registerCommand({
+        command: "plugins.toggle",
+        name: "Plugins: Toggle Visibility",
+        detail: "Toggles the plugins pane in the sidebar",
+        execute: togglePlugins,
+        enabled: () => configuration.getValue("sidebar.plugins.enabled")
+    })
 }


### PR DESCRIPTION
#2343 added the functionality to toggle the Explorer pane in the sidebar. This adds the same functionality to the Plugins pane.

The bug mentioned in #2349 does not affect this command.