### PR TITLE
Remove 'Split -> File Explorer Split' menu item

### DIFF
--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -634,12 +634,6 @@ export const buildMenu = (mainWindow, loadInit) => {
                 },
             },
             {
-                label: "File Explorer Split",
-                click(item, focusedWindow) {
-                    executeVimCommand(focusedWindow, ":Lexplore | vertical resize 30")
-                },
-            },
-            {
                 type: "separator",
             },
             {


### PR DESCRIPTION
Oni's menu items were originally created to mimic GVim's as closely as possible.  One of those items was "File Explorer Split" which just ran the `:Lexplore` command.  Now that we have a legitimate File Explorer there's no reason for this menu item to exist.  Besides, if there is some Vim expert who prefers `:Lexplore` over our File Explorer they wouldn't have used the "File Explorer Split" menu item anyway.