### PR TITLE
Fix cursor position when multi-byte characters are in the line

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -217,7 +217,7 @@ export class Buffer implements IBuffer {
     }
 
     public async getPosition(element: string): Promise<types.Position> {
-        const row: number = await this._neovimInstance.callFunction("line", ["."])
+        const row: number = await this._neovimInstance.callFunction("line", [element])
         const column: number = await this._neovimInstance.eval<number>(
             `strchars((getline('${element}') . '.')[0:col('${element}') - 1])`,
         )

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -88,7 +88,6 @@ export const activate = (
 
     const handleEnterCharacter = (pairs: IAutoClosingPair[], editor: Oni.Editor) => () => {
         Log.verbose("[AutoClosingPairs::handleEnterCharacter]")
-        const neovim: NeovimInstance = editor.neovim as any
         editor.blockInput(async (inputFunc: Oni.InputCallbackFunction) => {
             const activeBuffer = editor.activeBuffer
 
@@ -98,7 +97,7 @@ export const activate = (
             )
             const line = lines[0]
 
-            const { column } = activeBuffer.cursor
+            const { line: row, column } = activeBuffer.cursor
 
             const matchingPair = pairs.find(p => {
                 return column >= 1 && line[column] === p.close && line[column - 1] === p.open
@@ -109,14 +108,12 @@ export const activate = (
                 const beforePair = line.substring(0, column)
                 const afterPair = line.substring(column, line.length)
 
-                const pos = await neovim.callFunction("getpos", ["."])
-                const [, oneBasedLine] = pos
                 await activeBuffer.setLines(
                     activeBuffer.cursor.line,
                     activeBuffer.cursor.line + 1,
                     [beforePair, whiteSpacePrefix, whiteSpacePrefix + afterPair],
                 )
-                await activeBuffer.setCursorPosition(oneBasedLine, whiteSpacePrefix.length)
+                await activeBuffer.setCursorPosition(row + 1, whiteSpacePrefix.length)
                 await inputFunc("<tab>")
             } else {
                 await inputFunc("<enter>")

--- a/browser/src/Services/AutoClosingPairs.ts
+++ b/browser/src/Services/AutoClosingPairs.ts
@@ -67,9 +67,11 @@ export const activate = (
                 const beforePair = line.substring(0, column - 1)
                 const afterPair = line.substring(column + 1, line.length)
 
-                const pos = await neovim.callFunction("getpos", ["."])
-                const [, oneBasedLine, oneBasedColumn] = pos
-                await editor.activeBuffer.setCursorPosition(oneBasedLine - 1, oneBasedColumn - 2)
+                const cursorPosition = await editor.activeBuffer.getCursorPosition()
+                await editor.activeBuffer.setCursorPosition(
+                    cursorPosition.line,
+                    cursorPosition.character - 1,
+                )
 
                 await activeBuffer.setLines(
                     activeBuffer.cursor.line,

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -62,6 +62,8 @@ const CiTests = [
 
     "Theming.LightAndDarkColorsTest",
 
+    "MultiByteCursorColumnTest",
+
     // This test occasionally hangs and breaks tests after - trying to move it later...
     "LargeFileTest",
 ]

--- a/test/ci/MultiByteCursorColumnTest.ts
+++ b/test/ci/MultiByteCursorColumnTest.ts
@@ -1,0 +1,53 @@
+import * as assert from "assert"
+import * as Oni from "oni-api"
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+
+    oni.automation.sendKeys("i")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "insert")
+
+    oni.automation.sendKeys("ß")
+    oni.automation.sendKeys("<Esc>")
+
+    // Because the input is asynchronous, we need to use `waitFor` to wait
+    // for them to complete.
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "normal")
+    await assertPosition(oni, 0, "normal")
+
+    oni.automation.sendKeys("i")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "insert")
+    await assertPosition(oni, 0, "insert before")
+
+    oni.automation.sendKeys("<Esc>")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "normal")
+
+    oni.automation.sendKeys("a")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "insert")
+    await assertPosition(oni, 1, "insert after")
+
+    oni.automation.sendKeys("ß")
+    oni.automation.sendKeys("<Esc>")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "normal")
+    await assertPosition(oni, 1, "second normal")
+
+    oni.automation.sendKeys("a")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "insert")
+    await assertPosition(oni, 2, "second insert after")
+}
+
+async function assertPosition(
+    oni: Oni.Plugin.Api,
+    column: number,
+    position: string,
+): Promise<void> {
+    const cursor = oni.editors.activeEditor.activeBuffer.cursor
+    const cursorPosition = await oni.editors.activeEditor.activeBuffer.getCursorPosition()
+
+    assert.equal(cursor.column, column, position + " c " + cursor.column + " " + column)
+    assert.equal(
+        cursorPosition.character,
+        column,
+        position + " p " + cursorPosition.character + " " + column,
+    )
+}

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -157,7 +157,10 @@ let context.bufferNumber = bufnr("%")
 let context.bufferFullPath = expand("%:p")
 let context.bufferTotalLines = line("$")
 let context.line = line(".")
-let context.column = col(".")
+" the col function returns the position in bytes instead of characters
+" this is problematic for multi-byte characters
+" work around it by taking a slice of the line and counting characters
+let context.column = strchars((getline('.') . '.')[0:col('.') - 1])
 let context.mode = mode()
 let context.tabNumber = tabpagenr()
 let context.windowNumber = win_getid()


### PR DESCRIPTION
The vimscript `col()` and `getpos()` functions return the byte the cursor is at, as opposed to the character index.
Inside Oni this cursor value is often used to index into the line content.
That failed whenever any multi-byte character was present in the line.
This value need to be in byte-form for setting the cursor-position though.

As vim does not have a nice way to access the character index, I used the following workaround:
`strchars((getline('.') . '.')[0:col('.') - 1])`

`(getline('.') . '.')`
get line content and append a dot to lengthen it by one (because columns are one indexed in the std `col()` function)
`[0:col('.') - 1]`
slice the line from beginning to selected column (-1 because the slice is inclusive)
`strchars(...)`
count the characters

When I tested this with very long lines I couldn't notice a significant speed difference in moving the cursor.
I'm open to a nicer solution, but couldn't find a vimscript function to get the character index the cursor is on directly.

This affected all Oni code which needed to analyse text under the cursor (e.g. completion, highlighting, hovers, rename, ...)
Example of badly matched code:
![image](https://user-images.githubusercontent.com/16743652/42731627-5af1f378-8811-11e8-9815-83d9f8c690dd.png)
Highlighting is still broken even with this pr, because I couldn't figure out how it works and it is not dependent on the cursor.

Fixes https://github.com/onivim/oni/issues/1625