### PR TITLE
Fix for #2251 Oni does not correctly locate executables

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,5 +1,4 @@
 import * as path from "path"
-
 import { CLIArgs, parseCLIProcessArgv } from "./cli_args"
 
 import { spawn } from "child_process"
@@ -27,7 +26,10 @@ export async function main(cli_arguments: string[]): Promise<any> {
 
     // Otherwise, was loaded normally, so launch Oni.
 
-    const env = assign({}, process.env, {
+    const shellEnvPromise = import("shell-env")
+    const shellEnv = (await shellEnvPromise).sync()
+
+    const env = assign({}, process.env, shellEnv, {
         ONI_CLI: "1", // Let Oni know it was started from the CLI
         ELECTRON_NO_ATTACH_CONSOLE: "1",
     })


### PR DESCRIPTION
Issue #2251 doesn't appear to affect my linux system, but does affect my mac. I have tested this fix on both system, and it appears to fix the PATH issue for the mac.