### PR TITLE
Refactoring: Phase 1

### DIFF
--- a/browser/src/Services/Explorer/index.tsx
+++ b/browser/src/Services/Explorer/index.tsx
@@ -8,7 +8,8 @@ import { CommandManager } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
 import { EditorManager } from "./../EditorManager"
 import { SidebarManager } from "./../Sidebar"
-import { Workspace } from "./../Workspace"
+
+import { IWorkspace } from "./../../Services/Workspace"
 
 import { ExplorerSplit } from "./ExplorerSplit"
 
@@ -17,7 +18,7 @@ export const activate = (
     configuration: Configuration,
     editorManager: EditorManager,
     sidebarManager: SidebarManager,
-    workspace: Workspace,
+    workspace: IWorkspace,
 ) => {
     configuration.registerSetting("explorer.autoRefresh", {
         description:


### PR DESCRIPTION
# TL;DR 

This is a first PR in a series of refactors.

# Details

**What:** Trying to bring in the `oni-api` package to the same repo as the app.
**Reason:** So correlating changes could be made in an atomic (single) PR and without requiring a deployment of a new and untested version of the API.

Simply setting the API as a local-package yields errors that are usually aren't there (I guess it is a bug/feature on TS's side).
So this is a first in a series of PRs that incrementally fix those issues.