### PR TITLE
Feature/Color-highlight improvements

### DIFF
--- a/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
+++ b/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
@@ -67,6 +67,7 @@ class Highlight extends React.PureComponent<IProps, IState> {
                     left={this.props.left}
                     height={this.props.height}
                     width={this.props.width}
+                    data-id="color-highlight"
                 >
                     <HighlightSpan
                         fontFamily={this.props.fontFamily}
@@ -318,7 +319,6 @@ export default class ColorHighlightLayer implements Oni.BufferLayer {
                                     fontSize={this._fontSize}
                                     fontFamily={this._fontFamily}
                                     color={location.color.toLowerCase()}
-                                    data-id="color-highlight"
                                 >
                                     {location.color}
                                 </Highlight>

--- a/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
+++ b/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
@@ -24,7 +24,7 @@ const ColorHighlight = withProps<IProps>(styled.div).attrs({
         width: pixel(props.width),
     }),
 })`
-    display: flex;
+    display: block;
     justify-content: center;
     align-items: center;
     background-color: ${p => p.color};
@@ -32,8 +32,28 @@ const ColorHighlight = withProps<IProps>(styled.div).attrs({
     color: ${p => (Color(p.color).dark() ? "white" : "black")};
     font-family: ${p => p.fontFamily};
     font-size: ${p => p.fontSize};
+    line-height: ${p => pixel(p.height + 5)} /* vertically center text inside the highlight */
     white-space: nowrap;
 `
+
+interface IState {
+    error: Error
+}
+
+class Highlight extends React.PureComponent<IProps, IState> {
+    public state: IState = {
+        error: null,
+    }
+
+    public componentDidCatch(error: Error) {
+        this.setState({ error })
+    }
+
+    public render() {
+        const { error } = this.state
+        return !error && <ColorHighlight {...this.props} />
+    }
+}
 
 export default class ColorHighlightLayer implements Oni.BufferLayer {
     public render = memoize((context: Oni.BufferLayerRenderContext) => (
@@ -263,7 +283,7 @@ export default class ColorHighlightLayer implements Oni.BufferLayer {
 
                             const width = endPosition.pixelX - startPosition.pixelX
                             return (
-                                <ColorHighlight
+                                <Highlight
                                     width={width}
                                     left={startPosition.pixelX}
                                     top={startPosition.pixelY}
@@ -274,7 +294,7 @@ export default class ColorHighlightLayer implements Oni.BufferLayer {
                                     data-id="color-highlight"
                                 >
                                     {location.color}
-                                </ColorHighlight>
+                                </Highlight>
                             )
                         })
                     }

--- a/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
+++ b/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
@@ -6,39 +6,49 @@ import * as React from "react"
 
 import styled, { pixel, withProps } from "../../UI/components/common"
 
-interface IProps {
+interface IBackground {
     top: number
     left: number
     height: number
     width: number
+}
+
+interface IHighlight {
     color: string
     fontFamily: string
+    height: number
     fontSize: string
 }
 
-const ColorHighlight = withProps<IProps>(styled.div).attrs({
-    style: (props: IProps) => ({
+const Background = withProps<IBackground>(styled.div).attrs({
+    style: (props: IBackground) => ({
         top: pixel(props.top),
         left: pixel(props.left),
         height: pixel(props.height),
         width: pixel(props.width),
     }),
 })`
-    display: block;
-    justify-content: center;
-    align-items: center;
-    background-color: ${p => p.color};
+    background-color: ${p => p.theme["editor.background"]};
     position: absolute;
+    white-space: nowrap;
+`
+
+const HighlightSpan = withProps<IHighlight>(styled.div)`
+    display: block;
+    height: 100%;
+    width: 100%;
     color: ${p => (Color(p.color).dark() ? "white" : "black")};
     font-family: ${p => p.fontFamily};
     font-size: ${p => p.fontSize};
-    line-height: ${p => pixel(p.height + 5)} /* vertically center text inside the highlight */
-    white-space: nowrap;
+    line-height: ${p => pixel(p.height + 5)}; /* vertically center text inside the highlight */
+    background-color: ${p => p.color};
 `
 
 interface IState {
     error: Error
 }
+
+type IProps = IHighlight & IBackground
 
 class Highlight extends React.PureComponent<IProps, IState> {
     public state: IState = {
@@ -50,8 +60,25 @@ class Highlight extends React.PureComponent<IProps, IState> {
     }
 
     public render() {
-        const { error } = this.state
-        return !error && <ColorHighlight {...this.props} />
+        return (
+            !this.state.error && (
+                <Background
+                    top={this.props.top}
+                    left={this.props.left}
+                    height={this.props.height}
+                    width={this.props.width}
+                >
+                    <HighlightSpan
+                        fontFamily={this.props.fontFamily}
+                        fontSize={this.props.fontSize}
+                        height={this.props.height}
+                        color={this.props.color}
+                    >
+                        {this.props.children}
+                    </HighlightSpan>
+                </Background>
+            )
+        )
     }
 }
 

--- a/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
+++ b/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
@@ -229,7 +229,7 @@ export default class ColorHighlightLayer implements Oni.BufferLayer {
         const colorNames = this.CSS_COLOR_NAMES.map(name => `\\b${name}\\b`)
         const colorNamesRegex = new RegExp("(" + colorNames.join("|") + ")")
         this._colorRegex = new RegExp(
-            "\\b" + colorNamesRegex.source + "|" + this._colorCodeRegex.source + "\\b",
+            colorNamesRegex.source + "|" + this._colorCodeRegex.source,
             "gi",
         )
     }

--- a/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
+++ b/browser/src/Editor/OniEditor/ColorHighlightLayer.tsx
@@ -32,6 +32,7 @@ const ColorHighlight = withProps<IProps>(styled.div).attrs({
     color: ${p => (Color(p.color).dark() ? "white" : "black")};
     font-family: ${p => p.fontFamily};
     font-size: ${p => p.fontSize};
+    white-space: nowrap;
 `
 
 export default class ColorHighlightLayer implements Oni.BufferLayer {
@@ -203,6 +204,7 @@ export default class ColorHighlightLayer implements Oni.BufferLayer {
     constructor(private _config: Oni.Configuration) {
         this._fontSize = this._config.getValue("editor.fontSize")
         this._fontFamily = this._config.getValue("editor.fontFamily")
+        this._config.onConfigurationChanged.subscribe(this._updateFontFamily)
 
         this._constructRegex()
     }
@@ -215,12 +217,19 @@ export default class ColorHighlightLayer implements Oni.BufferLayer {
         return "CSS color highlight layer"
     }
 
+    private _updateFontFamily = (configChanges: Partial<Oni.ConfigurationValues>) => {
+        const fontFamilyChanged = Object.keys(configChanges).includes("editor.fontFamily")
+        if (fontFamilyChanged) {
+            this._fontFamily = configChanges["editor.fontFamily"]
+        }
+    }
+
     private _constructRegex() {
         // Construct a regex checking for both color codes and all the different css colornames
         const colorNames = this.CSS_COLOR_NAMES.map(name => `\\b${name}\\b`)
         const colorNamesRegex = new RegExp("(" + colorNames.join("|") + ")")
         this._colorRegex = new RegExp(
-            colorNamesRegex.source + "|" + this._colorCodeRegex.source,
+            "\\b" + colorNamesRegex.source + "|" + this._colorCodeRegex.source + "\\b",
             "gi",
         )
     }


### PR DESCRIPTION
Update the color highlight's fontfamily if a user changes their font mid session currently the font is set in the constructor and doesn't update if the the users font family changes ~, update the regex to match only on words i.e not mid string~

Add a background to cover the underlying text so the color doesnt bleed through

This PR doesn't address the regex issue as it is seemingly more complicated to resolve than I imagined for example `white-space` currently gets matched because of the white the issue with this is that the regex fuzzy matches so that for example a react component like `<Component color={"white"} />` gets matched i.e. the quotes wouldnt stop the match or `:black` the colon wouldn't stop the match, I'm not sure just stopping the hyphen specifically would be enough as html entities can also match so its not entirely clear what the right boundaries should be. Looking at vscode highlight plugins they seem to employ a range of different regexes depending on the filetype so support is only for some filetypes that there is a strategy for. Our current solution is far more general but causes these edge cases 🤔 


Outstanding:
- [x] mid color input rarely the editor can crash whilst an incomplete rgba color was being input, somehow the incomplete color was passed to the styled component causing it throw an error -> prevent incomplete match, seems rare as its is not easily reproduc