### PR TITLE
Bugfix/ Close signature help on scroll

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -119,6 +119,7 @@ export class NeovimEditor extends Editor implements IEditor {
     private _modeChanged$: Observable<Oni.Vim.Mode>
     private _cursorMoved$: Observable<Oni.Cursor>
     private _cursorMovedI$: Observable<Oni.Cursor>
+    private _onScroll$: Observable<Oni.EditorBufferScrolledEventArgs>
 
     private _hasLoaded: boolean = false
 
@@ -603,6 +604,7 @@ export class NeovimEditor extends Editor implements IEditor {
         })
 
         this._modeChanged$ = asObservable(this._neovimInstance.onModeChanged)
+        this._onScroll$ = asObservable(this._neovimInstance.onScroll)
 
         this.trackDisposable(
             this._neovimInstance.onModeChanged.subscribe(newMode => this._onModeChanged(newMode)),
@@ -643,6 +645,7 @@ export class NeovimEditor extends Editor implements IEditor {
         addInsertModeLanguageFunctionality(
             this._cursorMovedI$,
             this._modeChanged$,
+            this._onScroll$,
             this._toolTipsProvider,
         )
 

--- a/browser/src/Services/Language/SignatureHelp.ts
+++ b/browser/src/Services/Language/SignatureHelp.ts
@@ -21,15 +21,17 @@ import * as SignatureHelp from "./SignatureHelpView"
 export const initUI = (
     latestCursorAndBufferInfo$: Observable<ILatestCursorAndBufferInfo>,
     modeChanged$: Observable<Oni.Vim.Mode>,
+    onScroll$: Observable<Oni.EditorBufferScrolledEventArgs>,
     toolTips: IToolTipsProvider,
 ) => {
     const signatureHelpToolTipName = "signature-help-tool-tip"
 
+    onScroll$.subscribe(_ => toolTips.hideToolTip(signatureHelpToolTipName))
     // Show signature help as the cursor moves
     latestCursorAndBufferInfo$
-        .flatMap(async val => {
-            return showSignatureHelp(val.language, val.filePath, val.cursorLine, val.cursorColumn)
-        })
+        .flatMap(val =>
+            showSignatureHelp(val.language, val.filePath, val.cursorLine, val.cursorColumn),
+        )
         .subscribe(result => {
             if (result) {
                 toolTips.showToolTip(signatureHelpToolTipName, SignatureHelp.render(result), {

--- a/browser/src/Services/Language/addInsertModeLanguageFunctionality.ts
+++ b/browser/src/Services/Language/addInsertModeLanguageFunctionality.ts
@@ -26,11 +26,12 @@ export interface ILatestCursorAndBufferInfo {
 export const addInsertModeLanguageFunctionality = (
     cursorMoved$: Observable<Oni.Cursor>,
     modeChanged$: Observable<Oni.Vim.Mode>,
+    onScroll$: Observable<Oni.EditorBufferScrolledEventArgs>,
     toolTips: IToolTipsProvider,
 ) => {
     const latestCursorAndBufferInfo$: Observable<
         ILatestCursorAndBufferInfo
-    > = cursorMoved$.auditTime(10).mergeMap(async cursorPos => {
+    > = cursorMoved$.mergeMap(async cursorPos => {
         const editor = editorManager.activeEditor
         const buffer = editor.activeBuffer
 
@@ -45,5 +46,5 @@ export const addInsertModeLanguageFunctionality = (
         }
     })
 
-    SignatureHelp.initUI(latestCursorAndBufferInfo$, modeChanged$, toolTips)
+    SignatureHelp.initUI(latestCursorAndBufferInfo$, modeChanged$, onScroll$, toolTips)
 }


### PR DESCRIPTION
Currently the signature help remains open if a user scrolls the buffer mid input, causing it to follow the cursor to the wrong position.

This change removes the cursor moved `auditTime` and adds a scroll observable which closes the signature help on scroll

hopefully fixes #2237 