### PR TITLE
Ignore Yarn from Linguist.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # Declare text files that will always have LF line endings on checking
 oni eol=lf
+
+# Ignore the yarn library from Linguist, for the Github Language Stats.
+lib/yarn/* linguist-vendored=true


### PR DESCRIPTION
This is entirely a GitHub visual thing, so not at all urgent.

This tells Linguist (the tool used for GitHub language checking) to ignore `yarn` as vendored code.
This is what is currently causing Oni to come up as a JS project on GitHub, as it is a 3ish MB binary, and linguist works on file size rather than lines (well bytes of code reported).

Doesn't change anything else, except making that bar on the front page a lot more blue than yellow.

Whats annoying is that this can't be tested until its pushed. I've tried it with a local copy of linguist though, so we should be fine.