### PR TITLE
Add the CLI scripts back to the build command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -590,7 +590,7 @@
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
         "build":
-            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins",
+            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
         "build-debug":
             "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",


### PR DESCRIPTION
Looks like the building of the CLI script was removed at some point, which meant the CLI scripts weren't working if the user didn't explicitly call `yarn run build:cli`.

Should we do a bit of a shuffle with the `package.json` to rename some of the scripts so we can use `run-p` more?