### PR TITLE
Jump to files/directories created in the Explorer

### DIFF
--- a/browser/src/Services/Explorer/ExplorerStore.ts
+++ b/browser/src/Services/Explorer/ExplorerStore.ts
@@ -468,6 +468,11 @@ const Actions = {
             children: sortedFilesAndFolders,
         }
     },
+
+    selectFile: (filePath: string): ISelectFileAction => ({
+        type: "SELECT_FILE",
+        filePath,
+    }),
 }
 
 // Yank, Paste Delete register =============================
@@ -1004,11 +1009,10 @@ export const createNodeEpic: ExplorerEpic = (action$, store, { fileSystem }) =>
                 create: { nodeType },
             },
         } = store.getState()
-        const shouldExpand = Actions.expandDirectory(path.dirname(name))
         const createFileOrFolder =
             nodeType === "file" ? fileSystem.writeFile(name) : fileSystem.mkdir(name)
         return fromPromise(createFileOrFolder)
-            .flatMap(() => [Actions.createNode({ nodeType, name }), shouldExpand, Actions.refresh])
+            .flatMap(() => [Actions.createNode({ nodeType, name }), Actions.selectFile(name)])
             .catch(error => [Actions.createNodeFail(error.message)])
     })
 


### PR DESCRIPTION
* Add a `SELECT_FILE` action as the last step in `CREATE_NODE_COMMIT` so
that files created in the explorer are scrolled and highlighted.
* `SELECT_FILE` has the same effect as `EXPAND_DIRECTORY` + `REFRESH`,
so no need to include those as well.
* Updated unit tests.