### PR TITLE
Refocus previously open menu on reactivating Oni

### DIFF
--- a/browser/src/Input/KeyboardInput.tsx
+++ b/browser/src/Input/KeyboardInput.tsx
@@ -87,7 +87,7 @@ export class KeyboardInputView extends React.PureComponent<
         if (this.props.onActivate) {
             this._removeExistingDisposables()
             const d1 = this.props.onActivate.subscribe(() => {
-                focusManager.setFocus(this._keyboardElement)
+                focusManager.pushFocus(this._keyboardElement)
             })
             this._disposables.push(d1)
         }

--- a/browser/src/Services/FocusManager.ts
+++ b/browser/src/Services/FocusManager.ts
@@ -12,7 +12,9 @@ class FocusManager {
     }
 
     public pushFocus(element: HTMLElement) {
-        this._focusElementStack = [element, ...this._focusElementStack]
+        if (!this._focusElementStack.includes(element)) {
+            this._focusElementStack = [element, ...this._focusElementStack]
+        }
 
         window.setTimeout(() => this.enforceFocus(), 0)
     }

--- a/browser/test/Services/FocusManagerTests.ts
+++ b/browser/test/Services/FocusManagerTests.ts
@@ -1,0 +1,62 @@
+/* global:clock */
+import * as assert from "assert"
+import * as sinon from "sinon"
+
+import { focusManager } from "../../src/Services/FocusManager"
+
+// tslint:disable-next-line no-string-literal
+const clock: any = global["clock"]
+
+describe("FocusManager", () => {
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create()
+    })
+    afterEach(() => {
+        sandbox.restore()
+        // tslint:disable-next-line no-string-literal
+        focusManager["_focusElementStack"] = []
+    })
+
+    describe("pushFocus", () => {
+        let enforceFocus: sinon.SinonStub
+        beforeEach(() => {
+            enforceFocus = sandbox.stub(focusManager, "enforceFocus")
+        })
+
+        const assertEnforcesFocus = () => {
+            sinon.assert.notCalled(enforceFocus)
+            clock.tick(0)
+            sinon.assert.calledOnce(enforceFocus)
+            sinon.assert.calledWithExactly(enforceFocus)
+        }
+
+        it("prepends element to the stack and ensures it's focused", () => {
+            const elNew = "elNew" as any
+            const elPrev = "elPrev" as any
+            // tslint:disable-next-line no-string-literal
+            focusManager["_focusElementStack"] = [elPrev]
+
+            focusManager.pushFocus(elNew)
+
+            // tslint:disable-next-line no-string-literal
+            assert.deepStrictEqual(focusManager["_focusElementStack"], [elNew, elPrev])
+            assertEnforcesFocus()
+        })
+
+        it("does not update the stack if the element is already in it", () => {
+            const el1 = "el1" as any
+            const el2 = "el2" as any
+            const el3 = "el3" as any
+            // tslint:disable-next-line no-string-literal
+            focusManager["_focusElementStack"] = [el1, el2, el3]
+
+            focusManager.pushFocus(el2)
+
+            // tslint:disable-next-line no-string-literal
+            assert.deepStrictEqual(focusManager["_focusElementStack"], [el1, el2, el3])
+            assertEnforcesFocus()
+        })
+    })
+})

--- a/ui-tests/KeyboardInput.test.tsx
+++ b/ui-tests/KeyboardInput.test.tsx
@@ -1,0 +1,36 @@
+import { shallow, ShallowWrapper } from "enzyme"
+import * as React from "react"
+import { Event } from "oni-types"
+
+import { KeyboardInputView } from "../browser/src/Input/KeyboardInput"
+jest.mock("../browser/src/Services/FocusManager")
+import { focusManager } from "../browser/src/Services/FocusManager"
+
+describe("<KeyboardInputView />", () => {
+    describe("onActivate", () => {
+        let wrapper: ShallowWrapper
+        let onActivate: Event<void>
+        beforeEach(() => {
+            onActivate = new Event()
+            wrapper = shallow(
+                <KeyboardInputView
+                    top={10}
+                    left={10}
+                    height={100}
+                    foregroundColor={"#fffff"}
+                    fontFamily={"Courier New"}
+                    fontSize={"10"}
+                    fontCharacterWidthInPixels={10}
+                    onActivate={onActivate}
+                />,
+            )
+            wrapper.instance()["_keyboardElement"] = "MockElement" as any
+        })
+
+        it("pushes cursor focus to it's element", () => {
+            expect(focusManager.pushFocus).not.toBeCalled()
+            onActivate.dispatch()
+            expect(focusManager.pushFocus).toHaveBeenCalledWith("MockElement")
+        })
+    })
+})


### PR DESCRIPTION
* If the command menu is open and you alt-tab away from Oni, then
alt-tab back again, the menu remains open but no longer has cursor
focus.
* So ensure focus is not lost on reactivating Oni by not overwriting the
saved focus stack.