### PR TITLE
Move API to oni-api and use it in preparetion for pluginization

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -182,6 +182,8 @@ export const start = async (args: string[]): Promise<void> => {
     pluginManager.discoverPlugins()
     Performance.endMeasure("Oni.Start.Plugins.Discover")
 
+    const oniApi = pluginManager.getApi()
+
     Performance.startMeasure("Oni.Start.Themes")
     const Themes = await themesPromise
     const IconThemes = await iconThemesPromise
@@ -215,7 +217,6 @@ export const start = async (args: string[]): Promise<void> => {
 
     const StatusBar = await statusBarPromise
     StatusBar.activate(configuration)
-    const statusBar = StatusBar.getInstance()
 
     const Overlay = await overlayPromise
     Overlay.activate()
@@ -261,7 +262,7 @@ export const start = async (args: string[]): Promise<void> => {
     const tasks = Tasks.getInstance()
 
     const LanguageManager = await languageManagerPromise
-    LanguageManager.activate(configuration, editorManager, pluginManager, statusBar, workspace)
+    LanguageManager.activate(oniApi)
     const languageManager = LanguageManager.getInstance()
 
     Performance.startMeasure("Oni.Start.Editors")
@@ -315,24 +316,9 @@ export const start = async (args: string[]): Promise<void> => {
     const sidebarManager = Sidebar.getInstance()
 
     const VCSManager = await vcsManagerPromise
-    VCSManager.activate(
-        workspace,
-        editorManager,
-        statusBar,
-        commandManager,
-        menuManager,
-        sidebarManager,
-        notifications,
-        configuration,
-    )
+    VCSManager.activate(oniApi, sidebarManager, notifications)
 
-    Explorer.activate(
-        commandManager,
-        configuration,
-        editorManager,
-        Sidebar.getInstance(),
-        workspace,
-    )
+    Explorer.activate(oniApi, configuration, Sidebar.getInstance())
     Learning.activate(
         commandManager,
         configuration,

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -89,6 +89,10 @@ export class PluginManager implements Oni.IPluginManager {
         this._pluginsActivated = true
         this._pluginsLoaded.dispatch()
 
+        return this.getApi()
+    }
+
+    public getApi(): Oni.Plugin.Api {
         return this._anonymousPlugin.oni
     }
 

--- a/browser/src/Services/Explorer/index.tsx
+++ b/browser/src/Services/Explorer/index.tsx
@@ -4,20 +4,18 @@
  * Entry point for explorer-related features
  */
 
-import { IWorkspace } from "./../../Services/Workspace"
-import { CallbackCommand, CommandManager } from "./../CommandManager"
+import * as Oni from "oni-api"
+
+import { CallbackCommand } from "./../CommandManager"
 import { Configuration } from "./../Configuration"
-import { EditorManager } from "./../EditorManager"
 import { SidebarManager } from "./../Sidebar"
 
 import { ExplorerSplit } from "./ExplorerSplit"
 
 export const activate = (
-    commandManager: CommandManager,
+    oni: Oni.Plugin.Api,
     configuration: Configuration,
-    editorManager: EditorManager,
     sidebarManager: SidebarManager,
-    workspace: IWorkspace,
 ) => {
     configuration.registerSetting("explorer.autoRefresh", {
         description:
@@ -26,27 +24,22 @@ export const activate = (
         defaultValue: false,
     })
 
-    const explorerSplit: ExplorerSplit = new ExplorerSplit(
-        configuration,
-        workspace,
-        commandManager,
-        editorManager,
-    )
+    const explorerSplit: ExplorerSplit = new ExplorerSplit(oni)
     sidebarManager.add("files-o", explorerSplit)
 
     const explorerId = "oni.sidebar.explorer"
 
-    commandManager.registerCommand(
+    oni.commands.registerCommand(
         new CallbackCommand(
             "explorer.toggle",
             "Explorer: Toggle Visibility",
             "Toggles the explorer in the sidebar",
             () => sidebarManager.toggleVisibilityById(explorerId),
-            () => !!workspace.activeWorkspace,
+            () => !!oni.workspace.activeWorkspace,
         ),
     )
 
-    commandManager.registerCommand(
+    oni.commands.registerCommand(
         new CallbackCommand(
             "explorer.locate.buffer",
             "Explorer: Locate Current Buffer",
@@ -55,9 +48,9 @@ export const activate = (
                 if (sidebarManager.activeEntryId !== explorerId || !sidebarManager.isVisible) {
                     sidebarManager.setActiveEntry(explorerId)
                 }
-                explorerSplit.locateFile(editorManager.activeEditor.activeBuffer.filePath)
+                explorerSplit.locateFile(oni.editors.activeEditor.activeBuffer.filePath)
             },
-            () => !!workspace.activeWorkspace,
+            () => !!oni.workspace.activeWorkspace,
         ),
     )
 }

--- a/browser/src/Services/Language/LanguageClientStatusBar.tsx
+++ b/browser/src/Services/Language/LanguageClientStatusBar.tsx
@@ -15,8 +15,8 @@ export class LanguageClientStatusBar {
     private _item: Oni.StatusBarItem
     private _fileType: string
 
-    constructor(private _statusBar: Oni.StatusBar) {
-        this._item = this._statusBar.createItem(0, "oni.status.fileType")
+    constructor(private _oni: Oni.Plugin.Api) {
+        this._item = this._oni.statusBar.createItem(0, "oni.status.fileType")
     }
 
     public show(fileType: string): void {

--- a/browser/src/Services/Language/Workspace.ts
+++ b/browser/src/Services/Language/Workspace.ts
@@ -4,16 +4,13 @@
  * Handles workspace/ messages
  */
 
+import * as Oni from "oni-api"
 import * as types from "vscode-languageserver-types"
-
-import { IWorkspace } from "./../Workspace"
 
 import { LanguageManager } from "./LanguageManager"
 
-export const listenForWorkspaceEdits = (
-    languageManager: LanguageManager,
-    workspace: IWorkspace,
-) => {
+export const listenForWorkspaceEdits = (languageManager: LanguageManager, oni: Oni.Plugin.Api) => {
+    const workspace = oni.workspace
     languageManager.handleLanguageServerRequest("workspace/applyEdit", async (args: any) => {
         const payload: types.WorkspaceEdit = args.payload.edit.changes
         await workspace.applyEdits(payload)

--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -32,12 +32,7 @@ import { WorkspaceConfiguration } from "./WorkspaceConfiguration"
 
 const fsStat = promisify(stat)
 
-// Candidate interface to promote to Oni API
-export interface IWorkspace extends Oni.Workspace.Api {
-    applyEdits(edits: types.WorkspaceEdit): Promise<void>
-}
-
-export class Workspace implements IWorkspace {
+export class Workspace implements Oni.Workspace.Api {
     private _onDirectoryChangedEvent = new Event<string>()
     private _onFocusGainedEvent = new Event<Oni.Buffer>()
     private _onFocusLostEvent = new Event<Oni.Buffer>()

--- a/browser/src/Services/Workspace/WorkspaceConfiguration.ts
+++ b/browser/src/Services/Workspace/WorkspaceConfiguration.ts
@@ -5,12 +5,12 @@
  */
 
 import * as fs from "fs"
+import * as Oni from "oni-api"
 import * as path from "path"
 
 import * as Log from "oni-core-logging"
 
 import { Configuration } from "./../Configuration"
-import { IWorkspace } from "./Workspace"
 
 export const getWorkspaceConfigurationPath = (workspacePath: string): string => {
     return path.join(workspacePath, ".oni", "config.js")
@@ -25,7 +25,7 @@ export class WorkspaceConfiguration {
 
     constructor(
         private _configuration: Configuration,
-        private _workspace: IWorkspace,
+        private _workspace: Oni.Workspace.Api,
         private _fs: typeof fs = fs,
     ) {
         this._checkWorkspaceConfiguration()

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -276,11 +276,7 @@ export class MockOni implements Oni.Plugin.Api {
     private _statusBar = new MockStatusBar()
     private _workspace = new MockWorkspace()
 
-    constructor(private _configuration: Oni.Configuration) {
-        if (!this._configuration) {
-            this._configuration = new MockConfiguration()
-        }
-
+    constructor(private _configuration: Oni.Configuration = new MockConfiguration()) {
         this._editorManager.setActiveEditor(new MockEditor())
     }
 

--- a/browser/test/Mocks/index.ts
+++ b/browser/test/Mocks/index.ts
@@ -8,7 +8,7 @@
 export * from "./MockBuffer"
 export * from "./neovim/MockNeovimInstance"
 export * from "./MockPersistentStore"
-export * from "./MockPluginManager"
+import { MockPluginManager } from "./MockPluginManager"
 export * from "./MockThemeLoader"
 
 import * as Oni from "oni-api"
@@ -18,11 +18,11 @@ import * as types from "vscode-languageserver-types"
 
 import { Editor } from "./../../src/Editor/Editor"
 
+import { EditorManager } from "./../../src/Services/EditorManager"
 import * as Language from "./../../src/Services/Language"
 import { createCompletablePromise, ICompletablePromise } from "./../../src/Utility"
 
 import { TokenColor } from "./../../src/Services/TokenColors"
-import { IWorkspace } from "./../../src/Services/Workspace"
 
 export class MockWindowSplit {
     public get id(): string {
@@ -50,7 +50,7 @@ export class MockTokenColors {
 
 import { MockBuffer } from "./MockBuffer"
 
-export class MockConfiguration {
+export class MockConfiguration implements Oni.Configuration {
     private _currentConfigurationFiles: string[] = []
     private _onConfigurationChanged = new Event<any>()
 
@@ -72,6 +72,10 @@ export class MockConfiguration {
         this._configurationValues[key] = value
     }
 
+    public setValues(): void {
+        throw Error("Not yet implemented")
+    }
+
     public addConfigurationFile(filePath: string): void {
         this._currentConfigurationFiles = [...this._currentConfigurationFiles, filePath]
     }
@@ -87,7 +91,7 @@ export class MockConfiguration {
     }
 }
 
-export class MockWorkspace implements IWorkspace {
+export class MockWorkspace implements Oni.Workspace.Api {
     private _activeWorkspace: string = null
     private _onDirectoryChangedEvent = new Event<string>()
     private _onFocusGainedEvent = new Event<void>()
@@ -263,5 +267,120 @@ export class MockHoverRequestor extends MockRequestor<Language.IHoverResult>
         column: number,
     ): Promise<Language.IHoverResult> {
         return this.get(language, filePath, line, column)
+    }
+}
+
+export class MockOni implements Oni.Plugin.Api {
+    private _editorManager = new EditorManager()
+    private _pluginManager = new MockPluginManager()
+    private _statusBar = new MockStatusBar()
+    private _workspace = new MockWorkspace()
+
+    constructor(private _configuration: Oni.Configuration) {
+        if (!this._configuration) {
+            this._configuration = new MockConfiguration()
+        }
+
+        this._editorManager.setActiveEditor(new MockEditor())
+    }
+
+    get automation(): Oni.Automation.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get colors(): Oni.IColors {
+        throw Error("Not yet implemented")
+    }
+
+    get commands(): Oni.Commands.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get configuration(): Oni.Configuration {
+        return this._configuration
+    }
+
+    get contextMenu(): any /* TODO */ {
+        throw Error("Not yet implemented")
+    }
+
+    get diagnostics(): Oni.Plugin.Diagnostics.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get editors(): Oni.EditorManager {
+        return this._editorManager
+    }
+
+    get filter(): Oni.Menu.IMenuFilters {
+        throw Error("Not yet implemented")
+    }
+
+    get input(): Oni.Input.InputManager {
+        throw Error("Not yet implemented")
+    }
+
+    get language(): any /* TODO */ {
+        throw Error("Not yet implemented")
+    }
+
+    get log(): any /* TODO */ {
+        throw Error("Not yet implemented")
+    }
+
+    get notifications(): Oni.Notifications.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get overlays(): Oni.Overlays.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get plugins(): Oni.IPluginManager {
+        return this._pluginManager
+    }
+
+    get search(): Oni.Search.ISearch {
+        throw Error("Not yet implemented")
+    }
+
+    get sidebar(): Oni.Sidebar.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get ui(): Oni.Ui.IUi {
+        throw Error("Not yet implemented")
+    }
+
+    get menu(): Oni.Menu.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get process(): Oni.Process {
+        throw Error("Not yet implemented")
+    }
+
+    get recorder(): Oni.Recorder {
+        throw Error("Not yet implemented")
+    }
+
+    get snippets(): Oni.Snippets.SnippetManager {
+        throw Error("Not yet implemented")
+    }
+
+    get statusBar(): Oni.StatusBar {
+        return this._statusBar
+    }
+
+    get windows(): Oni.IWindowManager {
+        throw Error("Not yet implemented")
+    }
+
+    get workspace(): Oni.Workspace.Api {
+        return this._workspace
+    }
+
+    public populateQuickFix(entries: Oni.QuickFixEntry[]): void {
+        throw Error("Not yet implemented")
     }
 }

--- a/browser/test/Services/Language/LanguageManagerTests.ts
+++ b/browser/test/Services/Language/LanguageManagerTests.ts
@@ -8,7 +8,6 @@ import * as sinon from "sinon"
 
 import { Event } from "oni-types"
 
-import { EditorManager } from "./../../../src/Services/EditorManager"
 import * as Language from "./../../../src/Services/Language"
 
 import * as Mocks from "./../../Mocks"
@@ -44,16 +43,13 @@ export class MockLanguageClient implements Language.ILanguageClient {
 
 describe("LanguageManager", () => {
     // Mocks
-    let mockConfiguration: Mocks.MockConfiguration
-    let mockEditor: Mocks.MockEditor
-    let editorManager: EditorManager
-    let mockWorkspace: Mocks.MockWorkspace
+    let mockOni: Mocks.MockOni
 
     // Class under test
     let languageManager: Language.LanguageManager
 
     beforeEach(() => {
-        mockConfiguration = new Mocks.MockConfiguration({
+        const mockConfiguration = new Mocks.MockConfiguration({
             "editor.quickInfo.delay": 500,
             "editor.quickInfo.enabled": true,
             "status.priority": {
@@ -64,21 +60,9 @@ describe("LanguageManager", () => {
                 "oni.status.git": 2,
             },
         })
+        mockOni = new Mocks.MockOni(mockConfiguration)
 
-        editorManager = new EditorManager()
-        mockEditor = new Mocks.MockEditor()
-        editorManager.setActiveEditor(mockEditor)
-        mockWorkspace = new Mocks.MockWorkspace()
-
-        const mockStatusBar = new Mocks.MockStatusBar()
-
-        languageManager = new Language.LanguageManager(
-            mockConfiguration as any,
-            editorManager,
-            new Mocks.MockPluginManager() as any,
-            mockStatusBar,
-            mockWorkspace,
-        )
+        languageManager = new Language.LanguageManager(mockOni)
     })
 
     it("sends didOpen request if language server is registered after enter event", async () => {
@@ -86,6 +70,7 @@ describe("LanguageManager", () => {
         // This can happen if a plugin registers a language server, because we spin
         // up the editors before initializing plugins.
         const mockBuffer = new Mocks.MockBuffer("javascript", "test.js", ["a", "b", "c"])
+        const mockEditor = mockOni.editors.activeEditor as Mocks.MockEditor
         mockEditor.simulateBufferEnter(mockBuffer)
 
         const mockLanguageClient = new MockLanguageClient()

--- a/package.json
+++ b/package.json
@@ -706,7 +706,7 @@
         "minimist": "1.2.0",
         "msgpack-lite": "0.1.26",
         "ocaml-language-server": "^1.0.27",
-        "oni-api": "0.0.48",
+        "oni-api": "0.0.49",
         "oni-neovim-binaries": "0.1.3",
         "oni-ripgrep": "0.0.4",
         "oni-types": "^0.0.8",

--- a/ui-tests/ExplorerSplit.test.tsx
+++ b/ui-tests/ExplorerSplit.test.tsx
@@ -6,11 +6,7 @@ jest.mock("../browser/src/Services/Explorer/ExplorerStore")
 import * as React from "react"
 import { shallow } from "enzyme"
 
-import { Configuration } from "../browser/src/Services/Configuration"
-import MockCommands from "./mocks/CommandManager"
-import { configuration } from "./mocks/Configuration"
-import MockEditorManager from "./mocks/EditorManager"
-import MockWorkspace from "./mocks/Workspace"
+import MockOni from "./mocks/Oni"
 
 import { createStore } from "../browser/src/Services/Explorer/ExplorerStore"
 import { ExplorerSplit } from "../browser/src/Services/Explorer/ExplorerSplit"
@@ -28,12 +24,7 @@ describe("ExplorerSplit", () => {
         } as Store<any>
         ;(createStore as jest.Mock).mockReturnValue(store)
 
-        explorerSplit = new ExplorerSplit(
-            configuration as Configuration,
-            new MockWorkspace(),
-            new MockCommands(),
-            new MockEditorManager(),
-        )
+        explorerSplit = new ExplorerSplit(new MockOni())
     })
 
     describe("locateFile", () => {

--- a/ui-tests/VersionControl/VersionControlManager.test.tsx
+++ b/ui-tests/VersionControl/VersionControlManager.test.tsx
@@ -8,14 +8,10 @@ import {
     VersionControlProvider,
 } from "./../../browser/src/Services/VersionControl"
 
-import MockCommands from "./../mocks/CommandManager"
-import { configuration as MockConfiguration } from "./../mocks/Configuration"
-import MockEditorManager from "./../mocks/EditorManager"
-import MockMenu from "./../mocks/MenuManager"
+import MockOni from "../mocks/Oni"
+import { mockStatusBarHide, mockStatusBarSetContents } from "./../mocks/Statusbar"
 import MockNotifications from "./../mocks/Notifications"
 import MockSidebar from "./../mocks/Sidebar"
-import MockStatusbar, { mockStatusBarHide, mockStatusBarSetContents } from "./../mocks/Statusbar"
-import MockWorkspace from "./../mocks/Workspace"
 
 jest.unmock("lodash")
 
@@ -46,14 +42,9 @@ describe("Version Control Manager tests", () => {
     let vcsManager: VersionControlManager
     beforeEach(() => {
         vcsManager = new VersionControlManager(
-            new MockWorkspace(),
-            new MockEditorManager(),
-            new MockStatusbar(),
-            new MockMenu(),
-            new MockCommands(),
+            new MockOni(),
             new MockSidebar(),
             new MockNotifications(),
-            MockConfiguration,
         )
         vcsManager.registerProvider(provider)
     })

--- a/ui-tests/VersionControl/VersionControlManager.test.tsx
+++ b/ui-tests/VersionControl/VersionControlManager.test.tsx
@@ -71,9 +71,9 @@ describe("Version Control Manager tests", () => {
         expect(vcsManager.activeProvider).toBeFalsy()
     })
 
-    it("Should correctly hide the status bar item if the dir cannot handle the workspace", () => {
+    it("Should correctly hide the status bar item if the dir cannot handle the workspace", async () => {
         provider.canHandleWorkspace = async () => makePromise(false)
-        vcsManager.registerProvider(provider)
+        await vcsManager.registerProvider(provider)
         expect(mockStatusBarHide.mock.calls.length).toBe(1)
     })
 

--- a/ui-tests/VersionControl/VersionControlPane.test.tsx
+++ b/ui-tests/VersionControl/VersionControlPane.test.tsx
@@ -7,10 +7,9 @@ import store, {
     DefaultState,
     VersionControlState,
 } from "./../../browser/src/Services/VersionControl/VersionControlStore"
-import MockCommands from "./../mocks/CommandManager"
-import MockEditorManager from "./../mocks/EditorManager"
+
+import MockOni from "./../mocks/Oni"
 import MockSidebar from "./../mocks/Sidebar"
-import MockWorkspace from "./../mocks/Workspace"
 
 jest.mock("lodash/capitalize", (str: string) => str)
 jest.mock(
@@ -45,17 +44,12 @@ const provider: VersionControlProvider = {
 }
 
 describe("Version Control pane tests", () => {
-    const mockManager = new MockEditorManager()
-    const mockWorkspace = new MockWorkspace()
-    const mockCommands = new MockCommands()
     const mockSidebar = new MockSidebar()
     const vcsStore = store
     const vcsPane = new VersionControlPane(
-        mockManager,
-        mockWorkspace,
+        new MockOni(),
         provider,
         args => null,
-        mockCommands,
         mockSidebar,
         store,
     )

--- a/ui-tests/mocks/Oni.ts
+++ b/ui-tests/mocks/Oni.ts
@@ -1,0 +1,120 @@
+import * as Oni from "oni-api"
+
+import MockCommands from "./CommandManager"
+import { configuration } from "./Configuration"
+import MockEditorManager from "./EditorManager"
+import MockMenu from "./MenuManager"
+import MockSidebar from "./../mocks/Sidebar"
+import MockStatusbar from "./Statusbar"
+import MockWorkspace from "./Workspace"
+
+class MockOni implements Oni.Plugin.Api {
+    private _commands = new MockCommands()
+    private _configuration = configuration
+    private _editorManager = new MockEditorManager()
+    private _sidebar = new MockSidebar()
+    private _statusBar = new MockStatusbar()
+    private _workspace = new MockWorkspace()
+
+    get automation(): Oni.Automation.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get colors(): Oni.IColors {
+        throw Error("Not yet implemented")
+    }
+
+    get commands(): Oni.Commands.Api {
+        return this._commands
+    }
+
+    get configuration(): Oni.Configuration {
+        return this._configuration
+    }
+
+    get contextMenu(): any /* TODO */ {
+        throw Error("Not yet implemented")
+    }
+
+    get diagnostics(): Oni.Plugin.Diagnostics.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get editors(): Oni.EditorManager {
+        return this._editorManager
+    }
+
+    get filter(): Oni.Menu.IMenuFilters {
+        throw Error("Not yet implemented")
+    }
+
+    get input(): Oni.Input.InputManager {
+        throw Error("Not yet implemented")
+    }
+
+    get language(): any /* TODO */ {
+        throw Error("Not yet implemented")
+    }
+
+    get log(): any /* TODO */ {
+        throw Error("Not yet implemented")
+    }
+
+    get notifications(): Oni.Notifications.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get overlays(): Oni.Overlays.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get plugins(): Oni.IPluginManager {
+        throw Error("Not yet implemented")
+    }
+
+    get search(): Oni.Search.ISearch {
+        throw Error("Not yet implemented")
+    }
+
+    get sidebar(): Oni.Sidebar.Api {
+        return this._sidebar
+    }
+
+    get ui(): Oni.Ui.IUi {
+        throw Error("Not yet implemented")
+    }
+
+    get menu(): Oni.Menu.Api {
+        throw Error("Not yet implemented")
+    }
+
+    get process(): Oni.Process {
+        throw Error("Not yet implemented")
+    }
+
+    get recorder(): Oni.Recorder {
+        throw Error("Not yet implemented")
+    }
+
+    get snippets(): Oni.Snippets.SnippetManager {
+        throw Error("Not yet implemented")
+    }
+
+    get statusBar(): Oni.StatusBar {
+        return this._statusBar
+    }
+
+    get windows(): Oni.IWindowManager {
+        throw Error("Not yet implemented")
+    }
+
+    get workspace(): Oni.Workspace.Api {
+        return this._workspace
+    }
+
+    public populateQuickFix(entries: Oni.QuickFixEntry[]): void {
+        throw Error("Not yet implemented")
+    }
+}
+
+export default MockOni

--- a/ui-tests/mocks/Workspace.ts
+++ b/ui-tests/mocks/Workspace.ts
@@ -1,6 +1,6 @@
-import { IWorkspace, Workspace } from "./../../browser/src/Services/Workspace"
+import { Workspace } from "./../../browser/src/Services/Workspace"
 
-const MockWorkspace = jest.fn<IWorkspace>().mockImplementation(() => ({
+const MockWorkspace = jest.fn<Workspace>().mockImplementation(() => ({
     activeDirectory: "test/dir",
     onDirectoryChanged: {
         subscribe: jest.fn(),


### PR DESCRIPTION
A follow-up for: https://github.com/onivim/oni/pull/2443
Paired with: https://github.com/onivim/oni-api/pull/47

The intended change: Move part of the API into the API package (`IWorkspace` assimilated into `"oni-api"`-'s `Workspace`)

Additional change: Some almost-plugin-compatible modules got a further push that way by using `"oni-api"` instead of the core's singletons.

Also, an oni-api-impl mock is forming with most of it currently unimplemented.