### PR TITLE
[WIP] Fix east asian width issue

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -207,7 +207,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
 
         this._neovimInstance = new NeovimInstance(100, 100, this._configuration)
         this._bufferManager = new BufferManager(this._neovimInstance, this._actions, this._store)
-        this._screen = new NeovimScreen()
+        this._screen = new NeovimScreen(this._configuration)
 
         this._screenWithPredictions = new ScreenWithPredictions(this._screen, this._configuration)
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -162,6 +162,8 @@ const BaseConfiguration: IConfigurationValues = {
 
     "editor.imageLayerExtensions": [".gif", ".jpg", ".jpeg", ".bmp", ".png"],
 
+    "editor.useEastAsianWidth": false,
+
     "explorer.persistDeletedFiles": true,
     "explorer.maxUndoFileSizeInBytes": 500_000,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -233,6 +233,10 @@ export interface IConfigurationValues {
     "editor.cursorColumn": boolean
     "editor.cursorColumnOpacity": number
 
+    // Use eaw (east asian width) to get the width of the character
+    // instead of wcwidth
+    "editor.useEastAsianWidth": boolean
+
     "keyDisplayer.showInInsertMode": boolean
 
     "learning.enabled": boolean

--- a/browser/src/neovim/Screen.ts
+++ b/browser/src/neovim/Screen.ts
@@ -1,9 +1,11 @@
 import { Grid } from "./../Grid"
+import { Configuration } from "./../Services/Configuration"
 import * as Actions from "./actions"
 
 export type Mode = "insert" | "normal" | "visual" | "cmdline_normal"
 
 const wcwidth = require("wcwidth") // tslint:disable-line no-var-requires
+const eaw = require("eaw") // tslint:disable-line no-var-requires
 
 export interface IHighlight {
     bold?: boolean
@@ -92,6 +94,11 @@ const DefaultCell: ICell = {
 }
 
 export class NeovimScreen implements IScreen {
+    /**
+     * A function to get the width of the character
+     */
+    public getCharacterWidth: any
+
     private _backgroundColor: string = "#000000"
     private _currentHighlight: IHighlight = {}
     private _cursorColumn: number = 0
@@ -169,6 +176,12 @@ export class NeovimScreen implements IScreen {
         return this._currentHighlight.backgroundColor || this._backgroundColor
     }
 
+    constructor(private _configuration: Configuration) {
+        this.getCharacterWidth = this._configuration.getValue("editor.useEastAsianWidth")
+            ? eaw.getWidth
+            : wcwidth
+    }
+
     public getCell = (x: number, y: number) => {
         const cell = this._grid.getCell(x, y)
 
@@ -206,7 +219,7 @@ export class NeovimScreen implements IScreen {
                 for (let i = 0; i < characters.length; i++) {
                     const character = characters[i]
 
-                    const characterWidth = Math.max(wcwidth(character), 1)
+                    const characterWidth = Math.max(this.getCharacterWidth(character), 1)
 
                     this._setCell(col + i, row, {
                         foregroundColor,

--- a/browser/test/neovim/ScreenTests.ts
+++ b/browser/test/neovim/ScreenTests.ts
@@ -1,0 +1,32 @@
+import * as assert from "assert"
+import * as sinon from "sinon"
+
+import { NeovimScreen } from "../../src/neovim/Screen"
+
+describe("Screen", () => {
+    describe("getCharacterWidth", () => {
+        it("should return 1 for ① when editor.useEastAsianWidth is false", () => {
+            // Mock configulation
+            const configulation = {
+                getValue: sinon.stub().returns(false),
+            }
+            // Instantiate
+            const screen = new NeovimScreen(configulation as any)
+            // Test getCharacterWidth()
+            const characterWidth = screen.getCharacterWidth("①")
+            assert.strictEqual(characterWidth, 1)
+        })
+
+        it("should return 2 for ① when editor.useEastAsianWidth is true", () => {
+            // Mock configulation
+            const configulation = {
+                getValue: sinon.stub().returns(true),
+            }
+            // Instantiate
+            const screen = new NeovimScreen(configulation as any)
+            // Test getCharacterWidth()
+            const characterWidth = screen.getCharacterWidth("①")
+            assert.strictEqual(characterWidth, 2)
+        })
+    })
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
     "homepage": "https://www.onivim.io",
     "version": "0.3.7",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
-    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
+    "keywords": [
+        "vim",
+        "neovim",
+        "text",
+        "editor",
+        "ide",
+        "vim"
+    ],
     "main": "./lib/main/src/main.js",
     "bin": {
         "oni": "./lib/cli/src/cli.js",
@@ -43,23 +50,39 @@
         "mac": {
             "artifactName": "${productName}-${version}-osx.${ext}",
             "category": "public.app-category.developer-tools",
-            "target": ["dmg"],
-            "files": ["bin/osx/**/*"]
+            "target": [
+                "dmg"
+            ],
+            "files": [
+                "bin/osx/**/*"
+            ]
         },
         "linux": {
             "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
             "maintainer": "bryphe@outlook.com",
-            "target": ["tar.gz", "deb", "rpm"]
+            "target": [
+                "tar.gz",
+                "deb",
+                "rpm"
+            ]
         },
         "win": {
-            "target": ["zip", "dir"],
-            "files": ["bin/x86/**/*"]
+            "target": [
+                "zip",
+                "dir"
+            ],
+            "files": [
+                "bin/x86/**/*"
+            ]
         },
         "fileAssociations": [
             {
                 "name": "ADA source",
                 "role": "Editor",
-                "ext": ["adb", "ads"]
+                "ext": [
+                    "adb",
+                    "ads"
+                ]
             },
             {
                 "name": "Compiled AppleScript",
@@ -79,12 +102,20 @@
             {
                 "name": "ASP document",
                 "role": "Editor",
-                "ext": ["asp", "asa"]
+                "ext": [
+                    "asp",
+                    "asa"
+                ]
             },
             {
                 "name": "ASP.NET document",
                 "role": "Editor",
-                "ext": ["aspx", "ascx", "asmx", "ashx"]
+                "ext": [
+                    "aspx",
+                    "ascx",
+                    "asmx",
+                    "ashx"
+                ]
             },
             {
                 "name": "BibTeX bibliography",
@@ -99,7 +130,13 @@
             {
                 "name": "C++ source",
                 "role": "Editor",
-                "ext": ["cc", "cp", "cpp", "cxx", "c++"]
+                "ext": [
+                    "cc",
+                    "cp",
+                    "cpp",
+                    "cxx",
+                    "c++"
+                ]
             },
             {
                 "name": "C# source",
@@ -124,7 +161,10 @@
             {
                 "name": "Clojure source",
                 "role": "Editor",
-                "ext": ["clj", "cljs"]
+                "ext": [
+                    "clj",
+                    "cljs"
+                ]
             },
             {
                 "name": "Comma separated values",
@@ -139,12 +179,20 @@
             {
                 "name": "CGI script",
                 "role": "Editor",
-                "ext": ["cgi", "fcgi"]
+                "ext": [
+                    "cgi",
+                    "fcgi"
+                ]
             },
             {
                 "name": "Configuration file",
                 "role": "Editor",
-                "ext": ["cfg", "conf", "config", "htaccess"]
+                "ext": [
+                    "cfg",
+                    "conf",
+                    "config",
+                    "htaccess"
+                ]
             },
             {
                 "name": "Cascading style sheet",
@@ -169,7 +217,10 @@
             {
                 "name": "Erlang source",
                 "role": "Editor",
-                "ext": ["erl", "hrl"]
+                "ext": [
+                    "erl",
+                    "hrl"
+                ]
             },
             {
                 "name": "F-Script source",
@@ -179,17 +230,32 @@
             {
                 "name": "Fortran source",
                 "role": "Editor",
-                "ext": ["f", "for", "fpp", "f77", "f90", "f95"]
+                "ext": [
+                    "f",
+                    "for",
+                    "fpp",
+                    "f77",
+                    "f90",
+                    "f95"
+                ]
             },
             {
                 "name": "Header",
                 "role": "Editor",
-                "ext": ["h", "pch"]
+                "ext": [
+                    "h",
+                    "pch"
+                ]
             },
             {
                 "name": "C++ header",
                 "role": "Editor",
-                "ext": ["hh", "hpp", "hxx", "h++"]
+                "ext": [
+                    "hh",
+                    "hpp",
+                    "hxx",
+                    "h++"
+                ]
             },
             {
                 "name": "Go source",
@@ -199,17 +265,28 @@
             {
                 "name": "GTD document",
                 "role": "Editor",
-                "ext": ["gtd", "gtdlog"]
+                "ext": [
+                    "gtd",
+                    "gtdlog"
+                ]
             },
             {
                 "name": "Haskell source",
                 "role": "Editor",
-                "ext": ["hs", "lhs"]
+                "ext": [
+                    "hs",
+                    "lhs"
+                ]
             },
             {
                 "name": "HTML document",
                 "role": "Editor",
-                "ext": ["htm", "html", "phtml", "shtml"]
+                "ext": [
+                    "htm",
+                    "html",
+                    "phtml",
+                    "shtml"
+                ]
             },
             {
                 "name": "Include file",
@@ -249,7 +326,10 @@
             {
                 "name": "JavaScript source",
                 "role": "Editor",
-                "ext": ["js", "htc"]
+                "ext": [
+                    "js",
+                    "htc"
+                ]
             },
             {
                 "name": "Java Server Page",
@@ -274,7 +354,14 @@
             {
                 "name": "Lisp source",
                 "role": "Editor",
-                "ext": ["lisp", "cl", "l", "lsp", "mud", "el"]
+                "ext": [
+                    "lisp",
+                    "cl",
+                    "l",
+                    "lsp",
+                    "mud",
+                    "el"
+                ]
             },
             {
                 "name": "Log file",
@@ -294,7 +381,12 @@
             {
                 "name": "Markdown document",
                 "role": "Editor",
-                "ext": ["markdown", "mdown", "markdn", "md"]
+                "ext": [
+                    "markdown",
+                    "mdown",
+                    "markdn",
+                    "md"
+                ]
             },
             {
                 "name": "Makefile source",
@@ -304,17 +396,29 @@
             {
                 "name": "Mediawiki document",
                 "role": "Editor",
-                "ext": ["wiki", "wikipedia", "mediawiki"]
+                "ext": [
+                    "wiki",
+                    "wikipedia",
+                    "mediawiki"
+                ]
             },
             {
                 "name": "MIPS assembler source",
                 "role": "Editor",
-                "ext": ["s", "mips", "spim", "asm"]
+                "ext": [
+                    "s",
+                    "mips",
+                    "spim",
+                    "asm"
+                ]
             },
             {
                 "name": "Modula-3 source",
                 "role": "Editor",
-                "ext": ["m3", "cm3"]
+                "ext": [
+                    "m3",
+                    "cm3"
+                ]
             },
             {
                 "name": "MoinMoin document",
@@ -334,17 +438,28 @@
             {
                 "name": "OCaml source",
                 "role": "Editor",
-                "ext": ["ml", "mli", "mll", "mly"]
+                "ext": [
+                    "ml",
+                    "mli",
+                    "mll",
+                    "mly"
+                ]
             },
             {
                 "name": "Mustache document",
                 "role": "Editor",
-                "ext": ["mustache", "hbs"]
+                "ext": [
+                    "mustache",
+                    "hbs"
+                ]
             },
             {
                 "name": "Pascal source",
                 "role": "Editor",
-                "ext": ["pas", "p"]
+                "ext": [
+                    "pas",
+                    "p"
+                ]
             },
             {
                 "name": "Patch file",
@@ -354,7 +469,11 @@
             {
                 "name": "Perl source",
                 "role": "Editor",
-                "ext": ["pl", "pod", "perl"]
+                "ext": [
+                    "pl",
+                    "pod",
+                    "perl"
+                ]
             },
             {
                 "name": "Perl module",
@@ -364,47 +483,80 @@
             {
                 "name": "PHP source",
                 "role": "Editor",
-                "ext": ["php", "php3", "php4", "php5"]
+                "ext": [
+                    "php",
+                    "php3",
+                    "php4",
+                    "php5"
+                ]
             },
             {
                 "name": "PostScript source",
                 "role": "Editor",
-                "ext": ["ps", "eps"]
+                "ext": [
+                    "ps",
+                    "eps"
+                ]
             },
             {
                 "name": "Property list",
                 "role": "Editor",
-                "ext": ["dict", "plist", "scriptSuite", "scriptTerminology"]
+                "ext": [
+                    "dict",
+                    "plist",
+                    "scriptSuite",
+                    "scriptTerminology"
+                ]
             },
             {
                 "name": "Python source",
                 "role": "Editor",
-                "ext": ["py", "rpy", "cpy", "python"]
+                "ext": [
+                    "py",
+                    "rpy",
+                    "cpy",
+                    "python"
+                ]
             },
             {
                 "name": "R source",
                 "role": "Editor",
-                "ext": ["r", "s"]
+                "ext": [
+                    "r",
+                    "s"
+                ]
             },
             {
                 "name": "Ragel source",
                 "role": "Editor",
-                "ext": ["rl", "ragel"]
+                "ext": [
+                    "rl",
+                    "ragel"
+                ]
             },
             {
                 "name": "Remind document",
                 "role": "Editor",
-                "ext": ["rem", "remind"]
+                "ext": [
+                    "rem",
+                    "remind"
+                ]
             },
             {
                 "name": "reStructuredText document",
                 "role": "Editor",
-                "ext": ["rst", "rest"]
+                "ext": [
+                    "rst",
+                    "rest"
+                ]
             },
             {
                 "name": "HTML with embedded Ruby",
                 "role": "Editor",
-                "ext": ["rhtml", "erb"]
+                "ext": [
+                    "rhtml",
+                    "erb"
+                ]
             },
             {
                 "name": "SQL with embedded Ruby",
@@ -414,17 +566,28 @@
             {
                 "name": "Ruby source",
                 "role": "Editor",
-                "ext": ["rb", "rbx", "rjs", "rxml"]
+                "ext": [
+                    "rb",
+                    "rbx",
+                    "rjs",
+                    "rxml"
+                ]
             },
             {
                 "name": "Sass source",
                 "role": "Editor",
-                "ext": ["sass", "scss"]
+                "ext": [
+                    "sass",
+                    "scss"
+                ]
             },
             {
                 "name": "Scheme source",
                 "role": "Editor",
-                "ext": ["scm", "sch"]
+                "ext": [
+                    "scm",
+                    "sch"
+                ]
             },
             {
                 "name": "Setext document",
@@ -472,7 +635,10 @@
             {
                 "name": "SWIG source",
                 "role": "Editor",
-                "ext": ["i", "swg"]
+                "ext": [
+                    "i",
+                    "swg"
+                ]
             },
             {
                 "name": "Tcl source",
@@ -482,12 +648,20 @@
             {
                 "name": "TeX document",
                 "role": "Editor",
-                "ext": ["tex", "sty", "cls"]
+                "ext": [
+                    "tex",
+                    "sty",
+                    "cls"
+                ]
             },
             {
                 "name": "Plain text document",
                 "role": "Editor",
-                "ext": ["text", "txt", "utf8"]
+                "ext": [
+                    "text",
+                    "txt",
+                    "utf8"
+                ]
             },
             {
                 "name": "Textile document",
@@ -507,17 +681,32 @@
             {
                 "name": "XML document",
                 "role": "Editor",
-                "ext": ["xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml"]
+                "ext": [
+                    "xml",
+                    "xsd",
+                    "xib",
+                    "rss",
+                    "tld",
+                    "pt",
+                    "cpt",
+                    "dtml"
+                ]
             },
             {
                 "name": "XSL stylesheet",
                 "role": "Editor",
-                "ext": ["xsl", "xslt"]
+                "ext": [
+                    "xsl",
+                    "xslt"
+                ]
             },
             {
                 "name": "Electronic business card",
                 "role": "Editor",
-                "ext": ["vcf", "vcard"]
+                "ext": [
+                    "vcf",
+                    "vcard"
+                ]
             },
             {
                 "name": "Visual Basic source",
@@ -527,7 +716,10 @@
             {
                 "name": "YAML document",
                 "role": "Editor",
-                "ext": ["yaml", "yml"]
+                "ext": [
+                    "yaml",
+                    "yml"
+                ]
             },
             {
                 "name": "Text document",
@@ -589,10 +781,8 @@
     "scripts": {
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
-        "build":
-            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
-        "build-debug":
-            "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
+        "build": "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
+        "build-debug": "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
         "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
         "build:main": "cd main && tsc -p tsconfig.json",
@@ -600,92 +790,65 @@
         "build:cli": "cd cli && tsc -p tsconfig.json",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
         "build:plugin:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn run build",
-        "build:plugin:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn run build",
+        "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:plugin:oni-plugin-quickopen": "cd extensions/oni-plugin-quickopen && yarn run build",
         "build:test": "yarn run build:test:unit && yarn run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "run-s build:test:unit:*",
-        "build:test:unit:browser":
-            "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit:browser": "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
         "build:test:unit:main": "rimraf lib_test/main && cd main && tsc -p tsconfig.test.json",
         "build:webview_preload": "cd webview_preload && tsc -p tsconfig.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
-        "debug:test:unit:browser":
-            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "demo:screenshot":
-            "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
-        "demo:video":
-            "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
-        "dist:win:x86":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-        "dist:win:x64":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
-        "pack:win":
-            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo:screenshot": "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
+        "demo:video": "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
+        "dist:win:x86": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "dist:win:x64": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
+        "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "yarn run test:unit && yarn run test:integration",
-        "test:setup":
-            "yarn run build:test:integration && mocha -t 120000 --recursive lib_test/test/setup",
-        "test:integration":
-            "yarn run build:test:integration && mocha -t 120000 lib_test/test/CiTests.js --bail",
+        "test:setup": "yarn run build:test:integration && mocha -t 120000 --recursive lib_test/test/setup",
+        "test:integration": "yarn run build:test:integration && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:unit:react": "jest --config ./jest.config.js ./ui-tests",
         "test:unit:react:watch": "jest --config ./jest.config.js ./ui-tests --watch",
         "test:unit:react:coverage": "jest --config ./jest.config.js ./ui-tests --coverage",
-        "test:unit:browser":
-            "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "test:unit":
-            "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:unit:react",
-        "test:unit:main":
-            "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
+        "test:unit:browser": "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "test:unit": "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:unit:react",
+        "test:unit:main": "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
         "upload:dist": "node build/script/UploadDistributionBuildsToAzure",
         "fix-lint": "run-p fix-lint:*",
-        "fix-lint:browser":
-            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "fix-lint:cli": "tslint --fix --project cli/tsconfig.json --config tslint.json",
         "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
         "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
         "lint": "yarn run lint:browser && yarn run lint:main && yarn run lint:test",
-        "lint:browser":
-            "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "lint:cli": "tslint --project cli/tsconfig.json --config tslint.json",
         "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-        "lint:test":
-            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "ccov:instrument":
-            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-        "ccov:test:browser":
-            "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
-        "ccov:remap:browser:html":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
-        "ccov:remap:browser:lcov":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
+        "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser": "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
+        "ccov:remap:browser:html": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
+        "ccov:remap:browser:lcov": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
         "ccov:clean": "rimraf coverage",
         "ccov:upload:jest": "cd ./coverage/jest && codecov",
         "ccov:upload": "codecov",
         "launch": "electron lib/main/src/main.js",
-        "start":
-            "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
-        "start-hot":
-            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start": "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
+        "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
         "start-not-dev": "cross-env electron main.js",
-        "watch:browser":
-            "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
+        "watch:browser": "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
         "watch:plugins": "run-p watch:plugins:*",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-        "watch:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
         "watch:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && tsc --watch",
         "install:plugins": "run-s install:plugins:*",
-        "install:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
-        "install:plugins:oni-plugin-prettier":
-            "cd extensions/oni-plugin-prettier && yarn install --prod",
+        "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-prettier": "cd extensions/oni-plugin-prettier && yarn install --prod",
         "install:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn install --prod",
         "postinstall": "yarn run install:plugins && electron-rebuild && opencollective postinstall",
-        "profile:webpack":
-            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
+        "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
     "repository": {
         "type": "git",
@@ -696,6 +859,7 @@
         "chokidar": "^2.0.3",
         "color-normalize": "^1.0.3",
         "dompurify": "^1.0.3",
+        "eaw": "^0.1.5",
         "electron-settings": "^3.1.4",
         "find-up": "2.1.0",
         "fs-extra": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3352,6 +3352,12 @@ duplexify@^3.4.2, duplexify@^3.5.3:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+eaw@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/eaw/-/eaw-0.1.5.tgz#401dd2de48b98159f01fd18d81750e8e586f6df8"
+  dependencies:
+    minimist "^1.2.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -7574,17 +7580,17 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@^0.0.46:
-  version "0.0.46"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.46.tgz#99511a0c5488af1762b4744ce1ca79fea45b2b8b"
+oni-api@0.0.48:
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.48.tgz#531bfcbc72eeef48e250ae675cf8e0e0461e906c"
 
 oni-core-logging@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/oni-core-logging/-/oni-core-logging-1.0.0.tgz#7ad6c0ad8b06c23255202f97e229c2b0947dcf0b"
 
-oni-neovim-binaries@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/oni-neovim-binaries/-/oni-neovim-binaries-0.1.2.tgz#fccfab6aa71922437119a8de149582648f4e521d"
+oni-neovim-binaries@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/oni-neovim-binaries/-/oni-neovim-binaries-0.1.3.tgz#4855d11e9c1a6da586801bbb9996f61808c8b5b9"
 
 oni-release-downloader@^0.0.10:
   version "0.0.10"


### PR DESCRIPTION
Some characters (ex. ①: aka "Ambiguous" width characters) are cut in half.

<img width="148" alt="ambiguous" src="https://user-images.githubusercontent.com/8212553/43456200-7dfcc39a-94fd-11e8-8f90-280dbda141b2.png">

This PR adds "editor.useEastAsianWidth" option. (The default value leaves false)
Enabling this option fixes the issue. (You also need "set ambiwidth=double" in init.vim)