### PR TITLE
Bugfix/commit loading

### DIFF
--- a/browser/src/Plugins/PluginSidebarPane.tsx
+++ b/browser/src/Plugins/PluginSidebarPane.tsx
@@ -173,6 +173,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
                 render={(selectedId: string) => {
                     const defaultPluginItems = defaultPlugins.map(p => (
                         <SidebarItemView
+                            key={p.id}
                             indentationLevel={0}
                             isFocused={p.id === selectedId}
                             isContainer={false}
@@ -183,6 +184,7 @@ export class PluginsSidebarPaneView extends React.PureComponent<
 
                     const userPluginItems = userPlugins.map(p => (
                         <SidebarItemView
+                            key={p.id}
                             indentationLevel={0}
                             isFocused={p.id === selectedId}
                             isContainer={false}

--- a/browser/src/Services/Bookmarks/BookmarksPane.tsx
+++ b/browser/src/Services/Bookmarks/BookmarksPane.tsx
@@ -172,6 +172,7 @@ export class BookmarksPaneView extends React.PureComponent<
 
             const mapToItems = (selectedId: string) => (bm: IBookmark) => (
                 <SidebarItemView
+                    key={bm.id}
                     text={<BookmarkItemView bookmark={bm} />}
                     isFocused={selectedId === bm.id}
                     isContainer={false}

--- a/browser/src/Services/Learning/LearningPane.tsx
+++ b/browser/src/Services/Learning/LearningPane.tsx
@@ -169,6 +169,7 @@ export class LearningPaneView extends PureComponentWithDisposeTracking<
         const tutorialItems = (selectedId: string) =>
             this.state.tutorialInfo.map(t => (
                 <SidebarItemView
+                    key={t.tutorialInfo.id}
                     indentationLevel={0}
                     isFocused={selectedId === t.tutorialInfo.id}
                     text={<TutorialItemView info={t} />}

--- a/browser/src/Services/Menu/MenuComponent.tsx
+++ b/browser/src/Services/Menu/MenuComponent.tsx
@@ -8,7 +8,6 @@ import * as Oni from "oni-api"
 
 import { styled } from "../../UI/components/common"
 import { HighlightTextByIndex } from "./../../UI/components/HighlightText"
-// import { Visible } from "./../../UI/components/Visible"
 import { Icon, IconSize } from "./../../UI/Icon"
 
 import { focusManager } from "./../FocusManager"

--- a/browser/src/Services/VersionControl/VersionControlPane.tsx
+++ b/browser/src/Services/VersionControl/VersionControlPane.tsx
@@ -82,7 +82,6 @@ export default class VersionControlPane {
         let summary = null
         const { status } = this._store.getState()
         const filesToCommit = files || status.staged
-        this._dispatchLoading(true)
         try {
             summary = await this._vcsProvider.commitFiles(messages, filesToCommit)
             this._store.dispatch({ type: "COMMIT_SUCCESS", payload: { commit: summary } })
@@ -95,7 +94,6 @@ export default class VersionControlPane {
             this._store.dispatch({ type: "COMMIT_FAIL" })
         } finally {
             await this._refresh()
-            this._dispatchLoading(false)
         }
     }
 
@@ -191,8 +189,7 @@ export default class VersionControlPane {
     }
 
     private _refresh = async () => {
-        await this.getStatus()
-        await this.getLogs()
+        await Promise.all([this.getStatus(), this.getLogs()])
     }
 
     private _getStatusIfVisible = async () => {

--- a/browser/src/Services/VersionControl/VersionControlPane.tsx
+++ b/browser/src/Services/VersionControl/VersionControlPane.tsx
@@ -82,6 +82,7 @@ export default class VersionControlPane {
         let summary = null
         const { status } = this._store.getState()
         const filesToCommit = files || status.staged
+        this._dispatchLoading(true)
         try {
             summary = await this._vcsProvider.commitFiles(messages, filesToCommit)
             this._store.dispatch({ type: "COMMIT_SUCCESS", payload: { commit: summary } })
@@ -94,6 +95,7 @@ export default class VersionControlPane {
             this._store.dispatch({ type: "COMMIT_FAIL" })
         } finally {
             await this._refresh()
+            this._dispatchLoading(false)
         }
     }
 
@@ -165,8 +167,10 @@ export default class VersionControlPane {
                 await this.uncommitFile(selected)
                 break
             case status.staged.includes(selected):
+                this._store.dispatch({ type: "COMMIT_START", payload: { files: [selected] } })
+                break
             case selected === "commit_all" && !!status.staged.length:
-                this._store.dispatch({ type: "COMMIT_START" })
+                this._store.dispatch({ type: "COMMIT_START", payload: { files: status.staged } })
                 break
             default:
                 break

--- a/browser/src/Services/VersionControl/VersionControlView.tsx
+++ b/browser/src/Services/VersionControl/VersionControlView.tsx
@@ -24,6 +24,7 @@ const StatusContainer = styled.div`
 
 interface IStateProps {
     loading: boolean
+    filesToCommit: string[]
     loadingSection: ProviderActions
     status: StatusResult
     hasFocus: boolean
@@ -40,6 +41,7 @@ interface IStateProps {
 interface IDispatchProps {
     cancelCommit: () => void
     updateCommitMessage: (message: string[]) => void
+    setLoading: (loading: boolean) => void
 }
 
 interface IProps {
@@ -150,9 +152,12 @@ export class VersionControlView extends React.Component<ConnectedProps, State> {
             showHelp,
             loading,
             committing,
+            filesToCommit,
             loadingSection,
             status: { modified, staged, untracked },
         } = this.props
+
+        const commitInProgress = loading && loadingSection === "commit"
 
         return warning ? (
             <SectionTitle>
@@ -181,10 +186,10 @@ export class VersionControlView extends React.Component<ConnectedProps, State> {
                                 icon="plus-circle"
                                 files={staged}
                                 selectedId={selectedId}
-                                committing={committing}
+                                filesToCommit={filesToCommit}
                                 selectedToCommit={this.isSelected}
                                 visible={this.state.staged}
-                                loading={loading && loadingSection === "commit"}
+                                loading={commitInProgress}
                                 handleSelection={this.props.handleSelection}
                                 toggleVisibility={() => this.toggleVisibility(IDs.staged)}
                                 handleCommitOne={this.handleCommitOne}
@@ -227,6 +232,7 @@ const mapStateToProps = (state: VersionControlState): IStateProps => ({
     message: state.commit.message,
     selectedItem: state.selected,
     commits: state.commit.previousCommits,
+    filesToCommit: state.commit.files,
     showHelp: state.help.active,
     loading: state.loading.active,
     loadingSection: state.loading.type,

--- a/browser/src/UI/components/VersionControl/Staged.tsx
+++ b/browser/src/UI/components/VersionControl/Staged.tsx
@@ -21,7 +21,7 @@ interface IProps {
     icon: string
     loading: boolean
     handleSelection: (id: string) => void
-    committing?: boolean
+    filesToCommit: string[]
     toggleVisibility: () => void
     handleCommitMessage: (evt: React.ChangeEvent<HTMLInputElement>) => void
     handleCommitOne: () => void
@@ -81,8 +81,9 @@ const StagedSection: React.SFC<IProps> = props => {
             {props.visible &&
                 props.files.map(file => {
                     const isSelected = file === props.selectedId
+                    const isLoading = props.filesToCommit.includes(file) && props.loading
                     return (
-                        <LoadingHandler loading={isSelected && props.loading} key={file}>
+                        <LoadingHandler loading={isLoading} key={file}>
                             {props.selectedToCommit(file) ? (
                                 <CommitMessage
                                     handleCommitCancel={props.handleCommitCancel}

--- a/browser/src/UI/components/WindowSplits.tsx
+++ b/browser/src/UI/components/WindowSplits.tsx
@@ -93,14 +93,12 @@ export class WindowSplitView extends React.PureComponent<IWindowSplitViewProps, 
             <div className={className}>
                 <AutoSizer>
                     {({ height, width }) => {
-                        // return <div>{width}{height}</div>
                         const items = layoutFromSplitInfo(this.props.split, width, height)
                         const vals: JSX.Element[] = Object.values(items).map(item => {
                             const style = rectangleToStyleProperties(item.rectangle, height)
                             return (
-                                <div style={style}>
+                                <div style={style} key={item.split.id}>
                                     <WindowSplitHost
-                                        key={item.split.id}
                                         id={item.split.id}
                                         containerClassName="editor"
                                         split={item.split}

--- a/ui-tests/VersionControl/VersionControlStore.test.ts
+++ b/ui-tests/VersionControl/VersionControlStore.test.ts
@@ -40,18 +40,21 @@ describe("Version control reducer test", () => {
         const state = vcsStore.getState()
         expect(state.selected).toBe("/test.txt")
     })
+
     it("Should correctly set the commit active on commit start", () => {
-        vcsStore.dispatch({ type: "COMMIT_START" })
+        vcsStore.dispatch({ type: "COMMIT_START", payload: { files: ["/test.txt"] } })
         const state = vcsStore.getState()
         expect(state.commit.active).toBe(true)
     })
+
     it("Should correctly set the commit active to false on commit cancel", () => {
         vcsStore.dispatch({ type: "COMMIT_CANCEL" })
         const state = vcsStore.getState()
         expect(state.commit.active).toBe(false)
     })
+
     it("Should set commit active to false on commit success and add the commit", () => {
-        vcsStore.dispatch({ type: "COMMIT_START" })
+        vcsStore.dispatch({ type: "COMMIT_START", payload: { files: ["/test.txt"] } })
         vcsStore.dispatch({
             type: "UPDATE_COMMIT_MESSAGE",
             payload: { message: ["commit message"] },

--- a/ui-tests/VersionControl/VersionControlView.test.tsx
+++ b/ui-tests/VersionControl/VersionControlView.test.tsx
@@ -49,6 +49,9 @@ describe("<VersionControlView />", () => {
     const container = shallow(
         <VersionControlView
             {...state}
+            commit={noop}
+            filesToCommit={["/test.txt"]}
+            setLoading={noop}
             IDs={IDs}
             showHelp={true}
             committing={false}
@@ -70,6 +73,9 @@ describe("<VersionControlView />", () => {
         const container = mount(
             <VersionControlView
                 {...state}
+                commit={noop}
+                setLoading={noop}
+                filesToCommit={["/test.txt"]}
                 IDs={IDs}
                 loading={false}
                 loadingSection={null}
@@ -125,6 +131,7 @@ describe("<VersionControlView />", () => {
         const wrapper = mount(
             <Staged
                 files={[]}
+                filesToCommit={["test.txt"]}
                 titleId="staged"
                 visible={false}
                 handleCommitOne={jest.fn()}
@@ -147,6 +154,7 @@ describe("<VersionControlView />", () => {
         const wrapper = mount(
             <Staged
                 files={["test.txt"]}
+                filesToCommit={["test.txt"]}
                 selectedToCommit={() => false}
                 titleId="staged"
                 visible
@@ -163,29 +171,33 @@ describe("<VersionControlView />", () => {
         )
         expect(wrapper.find(LoadingHandler).length).toBe(2)
     })
-    it("should render an in place of the commit all explainer", () => {
+
+    it("should render an Input in place of the commit all explainer", () => {
         const wrapper = mount(
             <Staged
-                files={["test.txt"]}
-                selectedToCommit={() => true}
-                titleId="staged"
                 visible
+                loading
+                icon="cross"
+                titleId="staged"
+                files={["test.txt"]}
+                filesToCommit={[]}
+                selectedToCommit={() => true}
                 handleCommitOne={jest.fn()}
                 handleCommitMessage={jest.fn()}
                 handleCommitCancel={jest.fn()}
                 handleCommitAll={jest.fn()}
                 toggleVisibility={noop}
                 selectedId="commit_all"
-                icon="cross"
-                loading
                 handleSelection={noop}
             />,
         )
         expect(wrapper.find(CommitMessage).length).toBe(1)
     })
+
     it("should render help if show help is true", () => {
         expect(container.find(Help).length).toBe(1)
     })
+
     it("should render help prompt if show help is false", () => {
         container.setProps({ showHelp: false })
         expect(

--- a/vim/core/oni-plugin-git/src/index.tsx
+++ b/vim/core/oni-plugin-git/src/index.tsx
@@ -177,7 +177,7 @@ export class GitVersionControlProvider implements VCS.VersionControlProvider {
 
     public commitFiles = async (message: string[], files?: string[]): Promise<VCS.Commits> => {
         try {
-            const commit = this._git(this._projectRoot).commit(message, files)
+            const commit = await this._git(this._projectRoot).commit(message, files)
             const changed = (files || []).map(file => ({
                 path: file,
                 status: VCS.Statuses.committed,
@@ -256,7 +256,7 @@ export class GitVersionControlProvider implements VCS.VersionControlProvider {
             .reduce<VCS.Blame>(
                 (acc, [key, value], index) => {
                     const formattedKey = key.replace("-", "_")
-                    if (!index) {
+                    if (!index && value) {
                         acc.hash = formattedKey
                         const [originalLine, finalLine, numberOfLines] = value.split(" ")
                         acc.line = {


### PR DESCRIPTION
This PR fixes a bug where the promise for the vcs `commit` function was not being awaited meaning that the loading spinner wasn't showing properly when the commit takes a while (e.g. due to pre-commit hooks), this change causes the promise to be properly awaited

Also added a few missing keys to react lists,