### PR TITLE
Fix for 2272 - <f12> opens in current tab

### DIFF
--- a/browser/src/Editor/NeovimEditor/Definition.ts
+++ b/browser/src/Editor/NeovimEditor/Definition.ts
@@ -19,7 +19,7 @@ export enum OpenType {
 export class Definition {
     constructor(private _editor: Oni.Editor, private _store: Store<State.IState>) {}
 
-    public async gotoDefinitionUnderCursor(openType: OpenType = OpenType.NewTab): Promise<void> {
+    public async gotoDefinitionUnderCursor(openOptions?: Oni.FileOpenOptions): Promise<void> {
         const activeDefinition = this._store.getState().definition
 
         if (!activeDefinition) {
@@ -31,33 +31,21 @@ export class Definition {
         const line = range.start.line
         const column = range.start.character
 
-        await this.gotoPositionInUri(uri, line, column, openType)
+        await this.gotoPositionInUri(uri, line, column, openOptions)
     }
 
     public async gotoPositionInUri(
         uri: string,
         line: number,
         column: number,
-        openType: OpenType = OpenType.NewTab,
+        openOptions?: Oni.FileOpenOptions,
     ): Promise<void> {
         const filePath = Helpers.unwrapFileUriPath(uri)
 
         const activeEditor = this._editor
-        const command = this._getCommandFromOpenType(openType)
 
-        await activeEditor.neovim.command(`${command} ${filePath}`)
+        await this._editor.openFile(filePath, openOptions)
         await activeEditor.neovim.command(`cal cursor(${line + 1}, ${column + 1})`)
         await activeEditor.neovim.command("norm zz")
-    }
-
-    private _getCommandFromOpenType(openType: OpenType) {
-        switch (openType) {
-            case OpenType.SplitVertical:
-                return "vsp"
-            case OpenType.SplitHorizontal:
-                return "sp"
-            default:
-                return "e"
-        }
     }
 }

--- a/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
+++ b/browser/src/Editor/NeovimEditor/NeovimEditorCommands.ts
@@ -141,10 +141,25 @@ export class NeovimEditorCommands {
                 () => this._definition.gotoDefinitionUnderCursor(),
             ),
             new CallbackCommand("language.gotoDefinition.openVertical", null, null, () =>
-                this._definition.gotoDefinitionUnderCursor(1),
+                this._definition.gotoDefinitionUnderCursor({
+                    openMode: Oni.FileOpenMode.VerticalSplit,
+                }),
             ),
             new CallbackCommand("language.gotoDefinition.openHorizontal", null, null, () =>
-                this._definition.gotoDefinitionUnderCursor(2),
+                this._definition.gotoDefinitionUnderCursor({
+                    openMode: Oni.FileOpenMode.HorizontalSplit,
+                }),
+            ),
+            new CallbackCommand("language.gotoDefinition.openNewTab", null, null, () =>
+                this._definition.gotoDefinitionUnderCursor({ openMode: Oni.FileOpenMode.NewTab }),
+            ),
+            new CallbackCommand("language.gotoDefinition.openEdit", null, null, () =>
+                this._definition.gotoDefinitionUnderCursor({ openMode: Oni.FileOpenMode.Edit }),
+            ),
+            new CallbackCommand("language.gotoDefinition.openExistingTab", null, null, () =>
+                this._definition.gotoDefinitionUnderCursor({
+                    openMode: Oni.FileOpenMode.ExistingTab,
+                }),
             ),
 
             new CallbackCommand("editor.rename", "Rename", "Rename an item", () =>


### PR DESCRIPTION
This is a fix for #2272 to make `language.gotoDefinition` use the `Oni.DefaultFileOpenOptions.openMode` setting by default. It also adds:

- `language.gotoDefinition.openNewTab`
- `language.gotoDefinition.openEdit`
- `language.gotoDefinition.openExistingTab`

so that users can create bindings for the specific behavior they want.