### PR TITLE
Feature/import cost layer

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -22,6 +22,10 @@ import { commandManager } from "./../../Services/CommandManager"
 import { getInstance as getCompletionProvidersInstance } from "./../../Services/Completion/CompletionProviders"
 import { configuration } from "./../../Services/Configuration"
 import { getInstance as getDiagnosticsInstance } from "./../../Services/Diagnostics"
+import {
+    default as getBufferLayerInstance,
+    BufferLayerManager,
+} from "./../../Editor/NeovimEditor/BufferLayerManager"
 import { editorManager } from "./../../Services/EditorManager"
 import { inputManager } from "./../../Services/InputManager"
 import * as LanguageManager from "./../../Services/Language"
@@ -138,6 +142,10 @@ export class Oni implements OniApi.Plugin.Api {
 
     public get overlays(): OniApi.Overlays.Api {
         return getOverlayInstance()
+    }
+
+    public get bufferLayers(): BufferLayerManager {
+        return getBufferLayerInstance()
     }
 
     public get process(): OniApi.Process {

--- a/extensions/oni-plugin-import-cost/package.json
+++ b/extensions/oni-plugin-import-cost/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "oni-plugin-import-cost",
+    "version": "1.0.0",
+    "description": "An import cost buffer layer for Oni",
+    "main": "lib/index.js",
+    "author": "A. Sowemimo",
+    "license": "MIT",
+    "engines": {
+        "oni": "^0.2.6"
+    },
+    "scripts": {
+        "build": "rimraf lib && tsc",
+        "test": "tsc -p tsconfig.test.json && mocha --recursive ./lib_test/test"
+    },
+    "dependencies": {
+        "import-cost": "^1.5.0",
+        "oni-api": "^0.0.46",
+        "oni-types": "^0.0.8",
+        "react": "^16.4.2",
+        "styled-components": "^3.4.2"
+    },
+    "devDependencies": {
+        "rimraf": "^2.6.2",
+        "typescript": "^2.9.2"
+    }
+}

--- a/extensions/oni-plugin-import-cost/package.json
+++ b/extensions/oni-plugin-import-cost/package.json
@@ -16,11 +16,13 @@
         "import-cost": "^1.5.0",
         "oni-api": "^0.0.46",
         "oni-types": "^0.0.8",
-        "react": "^16.4.2",
-        "styled-components": "^3.4.2"
+        "react": "^16.4.2"
     },
     "devDependencies": {
         "rimraf": "^2.6.2",
         "typescript": "^2.9.2"
+    },
+    "peerDependencies": {
+        "styled-components": "^3.2.6"
     }
 }

--- a/extensions/oni-plugin-import-cost/src/index.tsx
+++ b/extensions/oni-plugin-import-cost/src/index.tsx
@@ -10,6 +10,7 @@ interface PackageProps extends SizeProps {
     width: number
     hide: boolean
     background: string
+    height: number
 }
 
 type Status = "calculating" | "done" | null | "error"
@@ -62,6 +63,7 @@ const Package = withProps<PackageProps>(styled.div).attrs({
     }),
 })`
     color: ${p => getColorForSize(p.size)};
+    height: ${p => px(p.height)};
     background-color: ${p => p.background};
     padding-left: 5px;
     position: absolute;
@@ -160,6 +162,12 @@ class ImportCosts extends React.Component<Props, State> {
     }
 
     getSize = (num: number): { kb: number; size: SizeProps["size"] } => {
+        if (!num) {
+            return {
+                kb: null,
+                size: null,
+            }
+        }
         const sizeInKbs = Math.round(num / 1024 * 10) / 10
         const sizeDescription =
             sizeInKbs >= this.props.largeSize
@@ -175,12 +183,25 @@ class ImportCosts extends React.Component<Props, State> {
 
     render() {
         const { status, packages } = this.state
+        const {
+            context: { fontPixelHeight },
+        } = this.props
         return (
             <Packages>
                 {packages.map(pkg => {
                     switch (pkg.status) {
                         case "calculating":
-                            return <Package {...this.getPosition(pkg.line)}>calculating...</Package>
+                            return (
+                                <Package
+                                    key={pkg.line}
+                                    data-id="import-cost"
+                                    height={fontPixelHeight}
+                                    {...this.getPosition(pkg.line)}
+                                    background={this.props.colors["editor.background"]}
+                                >
+                                    calculating...
+                                </Package>
+                            )
                         case "done":
                             const position = this.getPosition(pkg.line)
                             const gzipSize = this.getSize(pkg.gzip)
@@ -189,6 +210,7 @@ class ImportCosts extends React.Component<Props, State> {
                                 <Package
                                     {...position}
                                     key={pkg.line}
+                                    height={fontPixelHeight}
                                     size={pkgSize.size}
                                     data-id="import-cost"
                                     background={this.props.colors["editor.background"]}

--- a/extensions/oni-plugin-import-cost/src/index.tsx
+++ b/extensions/oni-plugin-import-cost/src/index.tsx
@@ -1,0 +1,101 @@
+import * as Oni from "oni-api"
+import * as path from "path"
+import * as React from "react"
+import { importCost, cleanup, JAVASCRIPT, TYPESCRIPT } from "import-cost"
+
+interface Props {
+    buffer: Oni.Buffer
+    context: Oni.BufferLayerRenderContext
+}
+
+interface State {
+    status: "error" | "calculating" | "done" | null
+    packages: string[]
+}
+
+class ImportCosts extends React.Component<Props, State> {
+    emitter: any
+    state = {
+        status: null,
+        packages: [],
+    }
+
+    async componentDidMount() {
+        const { filePath } = this.props.buffer
+        const contentsArray = await this.props.buffer.getLines(0)
+        const fileContents = contentsArray.join("\n")
+        const filetype = path.extname(filePath).includes(".ts") ? TYPESCRIPT : JAVASCRIPT
+        this.setupEmitter(filePath, filetype, fileContents)
+    }
+
+    componentWillUnmount() {
+        this.emitter.removeAllListeners()
+    }
+
+    setupEmitter(filePath: string, filetype: string, fileContents: string) {
+        this.emitter = importCost(filePath, fileContents, filetype)
+        this.emitter.on("error", e => this.setState({ status: "error" }))
+        this.emitter.on("start", packages => this.setState({ status: "calculating" }))
+        this.emitter.on("calculated", pkg =>
+            this.setState({ packages: [...this.state.packages, pkg] }),
+        )
+        this.emitter.on("done", packages => this.setState({ packages, status: "done" }))
+    }
+
+    getPosition = (line: number) => {
+        const lineContent = this.props.context.visibleLines[line - 1]
+        const character = lineContent.length || 0
+        console.log("line: ", line)
+        console.log("lineContent: ", lineContent)
+        console.log("character: ", character)
+        const pos = this.props.context.bufferToPixel({ character, line: line + 1 })
+        return pos ? pos.pixelX : null
+    }
+
+    render() {
+        const { status, packages } = this.state
+        switch (status) {
+            case "calculating":
+                return <div>calculating...</div>
+            case "done":
+                return (
+                    <div style={{ position: "relative", top: 0, left: 0, right: 0, bottom: 0 }}>
+                        {packages.map(pkg => (
+                            <span
+                                style={{ left: this.getPosition(pkg.line), position: "absolute" }}
+                            >
+                                {pkg.name} {pkg.gzip} {pkg.line}
+                            </span>
+                        ))}
+                    </div>
+                )
+            default:
+                return null
+        }
+    }
+}
+
+export class ImportCostLayer implements Oni.BufferLayer {
+    constructor(private _oni: Oni.Plugin.Api, private _buffer) {}
+    get id() {
+        return "import-costs"
+    }
+
+    render(context: Oni.BufferLayerRenderContext) {
+        return <ImportCosts buffer={this._buffer} context={context} />
+    }
+}
+
+export interface OniWithLayers extends Oni.Plugin.Api {
+    bufferLayers: any
+}
+
+export const activate = async (oni: OniWithLayers) => {
+    const isCompatible = (buf: Oni.Buffer) => {
+        const ext = path.extname(buf.filePath)
+        return ext.includes(".ts") || ext.includes(".js")
+    }
+    oni.bufferLayers.addBufferLayer(isCompatible, buf => {
+        return new ImportCostLayer(oni, buf)
+    })
+}

--- a/extensions/oni-plugin-import-cost/tsconfig.json
+++ b/extensions/oni-plugin-import-cost/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "preserveConstEnums": true,
+        "outDir": "./lib",
+        "jsx": "react",
+        "lib": ["dom", "es2017"],
+        "declaration": true,
+        "sourceMap": true,
+        "target": "es2015",
+        "skipLibCheck": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx"],
+    "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -600,6 +600,8 @@
         "build:cli": "cd cli && tsc -p tsconfig.json",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
         "build:plugin:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn run build",
+        "build:plugin:oni-plugin-import-cost":
+            "cd extensions/oni-plugin-import-cost && yarn run build",
         "build:plugin:oni-plugin-markdown-preview":
             "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:plugin:oni-plugin-quickopen": "cd extensions/oni-plugin-quickopen && yarn run build",
@@ -674,12 +676,16 @@
             "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
         "watch:plugins": "run-p watch:plugins:*",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
+        "watch:plugins:oni-plugin-import-cost":
+            "cd extensions/oni-plugin-import-cost && tsc --watch",
         "watch:plugins:oni-plugin-markdown-preview":
             "cd extensions/oni-plugin-markdown-preview && tsc --watch",
         "watch:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && tsc --watch",
         "install:plugins": "run-s install:plugins:*",
         "install:plugins:oni-plugin-markdown-preview":
             "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-import-cost":
+            "cd extensions/oni-plugin-import-cost && yarn install --prod",
         "install:plugins:oni-plugin-prettier":
             "cd extensions/oni-plugin-prettier && yarn install --prod",
         "install:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn install --prod",


### PR DESCRIPTION
Was inspired by https://github.com/yardnsm/vim-import-cost to implement an import cost buffer layer similar to [this](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost).

It uses the `import-cost` npm package which does *all* of the hard work I just render the result of it in a buffer layer.

The layer is in the extensions dir and is something that I think can be separated out once we have plugin management sorted.

<img width="817" alt="screen shot 2018-08-15 at 12 54 06" src="https://user-images.githubusercontent.com/22454918/44210558-bcb86900-a15e-11e8-9023-0693c3d41935.png">

Outstanding:

- [ ] Add configurable size boundaries for packages and colors config opts for sizes
- [ ] Attempt to add jest test for layer
- [ ] Allow priorities to be specified for layer i.e. this would clash with git blame but currently has a hard coded z-index (make that user configurable)