### PR TITLE
Changed spacing of elements in the explorer sidebar to be more readable

### DIFF
--- a/browser/src/UI/components/SidebarItemView.tsx
+++ b/browser/src/UI/components/SidebarItemView.tsx
@@ -42,7 +42,7 @@ const SidebarItemStyleWrapper = withProps<ISidebarItemViewProps>(styled.div)`
     justify-content: center;
     align-items: center;
     padding-top: 4px;
-    padding-bottom: 4px;
+    padding-bottom: 3px;
     position: relative;
 
     cursor: pointer;
@@ -52,7 +52,7 @@ const SidebarItemStyleWrapper = withProps<ISidebarItemViewProps>(styled.div)`
         flex: 0 0 auto;
         width: 20px;
         text-align: center;
-        margin-right: 7px;
+        margin-right: 1px;
     }
 
     .name {
@@ -82,7 +82,7 @@ const SidebarItemBackground = withProps<ISidebarItemViewProps>(styled.div)`
     bottom: 0px;
 `
 
-const INDENT_AMOUNT = 6
+const INDENT_AMOUNT = 12
 
 export class SidebarItemView extends React.PureComponent<ISidebarItemViewProps, {}> {
     public render(): JSX.Element {


### PR DESCRIPTION
Changes related to the file explorer spacing as explained in #2510 
This change hopefully makes the file explorer easier to read. 

1. Slightly reduced spacing between each element in the explorer. 
2. Reduced space between the caret/icon and the text.
3. Doubled the indentation amount.