### PR TITLE
Bugfix/fix welcome buffer layer

### DIFF
--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -344,15 +344,15 @@ export class Buffer implements IBuffer {
             return false
         }
 
-        const result = layers.reduce<boolean>((prev, curr) => {
-            if (prev) {
+        const result = layers.reduce<boolean>((layerHandlerExists, currentLayer) => {
+            if (layerHandlerExists) {
                 return true
             }
 
-            if (!curr || !curr.handleInput) {
+            if (!currentLayer || !currentLayer.handleInput) {
                 return false
             } else {
-                return curr.handleInput(key)
+                return currentLayer.handleInput(key)
             }
         }, false)
 

--- a/browser/src/Editor/BufferManager.ts
+++ b/browser/src/Editor/BufferManager.ts
@@ -338,25 +338,29 @@ export class Buffer implements IBuffer {
     public handleInput(key: string): boolean {
         const state = this._store.getState()
 
-        const layers: IBufferLayer[] = state.layers[this._id]
+        const bufferLayers: IBufferLayer[] = state.layers[this._id]
 
-        if (!layers || !layers.length) {
+        if (!bufferLayers || !bufferLayers.length) {
             return false
         }
 
-        const result = layers.reduce<boolean>((layerHandlerExists, currentLayer) => {
-            if (layerHandlerExists) {
-                return true
-            }
+        const layerShouldHandleInput = bufferLayers.reduce<boolean>(
+            (layerHandlerExists, currentLayer) => {
+                if (layerHandlerExists) {
+                    return true
+                }
 
-            if (!currentLayer || !currentLayer.handleInput) {
+                if (!currentLayer || !currentLayer.handleInput) {
+                    return false
+                } else if (currentLayer.isActive && currentLayer.isActive()) {
+                    return currentLayer.handleInput(key)
+                }
                 return false
-            } else {
-                return currentLayer.handleInput(key)
-            }
-        }, false)
+            },
+            false,
+        )
 
-        return result
+        return layerShouldHandleInput
     }
     public async updateHighlights(
         tokenColors: TokenColor[],

--- a/browser/src/Editor/NeovimEditor/BufferLayerManager.ts
+++ b/browser/src/Editor/NeovimEditor/BufferLayerManager.ts
@@ -11,6 +11,7 @@ export type BufferFilter = (buf: Oni.Buffer) => boolean
 
 export interface IBufferLayer extends Oni.BufferLayer {
     handleInput?: (key: string) => boolean
+    isActive?: () => boolean
 }
 
 export const createBufferFilterFromLanguage = (language: string) => (buf: Oni.Buffer): boolean => {

--- a/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/HoverRenderer.tsx
@@ -8,9 +8,9 @@ import * as React from "react"
 import * as types from "vscode-languageserver-types"
 
 import getTokens from "./../../Services/SyntaxHighlighting/TokenGenerator"
-import { enableMouse } from "./../../UI/components/common"
+import styled, { enableMouse } from "./../../UI/components/common"
 import { ErrorInfo } from "./../../UI/components/ErrorInfo"
-import { QuickInfoElement, QuickInfoWrapper } from "./../../UI/components/QuickInfo"
+import { QuickInfoElement } from "./../../UI/components/QuickInfo"
 import QuickInfoWithTheme from "./../../UI/components/QuickInfoContainer"
 
 import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpers"
@@ -22,7 +22,9 @@ import { IToolTipsProvider } from "./ToolTipsProvider"
 
 const HoverToolTipId = "hover-tool-tip"
 
-const HoverRendererContainer = QuickInfoWrapper.extend`
+const HoverRendererContainer = styled.div`
+    user-select: none;
+    cursor: default;
     ${enableMouse};
 `
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -146,7 +146,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
     private _bufferLayerManager = getLayerManagerInstance()
     private _screenWithPredictions: ScreenWithPredictions
 
-    private _onEmptyBuffer = new Event<void>()
+    private _onShowWelcomeScreen = new Event<void>()
     private _onNeovimQuit: Event<void> = new Event<void>()
 
     private _autoFocus: boolean = true
@@ -155,8 +155,8 @@ export class NeovimEditor extends Editor implements Oni.Editor {
         return this._onNeovimQuit
     }
 
-    public get onEmptyBuffer() {
-        return this._onEmptyBuffer
+    public get onShowWelcomeScreen() {
+        return this._onShowWelcomeScreen
     }
 
     public get /* override */ activeBuffer(): Oni.Buffer {
@@ -1043,7 +1043,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
             await this.openFiles(filesToOpen, { openMode: Oni.FileOpenMode.Edit })
         } else {
             if (this._configuration.getValue("experimental.welcome.enabled")) {
-                this._onEmptyBuffer.dispatch()
+                this._onShowWelcomeScreen.dispatch()
             }
         }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -94,8 +94,6 @@ import CommandLine from "./../../UI/components/CommandLine"
 import ExternalMenus from "./../../UI/components/ExternalMenus"
 import WildMenu from "./../../UI/components/WildMenu"
 
-// import { WelcomeBufferLayer } from "./WelcomeBufferLayer"
-
 import { CanvasRenderer } from "../../Renderer/CanvasRenderer"
 import { WebGLRenderer } from "../../Renderer/WebGL/WebGLRenderer"
 import { getInstance as getNotificationsInstance } from "./../../Services/Notifications"

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -148,6 +148,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
     private _bufferLayerManager = getLayerManagerInstance()
     private _screenWithPredictions: ScreenWithPredictions
 
+    private _welcomeActive = false
     private _onEmptyBuffer = new Event<void>()
     private _onNeovimQuit: Event<void> = new Event<void>()
 
@@ -840,6 +841,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
     }
 
     public async createWelcomeBuffer() {
+        this._welcomeActive = true
         const buf = await this.openFile("WELCOME")
         await buf.setScratchBuffer()
         return buf
@@ -1110,8 +1112,8 @@ export class NeovimEditor extends Editor implements Oni.Editor {
             <Provider store={this._store}>
                 <NeovimSurface
                     onFileDrop={this._onFilesDropped}
-                    autoFocus={this._autoFocus}
                     renderer={this._renderer}
+                    autoFocus={this._autoFocus && !this._welcomeActive}
                     typingPrediction={this._typingPredictionManager}
                     neovimInstance={this._neovimInstance}
                     screen={this._screen}

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -94,7 +94,7 @@ import CommandLine from "./../../UI/components/CommandLine"
 import ExternalMenus from "./../../UI/components/ExternalMenus"
 import WildMenu from "./../../UI/components/WildMenu"
 
-import { WelcomeBufferLayer } from "./WelcomeBufferLayer"
+// import { WelcomeBufferLayer } from "./WelcomeBufferLayer"
 
 import { CanvasRenderer } from "../../Renderer/CanvasRenderer"
 import { WebGLRenderer } from "../../Renderer/WebGL/WebGLRenderer"
@@ -148,12 +148,17 @@ export class NeovimEditor extends Editor implements Oni.Editor {
     private _bufferLayerManager = getLayerManagerInstance()
     private _screenWithPredictions: ScreenWithPredictions
 
+    private _onEmptyBuffer = new Event<void>()
     private _onNeovimQuit: Event<void> = new Event<void>()
 
     private _autoFocus: boolean = true
 
     public get onNeovimQuit(): IEvent<void> {
         return this._onNeovimQuit
+    }
+
+    public get onEmptyBuffer() {
+        return this._onEmptyBuffer
     }
 
     public get /* override */ activeBuffer(): Oni.Buffer {
@@ -834,6 +839,12 @@ export class NeovimEditor extends Editor implements Oni.Editor {
         this._neovimInstance.autoCommands.executeAutoCommand("FocusLost")
     }
 
+    public async createWelcomeBuffer() {
+        const buf = await this.openFile("WELCOME")
+        await buf.setScratchBuffer()
+        return buf
+    }
+
     public async clearSelection(): Promise<void> {
         await this._neovimInstance.input("<esc>")
         await this._neovimInstance.input("a")
@@ -1034,8 +1045,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
             await this.openFiles(filesToOpen, { openMode: Oni.FileOpenMode.Edit })
         } else {
             if (this._configuration.getValue("experimental.welcome.enabled")) {
-                const buf = await this.openFile("WELCOME")
-                buf.addLayer(new WelcomeBufferLayer())
+                this._onEmptyBuffer.dispatch()
             }
         }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -148,7 +148,6 @@ export class NeovimEditor extends Editor implements Oni.Editor {
     private _bufferLayerManager = getLayerManagerInstance()
     private _screenWithPredictions: ScreenWithPredictions
 
-    private _welcomeActive = false
     private _onEmptyBuffer = new Event<void>()
     private _onNeovimQuit: Event<void> = new Event<void>()
 
@@ -841,7 +840,6 @@ export class NeovimEditor extends Editor implements Oni.Editor {
     }
 
     public async createWelcomeBuffer() {
-        this._welcomeActive = true
         const buf = await this.openFile("WELCOME")
         await buf.setScratchBuffer()
         return buf
@@ -1113,7 +1111,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
                 <NeovimSurface
                     onFileDrop={this._onFilesDropped}
                     renderer={this._renderer}
-                    autoFocus={this._autoFocus && !this._welcomeActive}
+                    autoFocus={this._autoFocus}
                     typingPrediction={this._typingPredictionManager}
                     neovimInstance={this._neovimInstance}
                     screen={this._screen}
@@ -1138,10 +1136,10 @@ export class NeovimEditor extends Editor implements Oni.Editor {
         }
 
         // Check if any of the buffer layers can handle the input...
-        const buf: IBuffer = this.activeBuffer as IBuffer
-        const result = buf && buf.handleInput(key)
+        const buf = this.activeBuffer
+        const layerInputHandler = buf && buf.handleInput(key)
 
-        if (result) {
+        if (layerInputHandler) {
             return
         }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -309,7 +309,7 @@ export class NeovimEditor extends Editor implements Oni.Editor {
 
         // Services
         const onColorsChanged = () => {
-            const updatedColors: any = this._colors.getColors()
+            const updatedColors = this._colors.getColors()
             this._actions.setColors(updatedColors)
         }
 

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -69,7 +69,7 @@ import { Workspace } from "./../../Services/Workspace"
 
 import { Editor } from "./../Editor"
 
-import { BufferManager, IBuffer } from "./../BufferManager"
+import { BufferManager } from "./../BufferManager"
 import { CompletionMenu } from "./CompletionMenu"
 import { HoverRenderer } from "./HoverRenderer"
 import { NeovimPopupMenu } from "./NeovimPopupMenu"

--- a/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimSurface.tsx
@@ -87,7 +87,7 @@ class NeovimSurface extends React.Component<INeovimSurfaceProps> {
                                     screen={this.props.screen}
                                 />
                             </div>
-                            <StackLayer zIndex={2}>
+                            <StackLayer>
                                 <Cursor typingPrediction={this.props.typingPrediction} />
                                 <CursorLine lineType={"line"} />
                                 <CursorLine lineType={"column"} />

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -9,8 +9,8 @@ import * as Oni from "oni-api"
 import * as Log from "oni-core-logging"
 import { Event } from "oni-types"
 
-import styled, { keyframes, enableMouse, Css, css } from "./../../UI/components/common"
 import { getMetadata } from "./../../Services/Metadata"
+import styled, { css, Css, enableMouse, keyframes } from "./../../UI/components/common"
 
 // const entrance = keyframes`
 //     0% { opacity: 0; transform: translateY(2px); }
@@ -164,16 +164,20 @@ export interface WelcomeButtonProps {
     onClick: () => void
 }
 
-export class WelcomeButton extends React.PureComponent<WelcomeButtonProps> {
-    private _button = React.createRef<HTMLElement>()
+interface IChromeDiv extends HTMLButtonElement {
+    scrollIntoViewIfNeeded: () => void
+}
 
-    componentDidUpdate(prevProps: WelcomeButtonProps) {
+export class WelcomeButton extends React.PureComponent<WelcomeButtonProps> {
+    private _button = React.createRef<IChromeDiv>()
+
+    public componentDidUpdate(prevProps: WelcomeButtonProps) {
         if (!prevProps.selected && this.props.selected) {
-            this._button.current.scrollIntoView()
+            this._button.current.scrollIntoViewIfNeeded()
         }
     }
 
-    render() {
+    public render() {
         return (
             <WelcomeButtonWrapper
                 innerRef={this._button}
@@ -213,9 +217,6 @@ interface IWelcomeCommandsDictionary {
 
 export class WelcomeBufferLayer implements Oni.BufferLayer {
     constructor(private _oni: OniWithActiveSection) {}
-    public get id(): string {
-        return "oni.welcome"
-    }
 
     public inputEvent = new Event<IWelcomInputEvent>()
 
@@ -228,6 +229,10 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
         openWorkspaceFolder: "workspace.openFolder",
         commandPalette: "quickOpen.show",
         commandline: "executeVimCommand",
+    }
+
+    public get id(): string {
+        return "oni.welcome"
     }
 
     public get friendlyName(): string {

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -4,13 +4,13 @@
  * IEditor implementation for Neovim
  */
 
-import * as React from "react"
 import * as Oni from "oni-api"
 import * as Log from "oni-core-logging"
 import { Event } from "oni-types"
+import * as React from "react"
 
 import { getMetadata } from "./../../Services/Metadata"
-import styled, { css, Css, enableMouse, keyframes } from "./../../UI/components/common"
+import styled, { Css, css, enableMouse, keyframes } from "./../../UI/components/common"
 
 // const entrance = keyframes`
 //     0% { opacity: 0; transform: translateY(2px); }
@@ -216,8 +216,6 @@ interface IWelcomeCommandsDictionary {
 }
 
 export class WelcomeBufferLayer implements Oni.BufferLayer {
-    constructor(private _oni: OniWithActiveSection) {}
-
     public inputEvent = new Event<IWelcomInputEvent>()
 
     public welcomeCommands: IWelcomeCommandsDictionary = {
@@ -230,6 +228,8 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
         commandPalette: "quickOpen.show",
         commandline: "executeVimCommand",
     }
+
+    constructor(private _oni: OniWithActiveSection) {}
 
     public get id(): string {
         return "oni.welcome"
@@ -306,12 +306,13 @@ const titleRow = css`
 `
 
 export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeViewState> {
-    private _welcomeElement = React.createRef<HTMLDivElement>()
     public state: WelcomeViewState = {
         version: null,
         currentIndex: 0,
         selectedId: this.props.buttonIds[0],
     }
+
+    private _welcomeElement = React.createRef<HTMLDivElement>()
 
     public async componentDidMount() {
         const metadata = await getMetadata()
@@ -341,7 +342,7 @@ export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeVi
         }
     }
 
-    componentDidUpdate() {
+    public componentDidUpdate() {
         if (this.props.active && this._welcomeElement && this._welcomeElement.current) {
             this._welcomeElement.current.focus()
         }

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -211,23 +211,16 @@ export const ButtonIds = [
 ]
 
 export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeViewState> {
-    constructor(props: WelcomeViewProps) {
-        super(props)
-
-        this.state = {
-            version: null,
-        }
+    public state: WelcomeViewState = {
+        version: null,
     }
 
-    public componentDidMount(): void {
-        getMetadata().then(metadata => {
-            this.setState({
-                version: metadata.version,
-            })
-        })
+    public async componentDidMount() {
+        const metadata = await getMetadata()
+        this.setState({ version: metadata.version })
     }
 
-    public render(): JSX.Element {
+    public render() {
         if (!this.state.version) {
             return null
         }
@@ -258,10 +251,10 @@ export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeVi
                 <Row style={{ width: "100%", marginTop: "64px", opacity: 1 }}>
                     <Column />
                     <VimNavigator
-                        style={{ width: "100%" }}
                         active={true}
+                        style={{ width: "100%" }}
                         ids={ButtonIds}
-                        render={(selectedId: string) => (
+                        render={selectedId => (
                             <WelcomeBufferLayerCommandsView selectedId={selectedId} />
                         )}
                     />

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -231,18 +231,6 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
     public inputEvent = new Event<IWelcomeInputEvent>()
 
     public readonly welcomeCommands: IWelcomeCommandsDictionary = {
-        openTutor: {
-            command: "oni.tutor.open",
-        },
-        openDocs: {
-            command: "oni.docs.open",
-        },
-        openConfig: {
-            command: "oni.config.openUserConfig",
-        },
-        openThemes: {
-            command: "oni.themes.open",
-        },
         openFile: {
             command: "oni.editor.newFile",
         },
@@ -254,6 +242,18 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
         },
         commandline: {
             command: "executeVimCommand",
+        },
+        openTutor: {
+            command: "oni.tutor.open",
+        },
+        openDocs: {
+            command: "oni.docs.open",
+        },
+        openConfig: {
+            command: "oni.config.openUserConfig",
+        },
+        openThemes: {
+            command: "oni.themes.open",
         },
     }
 

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -199,12 +199,12 @@ export interface OniWithActiveSection extends Oni.Plugin.Api {
     getActiveSection(): string
 }
 
-interface IWelcomInputEvent {
+export interface IWelcomeInputEvent {
     direction: number
     select: boolean
 }
 
-interface IWelcomeCommandsDictionary {
+export interface IWelcomeCommandsDictionary {
     openFile: string
     openTutor: string
     openDocs: string
@@ -216,7 +216,7 @@ interface IWelcomeCommandsDictionary {
 }
 
 export class WelcomeBufferLayer implements Oni.BufferLayer {
-    public inputEvent = new Event<IWelcomInputEvent>()
+    public inputEvent = new Event<IWelcomeInputEvent>()
 
     public welcomeCommands: IWelcomeCommandsDictionary = {
         openTutor: "oni.tutor.open",
@@ -282,7 +282,7 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
 export interface WelcomeViewProps {
     active: boolean
     buttonIds: string[]
-    inputEvent: Event<IWelcomInputEvent>
+    inputEvent: Event<IWelcomeInputEvent>
     commands: IWelcomeCommandsDictionary
     executeCommand: (cmd: string) => void
 }
@@ -320,7 +320,7 @@ export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeVi
         this.props.inputEvent.subscribe(this.handleInput)
     }
 
-    public handleInput = ({ direction, select }: IWelcomInputEvent) => {
+    public handleInput = ({ direction, select }: IWelcomeInputEvent) => {
         const { currentIndex } = this.state
         const newIndex = this.getNextIndex(direction, currentIndex)
         const selectedId = this.props.buttonIds[newIndex]

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -259,12 +259,17 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
 
     constructor(private _oni: OniWithActiveSection) {}
 
-    public get id(): string {
+    public get id() {
         return "oni.welcome"
     }
 
-    public get friendlyName(): string {
+    public get friendlyName() {
         return "Welcome"
+    }
+
+    public isActive(): boolean {
+        const activeSection = this._oni.getActiveSection()
+        return activeSection === "editor"
     }
 
     public handleInput(key: string) {
@@ -355,7 +360,7 @@ export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeVi
         const selectedId = this.props.buttonIds[newIndex]
         this.setState({ currentIndex: newIndex, selectedId })
 
-        if (select) {
+        if (select && this.props.active) {
             const currentCommand = this.getCurrentCommand(selectedId)
             this.props.executeCommand(currentCommand.command, currentCommand.args)
         }
@@ -425,8 +430,40 @@ export interface IWelcomeCommandsViewProps extends Partial<WelcomeViewProps> {
 export class WelcomeCommandsView extends React.PureComponent<IWelcomeCommandsViewProps, {}> {
     public render() {
         const { commands, executeCommand } = this.props
+        const isSelected = (command: string) => command === this.props.selectedId
         return (
             <Column>
+                <AnimatedContainer duration="0.25s">
+                    <SectionHeader>Quick Commands</SectionHeader>
+                    <WelcomeButton
+                        title="New File"
+                        onClick={() => executeCommand(commands.openFile.command)}
+                        description="Control + N"
+                        command={commands.openFile.command}
+                        selected={isSelected(commands.openFile.command)}
+                    />
+                    <WelcomeButton
+                        title="Open File / Folder"
+                        onClick={() => executeCommand(commands.openWorkspaceFolder.command)}
+                        description="Control + O"
+                        command={commands.openWorkspaceFolder.command}
+                        selected={isSelected(commands.openWorkspaceFolder.command)}
+                    />
+                    <WelcomeButton
+                        title="Command Palette"
+                        onClick={() => executeCommand(commands.commandPalette.command)}
+                        description="Control + Shift + P"
+                        command={commands.commandPalette.command}
+                        selected={isSelected(commands.commandPalette.command)}
+                    />
+                    <WelcomeButton
+                        title="Vim Ex Commands"
+                        description=":"
+                        command="editor.openExCommands"
+                        onClick={() => executeCommand(commands.commandline.command)}
+                        selected={isSelected(commands.commandline.command)}
+                    />
+                </AnimatedContainer>
                 <AnimatedContainer duration="0.25s">
                     <SectionHeader>Learn</SectionHeader>
                     <WelcomeButton
@@ -434,14 +471,14 @@ export class WelcomeCommandsView extends React.PureComponent<IWelcomeCommandsVie
                         onClick={() => executeCommand(commands.openTutor.command)}
                         description="Learn modal editing with an interactive tutorial."
                         command={commands.openTutor.command}
-                        selected={this.props.selectedId === commands.openTutor.command}
+                        selected={isSelected(commands.openTutor.command)}
                     />
                     <WelcomeButton
                         title="Documentation"
                         onClick={() => executeCommand(commands.openDocs.command)}
                         description="Discover what Oni can do for you."
                         command={commands.openDocs.command}
-                        selected={this.props.selectedId === commands.openDocs.command}
+                        selected={isSelected(commands.openDocs.command)}
                     />
                 </AnimatedContainer>
                 <AnimatedContainer duration="0.25s">
@@ -451,45 +488,14 @@ export class WelcomeCommandsView extends React.PureComponent<IWelcomeCommandsVie
                         onClick={() => executeCommand(commands.openConfig.command)}
                         description="Make Oni work the way you want."
                         command={commands.openConfig.command}
-                        selected={this.props.selectedId === commands.openConfig.command}
+                        selected={isSelected(commands.openConfig.command)}
                     />
                     <WelcomeButton
                         title="Themes"
                         onClick={() => executeCommand(commands.openThemes.command)}
                         description="Choose a theme that works for you."
                         command={commands.openThemes.command}
-                        selected={this.props.selectedId === commands.openThemes.command}
-                    />
-                </AnimatedContainer>
-                <AnimatedContainer duration="0.25s">
-                    <SectionHeader>Quick Commands</SectionHeader>
-                    <WelcomeButton
-                        title="New File"
-                        onClick={() => executeCommand(commands.openFile.command)}
-                        description="Control + N"
-                        command={commands.openFile.command}
-                        selected={this.props.selectedId === commands.openFile.command}
-                    />
-                    <WelcomeButton
-                        title="Open File / Folder"
-                        onClick={() => executeCommand(commands.openWorkspaceFolder.command)}
-                        description="Control + O"
-                        command={commands.openWorkspaceFolder.command}
-                        selected={this.props.selectedId === commands.openWorkspaceFolder.command}
-                    />
-                    <WelcomeButton
-                        title="Command Palette"
-                        onClick={() => executeCommand(commands.commandPalette.command)}
-                        description="Control + Shift + P"
-                        command={commands.commandPalette.command}
-                        selected={this.props.selectedId === commands.commandPalette.command}
-                    />
-                    <WelcomeButton
-                        title="Vim Ex Commands"
-                        description=":"
-                        command="editor.openExCommands"
-                        onClick={() => executeCommand(commands.commandline.command)}
-                        selected={this.props.selectedId === commands.commandline.command}
+                        selected={isSelected(commands.openThemes.command)}
                     />
                 </AnimatedContainer>
             </Column>

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -290,7 +290,7 @@ export class WelcomeBufferLayer implements Oni.BufferLayer {
         }
     }
 
-    public render(context: Oni.BufferLayerRenderContext): JSX.Element {
+    public render(context: Oni.BufferLayerRenderContext) {
         const active = this._oni.getActiveSection() === "editor"
         const ids = Object.values(this.welcomeCommands).map(({ command }) => command)
         return (

--- a/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
+++ b/browser/src/Editor/NeovimEditor/WelcomeBufferLayer.tsx
@@ -351,7 +351,7 @@ export class WelcomeView extends React.PureComponent<WelcomeViewProps, WelcomeVi
     public render() {
         const { version } = this.state
         return version ? (
-            <Column innerRef={this._welcomeElement} height="100%">
+            <Column innerRef={this._welcomeElement} height="100%" data-id="welcome-screen">
                 <Row extension={titleRow}>
                     <Column />
                     <Column alignment="flex-end">

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -54,7 +54,7 @@ import { IBuffer } from "../BufferManager"
 import ColorHighlightLayer from "./ColorHighlightLayer"
 import { ImageBufferLayer } from "./ImageBufferLayer"
 import IndentLineBufferLayer from "./IndentGuideBufferLayer"
-import { WelcomeBufferLayer, OniWithActiveSection } from "../NeovimEditor/WelcomeBufferLayer"
+import { OniWithActiveSection, WelcomeBufferLayer } from "../NeovimEditor/WelcomeBufferLayer"
 
 // Helper method to wrap a react component into a layer
 const wrapReactComponentWithLayer = (id: string, component: JSX.Element): Oni.BufferLayer => {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -54,6 +54,7 @@ import { IBuffer } from "../BufferManager"
 import ColorHighlightLayer from "./ColorHighlightLayer"
 import { ImageBufferLayer } from "./ImageBufferLayer"
 import IndentLineBufferLayer from "./IndentGuideBufferLayer"
+import { WelcomeBufferLayer, OniWithActiveSection } from "../NeovimEditor/WelcomeBufferLayer"
 
 // Helper method to wrap a react component into a layer
 const wrapReactComponentWithLayer = (id: string, component: JSX.Element): Oni.BufferLayer => {
@@ -208,6 +209,13 @@ export class OniEditor extends Utility.Disposable implements Oni.Editor {
                 _buf => new ColorHighlightLayer(this._configuration),
             )
         }
+
+        this._neovimEditor.onEmptyBuffer.subscribe(async () => {
+            const oni = this._pluginManager.getApi()
+            const buf = await this._neovimEditor.createWelcomeBuffer()
+            const welcome = new WelcomeBufferLayer(oni as OniWithActiveSection)
+            buf.addLayer(welcome)
+        })
     }
 
     public dispose(): void {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -51,10 +51,10 @@ import { SplitDirection, windowManager } from "./../../Services/WindowManager"
 
 import { ISession } from "../../Services/Sessions"
 import { IBuffer } from "../BufferManager"
+import { OniWithActiveSection, WelcomeBufferLayer } from "../NeovimEditor/WelcomeBufferLayer"
 import ColorHighlightLayer from "./ColorHighlightLayer"
 import { ImageBufferLayer } from "./ImageBufferLayer"
 import IndentLineBufferLayer from "./IndentGuideBufferLayer"
-import { OniWithActiveSection, WelcomeBufferLayer } from "../NeovimEditor/WelcomeBufferLayer"
 
 // Helper method to wrap a react component into a layer
 const wrapReactComponentWithLayer = (id: string, component: JSX.Element): Oni.BufferLayer => {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -210,11 +210,11 @@ export class OniEditor extends Utility.Disposable implements Oni.Editor {
             )
         }
 
-        this._neovimEditor.onEmptyBuffer.subscribe(async () => {
+        this._neovimEditor.onShowWelcomeScreen.subscribe(async () => {
             const oni = this._pluginManager.getApi()
-            const buf = await this._neovimEditor.createWelcomeBuffer()
-            const welcome = new WelcomeBufferLayer(oni as OniWithActiveSection)
-            buf.addLayer(welcome)
+            const welcomeBuffer = await this._neovimEditor.createWelcomeBuffer()
+            const welcomeLayer = new WelcomeBufferLayer(oni as OniWithActiveSection)
+            welcomeBuffer.addLayer(welcomeLayer)
         })
     }
 

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -52,8 +52,27 @@ export class Dependencies {
     }
 }
 
-const helpers = {
-    throttle,
+class Helpers {
+    constructor(private _oni: OniApi.Plugin.Api) {}
+    throttle = throttle
+    public getActiveSection() {
+        const isInsertOrCommandMode = () => {
+            return (
+                this._oni.editors.activeEditor.mode === "insert" ||
+                this._oni.editors.activeEditor.mode === "cmdline_normal"
+            )
+        }
+        switch (true) {
+            case this._oni.menu.isMenuOpen():
+                return "menu"
+            case this._oni.sidebar.isFocused:
+                return this._oni.sidebar.activeEntryId
+            case isInsertOrCommandMode():
+                return "commandline"
+            default:
+                return null
+        }
+    }
 }
 
 /**
@@ -184,7 +203,8 @@ export class Oni implements OniApi.Plugin.Api {
         return getWorkspaceInstance()
     }
 
-    public get helpers(): any {
+    public get helpers(): Helpers {
+        const helpers = new Helpers(this)
         return helpers
     }
 

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -52,27 +52,8 @@ export class Dependencies {
     }
 }
 
-class Helpers {
-    constructor(private _oni: OniApi.Plugin.Api) {}
-    throttle = throttle
-    public getActiveSection() {
-        const isInsertOrCommandMode = () => {
-            return (
-                this._oni.editors.activeEditor.mode === "insert" ||
-                this._oni.editors.activeEditor.mode === "cmdline_normal"
-            )
-        }
-        switch (true) {
-            case this._oni.menu.isMenuOpen():
-                return "menu"
-            case this._oni.sidebar.isFocused:
-                return this._oni.sidebar.activeEntryId
-            case isInsertOrCommandMode():
-                return "commandline"
-            default:
-                return null
-        }
-    }
+const helpers = {
+    throttle,
 }
 
 /**
@@ -203,8 +184,26 @@ export class Oni implements OniApi.Plugin.Api {
         return getWorkspaceInstance()
     }
 
-    public get helpers(): Helpers {
-        const helpers = new Helpers(this)
+    public getActiveSection() {
+        const isInsertOrCommandMode = () => {
+            return (
+                this.editors.activeEditor.mode === "insert" ||
+                this.editors.activeEditor.mode === "cmdline_normal"
+            )
+        }
+        switch (true) {
+            case this.menu.isMenuOpen():
+                return "menu"
+            case this.sidebar && this.sidebar.isFocused:
+                return this.sidebar.activeEntryId
+            case isInsertOrCommandMode():
+                return "commandline"
+            default:
+                return "editor"
+        }
+    }
+
+    public get helpers() {
         return helpers
     }
 

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -184,6 +184,20 @@ export class Oni implements OniApi.Plugin.Api {
         return getWorkspaceInstance()
     }
 
+    public get helpers() {
+        return helpers
+    }
+
+    public get search(): OniApi.Search.ISearch {
+        return new Search()
+    }
+
+    constructor() {
+        this._dependencies = new Dependencies()
+        this._ui = new Ui(react)
+        this._services = new Services()
+    }
+
     public getActiveSection() {
         const isInsertOrCommandMode = () => {
             return (
@@ -201,20 +215,6 @@ export class Oni implements OniApi.Plugin.Api {
             default:
                 return "editor"
         }
-    }
-
-    public get helpers() {
-        return helpers
-    }
-
-    public get search(): OniApi.Search.ISearch {
-        return new Search()
-    }
-
-    constructor() {
-        this._dependencies = new Dependencies()
-        this._ui = new Ui(react)
-        this._services = new Services()
     }
 
     public populateQuickFix(entries: OniApi.QuickFixEntry[]): void {

--- a/browser/src/Services/Browser/index.tsx
+++ b/browser/src/Services/Browser/index.tsx
@@ -173,6 +173,13 @@ export const activate = (
         detail: null,
     })
 
+    commandManager.registerCommand({
+        command: "oni.docs.open",
+        execute: () => openUrl("https://onivim.github.io/oni-docs/#/"),
+        name: "Browser: Open Documentation",
+        detail: "Open Oni's Documentation website",
+    })
+
     const getLayerForBuffer = (buffer: Oni.Buffer): BrowserLayer => {
         return (buffer as IBuffer).getLayerById<BrowserLayer>("oni.browser")
     }

--- a/browser/src/Services/Commands/GlobalCommands.ts
+++ b/browser/src/Services/Commands/GlobalCommands.ts
@@ -47,7 +47,7 @@ export const activate = (
 
     const commands = [
         new CallbackCommand("editor.executeVimCommand", null, null, (message: string) => {
-            const neovim = editorManager.activeEditor.neovim
+            const { neovim } = editorManager.activeEditor
             if (message.startsWith(":")) {
                 neovim.command('exec "' + message + '"')
             } else {
@@ -60,16 +60,20 @@ export const activate = (
             multiProcess.openNewWindow(),
         ),
 
+        new CallbackCommand("oni.editor.newFile", "Oni: Create new file", "Create a new file", () =>
+            editorManager.activeEditor.neovim.command("enew!"),
+        ),
+
         new CallbackCommand(
             "oni.editor.maximize",
-            "Maximize Window",
+            "Oni: Maximize Window",
             "Maximize the current window",
             () => remote.getCurrentWindow().maximize(),
         ),
 
         new CallbackCommand(
             "oni.editor.minimize",
-            "Minimize Window",
+            "Oni: Minimize Window",
             "Minimize the current window",
             () => remote.getCurrentWindow().minimize(),
         ),
@@ -80,13 +84,13 @@ export const activate = (
 
         new CallbackCommand(
             "oni.process.cycleNext",
-            "Focus Next Oni",
+            "Oni: Focus Next Oni",
             "Switch to the next running instance of Oni",
             () => multiProcess.focusNextInstance(),
         ),
         new CallbackCommand(
             "oni.process.cyclePrevious",
-            "Focus Previous Oni",
+            "Oni: Focus Previous Oni",
             "Switch to the previous running instance of Oni",
             () => multiProcess.focusPreviousInstance(),
         ),
@@ -114,7 +118,7 @@ export const activate = (
     if (Platform.isMac()) {
         const addToPathCommand = new CallbackCommand(
             "oni.editor.removeFromPath",
-            "Remove from PATH",
+            "Oni: Remove from PATH",
             "Disable executing 'oni' from terminal",
             Platform.removeFromPath,
             () => Platform.isAddedToPath(),
@@ -123,7 +127,7 @@ export const activate = (
 
         const removeFromPathCommand = new CallbackCommand(
             "oni.editor.addToPath",
-            "Add to PATH",
+            "Oni: Add to PATH",
             "Enable executing 'oni' from terminal",
             Platform.addToPath,
             () => !Platform.isAddedToPath(),

--- a/browser/src/Services/VersionControl/VersionControlManager.tsx
+++ b/browser/src/Services/VersionControl/VersionControlManager.tsx
@@ -141,9 +141,11 @@ export class VersionControlManager {
                 )
                 this._sidebar.add("code-fork", vcsPane) // TODO: Refactor API
             }
-
+            // TODO: this should only be active if this is a file under version control
             this._bufferLayerManager.addBufferLayer(
-                () => this._oni.configuration.getValue("experimental.vcs.blame.enabled"),
+                buffer =>
+                    this._oni.configuration.getValue("experimental.vcs.blame.enabled") &&
+                    !!buffer.filePath,
                 buf =>
                     new VersionControlBlameLayer(
                         buf,

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -158,12 +158,10 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
             this._maybeUpdateSelection(props.idToSelect)
         } else if (!selectedId) {
             const newIndex = lastSelectedIndex - 1 || 0
-            if (!selectedId) {
-                this.setState({
-                    lastSelectedIndex: newIndex,
-                    selectedId: this.props.ids[newIndex],
-                })
-            }
+            this.setState({
+                lastSelectedIndex: newIndex,
+                selectedId: this.props.ids[newIndex],
+            })
         }
     }
 

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -40,25 +40,17 @@ export interface IVimNavigatorProps {
 
 export interface IVimNavigatorState {
     selectedId: string
-    lastSelectedIndex: number
 }
 
 export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNavigatorState> {
-    public static defaultProps: Partial<IVimNavigatorProps> = {
-        ids: [],
-    }
-
     private _activeBinding: IMenuBinding = null
     private _activateEvent = new Event<void>()
 
-    public constructor(props: IVimNavigatorProps) {
+    constructor(props: IVimNavigatorProps) {
         super(props)
 
-        const selectedId = props.ids[0] || null
-        const lastSelectedIndex = props.ids.indexOf(selectedId) || 0
         this.state = {
-            selectedId,
-            lastSelectedIndex,
+            selectedId: props.ids && props.ids.length > 0 ? props.ids[0] : null,
         }
     }
 
@@ -87,9 +79,9 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
                     height={12}
                     onActivate={this._activateEvent}
                     onKeyDown={key => this._onKeyDown(key)}
-                    foregroundColor="white"
-                    fontFamily="Segoe UI"
-                    fontSize="12px"
+                    foregroundColor={"white"}
+                    fontFamily={"Segoe UI"}
+                    fontSize={"12px"}
                     fontCharacterWidthInPixels={12}
                 />
             </div>
@@ -153,24 +145,14 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
             this._releaseBinding()
         }
 
-        const { lastSelectedIndex, selectedId } = this.state
         if (props.idToSelect) {
             this._maybeUpdateSelection(props.idToSelect)
-        } else if (!selectedId) {
-            const newIndex = lastSelectedIndex - 1 || 0
-            this.setState({
-                lastSelectedIndex: newIndex,
-                selectedId: this.props.ids[newIndex],
-            })
         }
     }
 
     private _maybeUpdateSelection(id: string) {
         if (id !== this.state.selectedId) {
-            this.setState({
-                selectedId: id,
-                lastSelectedIndex: this.props.ids.indexOf(id),
-            })
+            this.setState({ selectedId: id })
 
             if (this.props.onSelectionChanged) {
                 this.props.onSelectionChanged(id)

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -44,12 +44,12 @@ export interface IVimNavigatorState {
 }
 
 export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNavigatorState> {
-    private _activeBinding: IMenuBinding = null
-    private _activateEvent = new Event<void>()
-
     public static defaultProps: Partial<IVimNavigatorProps> = {
         ids: [],
     }
+
+    private _activeBinding: IMenuBinding = null
+    private _activateEvent = new Event<void>()
 
     public constructor(props: IVimNavigatorProps) {
         super(props)

--- a/browser/src/UI/components/VimNavigator.tsx
+++ b/browser/src/UI/components/VimNavigator.tsx
@@ -40,17 +40,25 @@ export interface IVimNavigatorProps {
 
 export interface IVimNavigatorState {
     selectedId: string
+    lastSelectedIndex: number
 }
 
 export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNavigatorState> {
     private _activeBinding: IMenuBinding = null
     private _activateEvent = new Event<void>()
 
-    constructor(props: IVimNavigatorProps) {
+    public static defaultProps: Partial<IVimNavigatorProps> = {
+        ids: [],
+    }
+
+    public constructor(props: IVimNavigatorProps) {
         super(props)
 
+        const selectedId = props.ids[0] || null
+        const lastSelectedIndex = props.ids.indexOf(selectedId) || 0
         this.state = {
-            selectedId: props.ids && props.ids.length > 0 ? props.ids[0] : null,
+            selectedId,
+            lastSelectedIndex,
         }
     }
 
@@ -79,9 +87,9 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
                     height={12}
                     onActivate={this._activateEvent}
                     onKeyDown={key => this._onKeyDown(key)}
-                    foregroundColor={"white"}
-                    fontFamily={"Segoe UI"}
-                    fontSize={"12px"}
+                    foregroundColor="white"
+                    fontFamily="Segoe UI"
+                    fontSize="12px"
                     fontCharacterWidthInPixels={12}
                 />
             </div>
@@ -145,14 +153,26 @@ export class VimNavigator extends React.PureComponent<IVimNavigatorProps, IVimNa
             this._releaseBinding()
         }
 
+        const { lastSelectedIndex, selectedId } = this.state
         if (props.idToSelect) {
             this._maybeUpdateSelection(props.idToSelect)
+        } else if (!selectedId) {
+            const newIndex = lastSelectedIndex - 1 || 0
+            if (!selectedId) {
+                this.setState({
+                    lastSelectedIndex: newIndex,
+                    selectedId: this.props.ids[newIndex],
+                })
+            }
         }
     }
 
     private _maybeUpdateSelection(id: string) {
         if (id !== this.state.selectedId) {
-            this.setState({ selectedId: id })
+            this.setState({
+                selectedId: id,
+                lastSelectedIndex: this.props.ids.indexOf(id),
+            })
 
             if (this.props.onSelectionChanged) {
                 this.props.onSelectionChanged(id)

--- a/browser/src/UI/components/common.ts
+++ b/browser/src/UI/components/common.ts
@@ -77,11 +77,21 @@ export const StackLayer = styled<{ zIndex?: number | string }, "div">("div")`
     ${p => p.zIndex && `z-index: ${p.zIndex}`};
 `
 
+type GetBorder = (
+    args: {
+        isSelected?: boolean
+        borderSize?: string
+        theme?: styledComponents.ThemeProps<IThemeColors>
+    },
+) => string
+
+export const getSelectedBorder: GetBorder = ({ isSelected, borderSize = "1px", theme }) =>
+    isSelected
+        ? `${borderSize} solid ${theme["highlight.mode.normal.background"]}`
+        : `1px solid transparent`
+
 export const sidebarItemSelected = css`
-    border: ${(p: { isSelected?: boolean; theme?: styledComponents.ThemeProps<IThemeColors> }) =>
-        p.isSelected
-            ? `1px solid ${p.theme["highlight.mode.normal.background"]}`
-            : `1px solid transparent`};
+    border: ${getSelectedBorder};
 `
 
 export type StyledFunction<T> = styledComponents.ThemedStyledFunction<T, IThemeColors>

--- a/browser/src/UI/components/common.ts
+++ b/browser/src/UI/components/common.ts
@@ -88,7 +88,7 @@ type GetBorder = (
 export const getSelectedBorder: GetBorder = ({ isSelected, borderSize = "1px", theme }) =>
     isSelected
         ? `${borderSize} solid ${theme["highlight.mode.normal.background"]}`
-        : `1px solid transparent`
+        : `${borderSize} solid transparent`
 
 export const sidebarItemSelected = css`
     border: ${getSelectedBorder};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
     "homepage": "https://www.onivim.io",
     "version": "0.3.7",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
-    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
+    "keywords": [
+        "vim",
+        "neovim",
+        "text",
+        "editor",
+        "ide",
+        "vim"
+    ],
     "main": "./lib/main/src/main.js",
     "bin": {
         "oni": "./lib/cli/src/cli.js",
@@ -43,23 +50,39 @@
         "mac": {
             "artifactName": "${productName}-${version}-osx.${ext}",
             "category": "public.app-category.developer-tools",
-            "target": ["dmg"],
-            "files": ["bin/osx/**/*"]
+            "target": [
+                "dmg"
+            ],
+            "files": [
+                "bin/osx/**/*"
+            ]
         },
         "linux": {
             "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
             "maintainer": "bryphe@outlook.com",
-            "target": ["tar.gz", "deb", "rpm"]
+            "target": [
+                "tar.gz",
+                "deb",
+                "rpm"
+            ]
         },
         "win": {
-            "target": ["zip", "dir"],
-            "files": ["bin/x86/**/*"]
+            "target": [
+                "zip",
+                "dir"
+            ],
+            "files": [
+                "bin/x86/**/*"
+            ]
         },
         "fileAssociations": [
             {
                 "name": "ADA source",
                 "role": "Editor",
-                "ext": ["adb", "ads"]
+                "ext": [
+                    "adb",
+                    "ads"
+                ]
             },
             {
                 "name": "Compiled AppleScript",
@@ -79,12 +102,20 @@
             {
                 "name": "ASP document",
                 "role": "Editor",
-                "ext": ["asp", "asa"]
+                "ext": [
+                    "asp",
+                    "asa"
+                ]
             },
             {
                 "name": "ASP.NET document",
                 "role": "Editor",
-                "ext": ["aspx", "ascx", "asmx", "ashx"]
+                "ext": [
+                    "aspx",
+                    "ascx",
+                    "asmx",
+                    "ashx"
+                ]
             },
             {
                 "name": "BibTeX bibliography",
@@ -99,7 +130,13 @@
             {
                 "name": "C++ source",
                 "role": "Editor",
-                "ext": ["cc", "cp", "cpp", "cxx", "c++"]
+                "ext": [
+                    "cc",
+                    "cp",
+                    "cpp",
+                    "cxx",
+                    "c++"
+                ]
             },
             {
                 "name": "C# source",
@@ -124,7 +161,10 @@
             {
                 "name": "Clojure source",
                 "role": "Editor",
-                "ext": ["clj", "cljs"]
+                "ext": [
+                    "clj",
+                    "cljs"
+                ]
             },
             {
                 "name": "Comma separated values",
@@ -139,12 +179,20 @@
             {
                 "name": "CGI script",
                 "role": "Editor",
-                "ext": ["cgi", "fcgi"]
+                "ext": [
+                    "cgi",
+                    "fcgi"
+                ]
             },
             {
                 "name": "Configuration file",
                 "role": "Editor",
-                "ext": ["cfg", "conf", "config", "htaccess"]
+                "ext": [
+                    "cfg",
+                    "conf",
+                    "config",
+                    "htaccess"
+                ]
             },
             {
                 "name": "Cascading style sheet",
@@ -169,7 +217,10 @@
             {
                 "name": "Erlang source",
                 "role": "Editor",
-                "ext": ["erl", "hrl"]
+                "ext": [
+                    "erl",
+                    "hrl"
+                ]
             },
             {
                 "name": "F-Script source",
@@ -179,17 +230,32 @@
             {
                 "name": "Fortran source",
                 "role": "Editor",
-                "ext": ["f", "for", "fpp", "f77", "f90", "f95"]
+                "ext": [
+                    "f",
+                    "for",
+                    "fpp",
+                    "f77",
+                    "f90",
+                    "f95"
+                ]
             },
             {
                 "name": "Header",
                 "role": "Editor",
-                "ext": ["h", "pch"]
+                "ext": [
+                    "h",
+                    "pch"
+                ]
             },
             {
                 "name": "C++ header",
                 "role": "Editor",
-                "ext": ["hh", "hpp", "hxx", "h++"]
+                "ext": [
+                    "hh",
+                    "hpp",
+                    "hxx",
+                    "h++"
+                ]
             },
             {
                 "name": "Go source",
@@ -199,17 +265,28 @@
             {
                 "name": "GTD document",
                 "role": "Editor",
-                "ext": ["gtd", "gtdlog"]
+                "ext": [
+                    "gtd",
+                    "gtdlog"
+                ]
             },
             {
                 "name": "Haskell source",
                 "role": "Editor",
-                "ext": ["hs", "lhs"]
+                "ext": [
+                    "hs",
+                    "lhs"
+                ]
             },
             {
                 "name": "HTML document",
                 "role": "Editor",
-                "ext": ["htm", "html", "phtml", "shtml"]
+                "ext": [
+                    "htm",
+                    "html",
+                    "phtml",
+                    "shtml"
+                ]
             },
             {
                 "name": "Include file",
@@ -249,7 +326,10 @@
             {
                 "name": "JavaScript source",
                 "role": "Editor",
-                "ext": ["js", "htc"]
+                "ext": [
+                    "js",
+                    "htc"
+                ]
             },
             {
                 "name": "Java Server Page",
@@ -274,7 +354,14 @@
             {
                 "name": "Lisp source",
                 "role": "Editor",
-                "ext": ["lisp", "cl", "l", "lsp", "mud", "el"]
+                "ext": [
+                    "lisp",
+                    "cl",
+                    "l",
+                    "lsp",
+                    "mud",
+                    "el"
+                ]
             },
             {
                 "name": "Log file",
@@ -294,7 +381,12 @@
             {
                 "name": "Markdown document",
                 "role": "Editor",
-                "ext": ["markdown", "mdown", "markdn", "md"]
+                "ext": [
+                    "markdown",
+                    "mdown",
+                    "markdn",
+                    "md"
+                ]
             },
             {
                 "name": "Makefile source",
@@ -304,17 +396,29 @@
             {
                 "name": "Mediawiki document",
                 "role": "Editor",
-                "ext": ["wiki", "wikipedia", "mediawiki"]
+                "ext": [
+                    "wiki",
+                    "wikipedia",
+                    "mediawiki"
+                ]
             },
             {
                 "name": "MIPS assembler source",
                 "role": "Editor",
-                "ext": ["s", "mips", "spim", "asm"]
+                "ext": [
+                    "s",
+                    "mips",
+                    "spim",
+                    "asm"
+                ]
             },
             {
                 "name": "Modula-3 source",
                 "role": "Editor",
-                "ext": ["m3", "cm3"]
+                "ext": [
+                    "m3",
+                    "cm3"
+                ]
             },
             {
                 "name": "MoinMoin document",
@@ -334,17 +438,28 @@
             {
                 "name": "OCaml source",
                 "role": "Editor",
-                "ext": ["ml", "mli", "mll", "mly"]
+                "ext": [
+                    "ml",
+                    "mli",
+                    "mll",
+                    "mly"
+                ]
             },
             {
                 "name": "Mustache document",
                 "role": "Editor",
-                "ext": ["mustache", "hbs"]
+                "ext": [
+                    "mustache",
+                    "hbs"
+                ]
             },
             {
                 "name": "Pascal source",
                 "role": "Editor",
-                "ext": ["pas", "p"]
+                "ext": [
+                    "pas",
+                    "p"
+                ]
             },
             {
                 "name": "Patch file",
@@ -354,7 +469,11 @@
             {
                 "name": "Perl source",
                 "role": "Editor",
-                "ext": ["pl", "pod", "perl"]
+                "ext": [
+                    "pl",
+                    "pod",
+                    "perl"
+                ]
             },
             {
                 "name": "Perl module",
@@ -364,47 +483,80 @@
             {
                 "name": "PHP source",
                 "role": "Editor",
-                "ext": ["php", "php3", "php4", "php5"]
+                "ext": [
+                    "php",
+                    "php3",
+                    "php4",
+                    "php5"
+                ]
             },
             {
                 "name": "PostScript source",
                 "role": "Editor",
-                "ext": ["ps", "eps"]
+                "ext": [
+                    "ps",
+                    "eps"
+                ]
             },
             {
                 "name": "Property list",
                 "role": "Editor",
-                "ext": ["dict", "plist", "scriptSuite", "scriptTerminology"]
+                "ext": [
+                    "dict",
+                    "plist",
+                    "scriptSuite",
+                    "scriptTerminology"
+                ]
             },
             {
                 "name": "Python source",
                 "role": "Editor",
-                "ext": ["py", "rpy", "cpy", "python"]
+                "ext": [
+                    "py",
+                    "rpy",
+                    "cpy",
+                    "python"
+                ]
             },
             {
                 "name": "R source",
                 "role": "Editor",
-                "ext": ["r", "s"]
+                "ext": [
+                    "r",
+                    "s"
+                ]
             },
             {
                 "name": "Ragel source",
                 "role": "Editor",
-                "ext": ["rl", "ragel"]
+                "ext": [
+                    "rl",
+                    "ragel"
+                ]
             },
             {
                 "name": "Remind document",
                 "role": "Editor",
-                "ext": ["rem", "remind"]
+                "ext": [
+                    "rem",
+                    "remind"
+                ]
             },
             {
                 "name": "reStructuredText document",
                 "role": "Editor",
-                "ext": ["rst", "rest"]
+                "ext": [
+                    "rst",
+                    "rest"
+                ]
             },
             {
                 "name": "HTML with embedded Ruby",
                 "role": "Editor",
-                "ext": ["rhtml", "erb"]
+                "ext": [
+                    "rhtml",
+                    "erb"
+                ]
             },
             {
                 "name": "SQL with embedded Ruby",
@@ -414,17 +566,28 @@
             {
                 "name": "Ruby source",
                 "role": "Editor",
-                "ext": ["rb", "rbx", "rjs", "rxml"]
+                "ext": [
+                    "rb",
+                    "rbx",
+                    "rjs",
+                    "rxml"
+                ]
             },
             {
                 "name": "Sass source",
                 "role": "Editor",
-                "ext": ["sass", "scss"]
+                "ext": [
+                    "sass",
+                    "scss"
+                ]
             },
             {
                 "name": "Scheme source",
                 "role": "Editor",
-                "ext": ["scm", "sch"]
+                "ext": [
+                    "scm",
+                    "sch"
+                ]
             },
             {
                 "name": "Setext document",
@@ -472,7 +635,10 @@
             {
                 "name": "SWIG source",
                 "role": "Editor",
-                "ext": ["i", "swg"]
+                "ext": [
+                    "i",
+                    "swg"
+                ]
             },
             {
                 "name": "Tcl source",
@@ -482,12 +648,20 @@
             {
                 "name": "TeX document",
                 "role": "Editor",
-                "ext": ["tex", "sty", "cls"]
+                "ext": [
+                    "tex",
+                    "sty",
+                    "cls"
+                ]
             },
             {
                 "name": "Plain text document",
                 "role": "Editor",
-                "ext": ["text", "txt", "utf8"]
+                "ext": [
+                    "text",
+                    "txt",
+                    "utf8"
+                ]
             },
             {
                 "name": "Textile document",
@@ -507,17 +681,32 @@
             {
                 "name": "XML document",
                 "role": "Editor",
-                "ext": ["xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml"]
+                "ext": [
+                    "xml",
+                    "xsd",
+                    "xib",
+                    "rss",
+                    "tld",
+                    "pt",
+                    "cpt",
+                    "dtml"
+                ]
             },
             {
                 "name": "XSL stylesheet",
                 "role": "Editor",
-                "ext": ["xsl", "xslt"]
+                "ext": [
+                    "xsl",
+                    "xslt"
+                ]
             },
             {
                 "name": "Electronic business card",
                 "role": "Editor",
-                "ext": ["vcf", "vcard"]
+                "ext": [
+                    "vcf",
+                    "vcard"
+                ]
             },
             {
                 "name": "Visual Basic source",
@@ -527,7 +716,10 @@
             {
                 "name": "YAML document",
                 "role": "Editor",
-                "ext": ["yaml", "yml"]
+                "ext": [
+                    "yaml",
+                    "yml"
+                ]
             },
             {
                 "name": "Text document",
@@ -589,10 +781,8 @@
     "scripts": {
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
-        "build":
-            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
-        "build-debug":
-            "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
+        "build": "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
+        "build-debug": "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
         "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
         "build:main": "cd main && tsc -p tsconfig.json",
@@ -600,92 +790,65 @@
         "build:cli": "cd cli && tsc -p tsconfig.json",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
         "build:plugin:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn run build",
-        "build:plugin:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn run build",
+        "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:plugin:oni-plugin-quickopen": "cd extensions/oni-plugin-quickopen && yarn run build",
         "build:test": "yarn run build:test:unit && yarn run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "run-s build:test:unit:*",
-        "build:test:unit:browser":
-            "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit:browser": "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
         "build:test:unit:main": "rimraf lib_test/main && cd main && tsc -p tsconfig.test.json",
         "build:webview_preload": "cd webview_preload && tsc -p tsconfig.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
-        "debug:test:unit:browser":
-            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "demo:screenshot":
-            "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
-        "demo:video":
-            "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
-        "dist:win:x86":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-        "dist:win:x64":
-            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
-        "pack:win":
-            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo:screenshot": "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
+        "demo:video": "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
+        "dist:win:x86": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "dist:win:x64": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
+        "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "yarn run test:unit && yarn run test:integration",
-        "test:setup":
-            "yarn run build:test:integration && mocha -t 120000 --recursive lib_test/test/setup",
-        "test:integration":
-            "yarn run build:test:integration && mocha -t 120000 lib_test/test/CiTests.js --bail",
+        "test:setup": "yarn run build:test:integration && mocha -t 120000 --recursive lib_test/test/setup",
+        "test:integration": "yarn run build:test:integration && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:unit:react": "jest --config ./jest.config.js ./ui-tests",
         "test:unit:react:watch": "jest --config ./jest.config.js ./ui-tests --watch",
         "test:unit:react:coverage": "jest --config ./jest.config.js ./ui-tests --coverage",
-        "test:unit:browser":
-            "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "test:unit":
-            "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:unit:react",
-        "test:unit:main":
-            "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
+        "test:unit:browser": "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "test:unit": "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:unit:react",
+        "test:unit:main": "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
         "upload:dist": "node build/script/UploadDistributionBuildsToAzure",
         "fix-lint": "run-p fix-lint:*",
-        "fix-lint:browser":
-            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "fix-lint:cli": "tslint --fix --project cli/tsconfig.json --config tslint.json",
         "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
         "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
         "lint": "yarn run lint:browser && yarn run lint:main && yarn run lint:test",
-        "lint:browser":
-            "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "lint:cli": "tslint --project cli/tsconfig.json --config tslint.json",
         "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-        "lint:test":
-            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "ccov:instrument":
-            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-        "ccov:test:browser":
-            "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
-        "ccov:remap:browser:html":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
-        "ccov:remap:browser:lcov":
-            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
+        "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser": "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
+        "ccov:remap:browser:html": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
+        "ccov:remap:browser:lcov": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
         "ccov:clean": "rimraf coverage",
         "ccov:upload:jest": "cd ./coverage/jest && codecov",
         "ccov:upload": "codecov",
         "launch": "electron lib/main/src/main.js",
-        "start":
-            "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
-        "start-hot":
-            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start": "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
+        "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
         "start-not-dev": "cross-env electron main.js",
-        "watch:browser":
-            "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
+        "watch:browser": "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
         "watch:plugins": "run-p --race watch:plugins:*",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-        "watch:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
         "watch:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && tsc --watch",
         "install:plugins": "run-s install:plugins:*",
-        "install:plugins:oni-plugin-markdown-preview":
-            "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
-        "install:plugins:oni-plugin-prettier":
-            "cd extensions/oni-plugin-prettier && yarn install --prod",
+        "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-prettier": "cd extensions/oni-plugin-prettier && yarn install --prod",
         "install:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn install --prod",
         "postinstall": "yarn run install:plugins && electron-rebuild && opencollective postinstall",
-        "profile:webpack":
-            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
+        "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
     "repository": {
         "type": "git",
@@ -718,7 +881,7 @@
         "shell-env": "^0.3.0",
         "shelljs": "0.7.7",
         "simple-git": "^1.92.0",
-        "styled-components": "^3.2.6",
+        "styled-components": "^3.4.4",
         "typescript": "^2.8.1",
         "vscode-css-languageserver-bin": "^1.2.1",
         "vscode-html-languageserver-bin": "^1.1.0",

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -24,6 +24,8 @@ const CiTests = [
     "Configuration.TypeScriptEditor.NewConfigurationTest",
     "Configuration.TypeScriptEditor.CompletionTest",
 
+    "Welcome.BufferLayerTest",
+
     "TabBarSneakTest",
     "initVimPromptNotificationTest",
     "Editor.BuffersCursorTest",

--- a/test/ci/Welcome.BufferLayerTest.ts
+++ b/test/ci/Welcome.BufferLayerTest.ts
@@ -7,16 +7,25 @@ import * as os from "os"
 import * as path from "path"
 
 import * as Oni from "oni-api"
-
-const getWelcomeElement = () => document.querySelectorAll("[data-id='welcome-screen']")
+import { getSingleElementBySelector } from "./Common"
 
 export const test = async (oni: Oni.Plugin.Api) => {
     await oni.automation.waitForEditors()
-    await oni.automation.sleep(1000)
+    await oni.automation.sleep(2000)
 
-    const element = getWelcomeElement()
+    const element = getSingleElementBySelector("[data-id='welcome-screen']")
 
-    assert.ok(element[0], "Validate the welcome screen is present")
+    assert.ok(!!element, "Validate the welcome screen is present")
+
+    assert.ok(
+        oni.editors.activeEditor.activeBuffer.filePath.includes("WELCOME"),
+        "Validate that the current buffer is the Welcome one",
+    )
+    oni.automation.sendKeys("<enter>")
+    assert.ok(
+        !!oni.editors.activeEditor.activeBuffer.filePath,
+        "Validate it opens empty unnamed new file",
+    )
 }
 
 export const settings = {

--- a/test/ci/Welcome.BufferLayerTest.ts
+++ b/test/ci/Welcome.BufferLayerTest.ts
@@ -1,0 +1,29 @@
+/**
+ * Test script for the Welcome Screen Buffer Layer.
+ */
+
+import * as assert from "assert"
+import * as os from "os"
+import * as path from "path"
+
+import * as Oni from "oni-api"
+
+const getWelcomeElement = () => document.querySelectorAll("[data-id='welcome-screen']")
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    await oni.automation.waitForEditors()
+    await oni.automation.sleep(1000)
+
+    const element = getWelcomeElement()
+
+    assert.ok(element[0], "Validate the welcome screen is present")
+}
+
+export const settings = {
+    config: {
+        "oni.useDefaultConfig": true,
+        "oni.loadInitVim": false,
+        "experimental.welcome.enabled": true,
+        "_internal.hasCheckedInitVim": true,
+    },
+}

--- a/ui-tests/BufferManager.test.ts
+++ b/ui-tests/BufferManager.test.ts
@@ -4,16 +4,7 @@ describe("Buffer Manager Tests", () => {
     const neovim = {} as any
     const actions = {} as any
     const store = {
-        getState: jest.fn().mockReturnValue({
-            layers: {
-                "1": [
-                    {
-                        handleInput: (key: string) => true,
-                        isActive: () => true,
-                    },
-                ],
-            },
-        }),
+        getState: jest.fn(),
     } as any
 
     const manager = new BufferManager(neovim, actions, store)
@@ -88,8 +79,35 @@ describe("Buffer Manager Tests", () => {
     })
 
     it("should correctly pass input to a layer that implements a handler", () => {
+        store.getState.mockReturnValue({
+            layers: {
+                "1": [
+                    {
+                        handleInput: (key: string) => true,
+                        isActive: () => true,
+                    },
+                ],
+            },
+        })
+
         const buffer = manager.getBufferById("1")
         const canHandleInput = buffer.handleInput("h")
         expect(canHandleInput).toBeTruthy()
+    })
+
+    it("should not intercept input for a layer that implements a handler but return isActive = false", () => {
+        store.getState.mockReturnValue({
+            layers: {
+                "1": [
+                    {
+                        handleInput: (key: string) => true,
+                        isActive: () => false,
+                    },
+                ],
+            },
+        })
+        const buffer = manager.getBufferById("1")
+        const canHandleInput = buffer.handleInput("h")
+        expect(canHandleInput).toBeFalsy()
     })
 })

--- a/ui-tests/BufferManager.test.ts
+++ b/ui-tests/BufferManager.test.ts
@@ -95,7 +95,23 @@ describe("Buffer Manager Tests", () => {
         expect(canHandleInput).toBeTruthy()
     })
 
-    it("should not intercept input for a layer that implements a handler but return isActive = false", () => {
+    it("should not allow handling of input if isActive does not exist on the layer", () => {
+        store.getState.mockReturnValue({
+            layers: {
+                "1": [
+                    {
+                        handleInput: (key: string) => true,
+                    },
+                ],
+            },
+        })
+
+        const buffer = manager.getBufferById("1")
+        const canHandleInput = buffer.handleInput("h")
+        expect(canHandleInput).toBeFalsy()
+    })
+
+    it("should not intercept input for a layer that implements a handler but returns isActive = false", () => {
         store.getState.mockReturnValue({
             layers: {
                 "1": [

--- a/ui-tests/WelcomeCommandsView.test.tsx
+++ b/ui-tests/WelcomeCommandsView.test.tsx
@@ -1,0 +1,68 @@
+import { shallow } from "enzyme"
+import toJson from "enzyme-to-json"
+
+import * as React from "react"
+
+import {
+    WelcomeButton,
+    WelcomeCommandsView,
+} from "./../browser/src/Editor/NeovimEditor/WelcomeBufferLayer"
+
+describe("Welcome Layer test", () => {
+    const buttons = [
+        "button1",
+        "button2",
+        "button3",
+        "button4",
+        "button5",
+        "button6",
+        "button7",
+        "button8",
+    ]
+
+    const commands = {
+        openFile: { command: "button1" },
+        openTutor: { command: "button2" },
+        openDocs: { command: "button3" },
+        openConfig: { command: "button4" },
+        openThemes: { command: "button5" },
+        openWorkspaceFolder: { command: "button6" },
+        commandPalette: { command: "button7" },
+        commandline: { command: "button8" },
+    }
+    const executeMock = jest.fn()
+    it("should render without crashing", () => {
+        const wrapper = shallow(
+            <WelcomeCommandsView
+                selectedId="button1"
+                active
+                commands={commands}
+                executeCommand={executeMock}
+            />,
+        )
+        expect(wrapper.length).toBe(1)
+    })
+
+    it("should match last snapshot on record", () => {
+        const wrapper = shallow(
+            <WelcomeCommandsView
+                selectedId="button1"
+                active
+                commands={commands}
+                executeCommand={executeMock}
+            />,
+        )
+        expect(toJson(wrapper)).toMatchSnapshot()
+    })
+    it("should have the correct number of buttons for each commands", () => {
+        const wrapper = shallow(
+            <WelcomeCommandsView
+                selectedId="button1"
+                active
+                commands={commands}
+                executeCommand={executeMock}
+            />,
+        )
+        expect(wrapper.dive().find(WelcomeButton).length).toBe(Object.values(commands).length)
+    })
+})

--- a/ui-tests/WelcomeView.test.tsx
+++ b/ui-tests/WelcomeView.test.tsx
@@ -79,4 +79,9 @@ describe("<WelcomeView />", () => {
         expect(instance.state.currentIndex).toBe(0)
         expect(instance.state.selectedId).toBe("button1")
     })
+
+    it("should trigger a command on enter event", () => {
+        instance.handleInput({ direction: 0, select: true })
+        expect(executeCommand.mock.calls[0][0]).toBe("button1")
+    })
 })

--- a/ui-tests/WelcomeView.test.tsx
+++ b/ui-tests/WelcomeView.test.tsx
@@ -1,0 +1,82 @@
+import { mount } from "enzyme"
+import { Event } from "oni-types"
+import * as React from "react"
+
+import {
+    WelcomeView,
+    WelcomeViewProps,
+    WelcomeViewState,
+    IWelcomeInputEvent,
+} from "./../browser/src/Editor/NeovimEditor/WelcomeBufferLayer"
+
+describe("<WelcomeView />", () => {
+    const buttons = [
+        "button1",
+        "button2",
+        "button3",
+        "button4",
+        "button5",
+        "button6",
+        "button7",
+        "button8",
+    ]
+
+    const commands = {
+        openFile: "button1",
+        openTutor: "button2",
+        openDocs: "button3",
+        openConfig: "button4",
+        openThemes: "button5",
+        openWorkspaceFolder: "button6",
+        commandPalette: "button7",
+        commandline: "button8",
+    }
+
+    const executeCommand = jest.fn()
+    const inputEvent = new Event<IWelcomeInputEvent>("handleInputTestEvent")
+    let handleInputSpy: jest.SpyInstance<WelcomeView["handleInput"]>
+
+    afterEach(() => {
+        if (handleInputSpy) {
+            handleInputSpy.mockClear()
+        }
+        instance.setState({ selectedId: "button1", currentIndex: 0 })
+    })
+
+    const wrapper = mount<WelcomeViewProps, WelcomeViewState>(
+        <WelcomeView
+            active
+            buttonIds={buttons}
+            inputEvent={inputEvent}
+            commands={commands}
+            executeCommand={executeCommand}
+        />,
+    )
+    const instance = wrapper.instance() as WelcomeView
+
+    it("Should render without crashing", () => {
+        expect(wrapper.length).toBe(1)
+    })
+
+    it("should default initial state to the first button id", () => {
+        expect(instance.state.selectedId).toBe("button1")
+    })
+
+    it("should correctly update selection based on input", () => {
+        instance.handleInput({ direction: 1, select: false })
+        expect(instance.state.selectedId).toBe("button2")
+    })
+
+    it("should loop back to button if user navigates upwards at the first button", () => {
+        instance.handleInput({ direction: -1, select: false })
+        expect(instance.state.currentIndex).toBe(7)
+        expect(instance.state.selectedId).toBe("button8")
+    })
+
+    it("should loop back to button if user navigates downwards at the last button", () => {
+        instance.setState({ currentIndex: 7, selectedId: "button8" })
+        instance.handleInput({ direction: 1, select: false })
+        expect(instance.state.currentIndex).toBe(0)
+        expect(instance.state.selectedId).toBe("button1")
+    })
+})

--- a/ui-tests/WelcomeView.test.tsx
+++ b/ui-tests/WelcomeView.test.tsx
@@ -22,14 +22,14 @@ describe("<WelcomeView />", () => {
     ]
 
     const commands = {
-        openFile: "button1",
-        openTutor: "button2",
-        openDocs: "button3",
-        openConfig: "button4",
-        openThemes: "button5",
-        openWorkspaceFolder: "button6",
-        commandPalette: "button7",
-        commandline: "button8",
+        openFile: { command: "button1" },
+        openTutor: { command: "button2" },
+        openDocs: { command: "button3" },
+        openConfig: { command: "button4" },
+        openThemes: { command: "button5" },
+        openWorkspaceFolder: { command: "button6" },
+        commandPalette: { command: "button7" },
+        commandline: { command: "button8" },
     }
 
     const executeCommand = jest.fn()

--- a/ui-tests/__snapshots__/WelcomeCommandsView.test.tsx.snap
+++ b/ui-tests/__snapshots__/WelcomeCommandsView.test.tsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Welcome Layer test should match last snapshot on record 1`] = `
+<styled.div>
+  <styled.div
+    duration="0.25s"
+  >
+    <styled.div>
+      Quick Commands
+    </styled.div>
+    <WelcomeButton
+      command="button1"
+      description="Control + N"
+      onClick={[Function]}
+      selected={true}
+      title="New File"
+    />
+    <WelcomeButton
+      command="button6"
+      description="Control + O"
+      onClick={[Function]}
+      selected={false}
+      title="Open File / Folder"
+    />
+    <WelcomeButton
+      command="button7"
+      description="Control + Shift + P"
+      onClick={[Function]}
+      selected={false}
+      title="Command Palette"
+    />
+    <WelcomeButton
+      command="editor.openExCommands"
+      description=":"
+      onClick={[Function]}
+      selected={false}
+      title="Vim Ex Commands"
+    />
+  </styled.div>
+  <styled.div
+    duration="0.25s"
+  >
+    <styled.div>
+      Learn
+    </styled.div>
+    <WelcomeButton
+      command="button2"
+      description="Learn modal editing with an interactive tutorial."
+      onClick={[Function]}
+      selected={false}
+      title="Tutor"
+    />
+    <WelcomeButton
+      command="button3"
+      description="Discover what Oni can do for you."
+      onClick={[Function]}
+      selected={false}
+      title="Documentation"
+    />
+  </styled.div>
+  <styled.div
+    duration="0.25s"
+  >
+    <styled.div>
+      Customize
+    </styled.div>
+    <WelcomeButton
+      command="button4"
+      description="Make Oni work the way you want."
+      onClick={[Function]}
+      selected={false}
+      title="Configure"
+    />
+    <WelcomeButton
+      command="button5"
+      description="Choose a theme that works for you."
+      onClick={[Function]}
+      selected={false}
+      title="Themes"
+    />
+  </styled.div>
+</styled.div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7574,9 +7574,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-oni-api@0.0.48:
-  version "0.0.48"
-  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.48.tgz#531bfcbc72eeef48e250ae675cf8e0e0461e906c"
+oni-api@0.0.49:
+  version "0.0.49"
+  resolved "https://registry.yarnpkg.com/oni-api/-/oni-api-0.0.49.tgz#4d2b7c23d63e6306e873d83de148b5f89856bb56"
 
 oni-core-logging@^1.0.0:
   version "1.0.0"
@@ -9992,15 +9992,14 @@ style-loader@0.18.2:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-styled-components@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.2.6.tgz#99e6e75a746bdedd295a17e03dd1493055a1cc3b"
+styled-components@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.4.tgz#dbd2ea6338fb050b5b56783e189434fd7f18eda5"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
     fbjs "^0.8.16"
     hoist-non-react-statics "^2.5.0"
-    is-plain-object "^2.0.1"
     prop-types "^15.5.4"
     react-is "^16.3.1"
     stylis "^3.5.0"


### PR DESCRIPTION
This PR will fix #1413 and #1459 it uses the handle input method on the buffer layers to define a custom input handler for the welcome layer which is fairly simple i.e. `j` and `k` for navigation and `<enter>` to select, this PR also adds a method to the oni api called `getActiveSection` which returns a string representing the active section of the editor e.g. the particular sidebar element or the menu or commandline

Outstanding

- [x] Hide cursor when welcome is active
- [x] Fix welcome commands (some...)
- [x] Allow `enter` key passthrough
- [x] Add tests

~add sessions to welcome screen~ leave for another PR