### PR TITLE
Add commands to jump to previous/next error

### DIFF
--- a/browser/src/Services/Diagnostics/index.ts
+++ b/browser/src/Services/Diagnostics/index.ts
@@ -1,5 +1,5 @@
 /**
- * Diagnostics.ts
+ * Diagnostics/index.ts
  *
  * Integrates the `textDocument/publishDiagnostics` protocol with Oni's UI
  */
@@ -9,11 +9,11 @@ import * as types from "vscode-languageserver-types"
 
 import { Event, IEvent } from "oni-types"
 
-import { ILanguageServerNotificationResponse, LanguageManager } from "./Language"
+import { ILanguageServerNotificationResponse, LanguageManager } from "../Language"
 
-import * as Helpers from "./../Plugins/Api/LanguageClient/LanguageClientHelpers"
+import * as Helpers from "../../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
-import * as Utility from "./../Utility"
+import * as Utility from "../../Utility"
 
 interface IPublishDiagnosticsParams {
     uri: string

--- a/browser/src/Services/Diagnostics/navigateErrors.ts
+++ b/browser/src/Services/Diagnostics/navigateErrors.ts
@@ -1,0 +1,83 @@
+/**
+ * navigateErrors.ts
+ *
+ * Functions to jump to previous/next diagnostic error in the active buffer
+ */
+import { isInRange } from "./../../Utility"
+import { getAllErrorsForFile, getInstance as getDiagnosticsInstance } from "./../Diagnostics"
+import { editorManager } from "./../EditorManager"
+
+export const gotoNextError = async () => {
+    const errors = getDiagnosticsInstance().getErrors()
+    const activeBuffer = editorManager.activeEditor.activeBuffer
+    const currentFileErrors = getAllErrorsForFile(activeBuffer.filePath, errors)
+    const currentPosition = activeBuffer.cursor
+
+    if (!currentFileErrors) {
+        return
+    }
+
+    for (const error of currentFileErrors) {
+        if (isInRange(currentPosition.line, currentPosition.column, error.range)) {
+            continue
+        }
+
+        const currentLine = (await activeBuffer.getLines(currentPosition.line))[0]
+        if (
+            currentPosition.line === error.range.start.line &&
+            currentLine.length <= error.range.start.character
+        ) {
+            continue
+        }
+
+        if (
+            error.range.start.line > currentPosition.line ||
+            (error.range.start.line === currentPosition.line &&
+                error.range.start.character > currentPosition.column)
+        ) {
+            await activeBuffer.setCursorPosition(
+                error.range.start.line,
+                error.range.start.character,
+            )
+            return
+        }
+    }
+
+    await activeBuffer.setCursorPosition(
+        currentFileErrors[0].range.start.line,
+        currentFileErrors[0].range.start.character,
+    )
+}
+
+export const gotoPreviousError = async () => {
+    const errors = getDiagnosticsInstance().getErrors()
+    const activeBuffer = editorManager.activeEditor.activeBuffer
+    const currentFileErrors = getAllErrorsForFile(activeBuffer.filePath, errors)
+    const currentPosition = activeBuffer.cursor
+
+    if (!currentFileErrors) {
+        return
+    }
+
+    let lastError = currentFileErrors[currentFileErrors.length - 1]
+    for (const error of currentFileErrors) {
+        if (
+            isInRange(currentPosition.line, currentPosition.column, error.range) ||
+            error.range.start.line > currentPosition.line ||
+            (error.range.start.line === currentPosition.line &&
+                error.range.start.character > currentPosition.column)
+        ) {
+            await activeBuffer.setCursorPosition(
+                lastError.range.start.line,
+                lastError.range.start.character,
+            )
+            return
+        }
+        lastError = error
+    }
+
+    await activeBuffer.setCursorPosition(
+        lastError.range.start.line,
+        lastError.range.start.character,
+    )
+}

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -33,6 +33,7 @@ const CiTests = [
     "Editor.ScrollEventTest",
     "Editor.TabModifiedState",
     "Editor.CloseTabWithTabModesTabsTest",
+    "Editor.NextPreviousErrorTest",
     "Explorer.LocateBufferTest",
     "MarkdownPreviewTest",
     "PrettierPluginTest",

--- a/test/ci/Editor.NextPreviousErrorTest.ts
+++ b/test/ci/Editor.NextPreviousErrorTest.ts
@@ -122,5 +122,5 @@ helloWrld()
     `.trim()
 
     fs.writeFileSync(filePath, content)
-    return filePath
+    return filePath.replace(/\\/g, "/")
 }

--- a/test/ci/Editor.NextPreviousErrorTest.ts
+++ b/test/ci/Editor.NextPreviousErrorTest.ts
@@ -1,0 +1,126 @@
+/**
+ * Test that you can jump to the next/previous error
+ */
+import * as assert from "assert"
+import * as Oni from "oni-api"
+
+import { createNewFile, getTemporaryFilePath, navigateToFile } from "./Common"
+
+export const test = async (oni: Oni.Plugin.Api) => {
+    const filePath = createBrokenTypescriptFile()
+    await oni.automation.waitForEditors()
+
+    // open file with typescript errors
+    navigateToFile(filePath, oni)
+
+    // modify the buffer to trigger error checking
+    oni.automation.sendKeys("O")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "insert")
+    oni.automation.sendKeys("<esc>")
+    await oni.automation.waitFor(() => oni.editors.activeEditor.mode === "normal")
+
+    // wait for 3 errors to be highlighted
+    await oni.automation.waitFor(() => {
+        // @ts-ignore getErrors() is not exposed in the plugin API
+        const errors = oni.diagnostics.getErrors()
+        return (
+            errors[filePath] &&
+            errors[filePath] &&
+            errors[filePath]["language-typescript"] &&
+            errors[filePath]["language-typescript"].length === 3
+        )
+    })
+
+    // nextError jumps to 1st error
+    oni.commands.executeCommand("oni.editor.nextError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 5 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 0,
+    )
+
+    // nextError jumps to 2nd error
+    oni.commands.executeCommand("oni.editor.nextError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 7 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 7,
+    )
+
+    // nextError jumps to 3rd error
+    oni.commands.executeCommand("oni.editor.nextError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 9 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 0,
+    )
+
+    // nextError jumps back up to 1st error
+    oni.commands.executeCommand("oni.editor.nextError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 5 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 0,
+    )
+
+    // nextError jumps to 2nd error
+    oni.commands.executeCommand("oni.editor.nextError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 7 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 7,
+    )
+
+    // previousError jumps to 1st error
+    oni.commands.executeCommand("oni.editor.previousError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 5 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 0,
+    )
+
+    // previousError jumps back down to 3rd error
+    oni.commands.executeCommand("oni.editor.previousError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 9 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 0,
+    )
+
+    // previousError jumps to 2nd error
+    oni.commands.executeCommand("oni.editor.previousError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 7 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 7,
+    )
+
+    // previousError jumps to 1st error
+    oni.commands.executeCommand("oni.editor.previousError")
+    await oni.automation.waitFor(
+        () =>
+            oni.editors.activeEditor.activeBuffer.cursor.line === 5 &&
+            oni.editors.activeEditor.activeBuffer.cursor.column === 0,
+    )
+}
+
+import * as fs from "fs"
+import * as os from "os"
+
+const createBrokenTypescriptFile = (): string => {
+    const filePath = getTemporaryFilePath("ts")
+    const content = `
+function helloWorld() {
+    console.log('Hello World')
+}
+
+heloWorld()
+helloWorld()
+window.nonExistentThing.goodByeWorld()
+helloWorld()
+helloWrld()
+    `.trim()
+
+    fs.writeFileSync(filePath, content)
+    return filePath
+}


### PR DESCRIPTION
This PR adds `oni.editor.nextError` and `oni.editor.previousError` commands, as discussed in #2514. I have mainly tested this with Typescript.