### PR TITLE
Fix CURRENT_MONTH Snippet variable.

### DIFF
--- a/browser/src/Services/Snippets/SnippetVariableResolver.ts
+++ b/browser/src/Services/Snippets/SnippetVariableResolver.ts
@@ -27,7 +27,7 @@ export class SnippetVariableResolver implements VariableResolver {
             TM_FILEPATH: filePath,
             TM_FILENAME_BASE: path.basename(filePath, path.extname(filePath)),
             CURRENT_YEAR: currentDate.getFullYear().toString(),
-            CURRENT_MONTH: currentDate.getMonth().toString(),
+            CURRENT_MONTH: (currentDate.getMonth() + 1).toString(),
             CURRENT_DATE: currentDate.getDate().toString(),
             CURRENT_HOUR: currentDate.getHours().toString(),
             CURRENT_MINUTE: currentDate.getMinutes().toString(),

--- a/browser/src/Services/Snippets/SnippetVariableResolver.ts
+++ b/browser/src/Services/Snippets/SnippetVariableResolver.ts
@@ -20,18 +20,31 @@ export class SnippetVariableResolver implements VariableResolver {
         const filePath = this._buffer && this._buffer.filePath ? this._buffer.filePath : ""
 
         this._variableToValue = {
-            TM_LINE_INDEX: line.toString(),
-            TM_LINE_NUMBER: (line + 1).toString(),
-            TM_FILENAME: path.basename(filePath),
-            TM_DIRECTORY: path.dirname(filePath),
-            TM_FILEPATH: filePath,
-            TM_FILENAME_BASE: path.basename(filePath, path.extname(filePath)),
             CURRENT_YEAR: currentDate.getFullYear().toString(),
+            CURRENT_YEAR_SHORT: currentDate
+                .getFullYear()
+                .toString()
+                .slice(-2),
             CURRENT_MONTH: (currentDate.getMonth() + 1).toString(),
             CURRENT_DATE: currentDate.getDate().toString(),
             CURRENT_HOUR: currentDate.getHours().toString(),
             CURRENT_MINUTE: currentDate.getMinutes().toString(),
             CURRENT_SECOND: currentDate.getSeconds().toString(),
+            CURRENT_DAY_NAME: currentDate.toLocaleString("en-US", { weekday: "long" }),
+            CURRENT_DAY_NAME_SHORT: currentDate.toLocaleString("en-US", { weekday: "short" }),
+            CURRENT_MONTH_NAME: currentDate.toLocaleString("en-US", { month: "long" }),
+            CURRENT_MONTH_NAME_SHORT: currentDate.toLocaleString("en-US", { month: "short" }),
+            // SELECTION: "",
+            // CLIPBOARD: "",
+            // TM_SELECTED_TEXT: "",
+            // TM_CURRENT_LINE: "",
+            // TM_CURRENT_WORD: "",
+            TM_LINE_INDEX: line.toString(),
+            TM_LINE_NUMBER: (line + 1).toString(),
+            TM_FILENAME: path.basename(filePath),
+            TM_FILENAME_BASE: path.basename(filePath, path.extname(filePath)),
+            TM_DIRECTORY: path.dirname(filePath),
+            TM_FILEPATH: filePath,
         }
     }
 


### PR DESCRIPTION
This fixes the current month snippet variable, since its zero indexed. Having the month be one less than expected is a bit odd, so I brought it [inline with VSCode](https://github.com/Microsoft/vscode/blob/4e4e6f9b44dd9e6a53d1f08565c52b8ea9f61a5e/src/vs/editor/contrib/snippet/snippetVariables.ts#L201) (which the snippet provider is from).

I also added the other date based variables, and some placeholders for the others. I'm not sure if we will need them, and they are a bit more involved, so I left them for now. I also swapped the order around so it matches VSCode code base, which makes comparing a little easier.