### PR TITLE
Hook up showing files in hidden folders in QuickOpen.

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -145,6 +145,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.quickOpen.filterStrategy": "vscode",
     "editor.quickOpen.defaultOpenMode": Oni.FileOpenMode.Edit,
     "editor.quickOpen.alternativeOpenMode": Oni.FileOpenMode.ExistingTab,
+    "editor.quickOpen.showHidden": false,
 
     "editor.split.mode": "native",
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -145,7 +145,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.quickOpen.filterStrategy": "vscode",
     "editor.quickOpen.defaultOpenMode": Oni.FileOpenMode.Edit,
     "editor.quickOpen.alternativeOpenMode": Oni.FileOpenMode.ExistingTab,
-    "editor.quickOpen.showHidden": false,
+    "editor.quickOpen.showHidden": true,
 
     "editor.split.mode": "native",
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -163,6 +163,7 @@ export interface IConfigurationValues {
     "editor.quickInfo.delay": number
     "editor.quickOpen.defaultOpenMode": Oni.FileOpenMode
     "editor.quickOpen.alternativeOpenMode": Oni.FileOpenMode
+    "editor.quickOpen.showHidden": boolean
 
     "editor.errors.slideOnFocus": boolean
     "editor.formatting.formatOnSwitchToNormalMode": boolean // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun

--- a/browser/src/Services/Search/RipGrep.ts
+++ b/browser/src/Services/Search/RipGrep.ts
@@ -16,11 +16,12 @@ export function getCommand(): string {
     return '"' + path.join(rootPath, executableName) + '"'
 }
 
-export function getArguments(excludePaths: string[]): string[] {
+export function getArguments(excludePaths: string[], shouldShowHidden: boolean): string[] {
     const ignoreArguments = excludePaths.reduce((prev, cur) => {
         return prev.concat(["-g", "!" + cur])
     }, [])
 
-    // TODO: Add option to enable "--hidden"
-    return ["--vimgrep"].concat(ignoreArguments)
+    const showHidden = shouldShowHidden ? ["--hidden"] : []
+
+    return ["--vimgrep"].concat(showHidden, ignoreArguments)
 }

--- a/browser/src/Services/Search/SearchProvider.ts
+++ b/browser/src/Services/Search/SearchProvider.ts
@@ -32,7 +32,10 @@ export class Search implements Oni.Search.ISearch {
         const commandParts = [
             RipGrep.getCommand(),
             "--ignore-case",
-            ...RipGrep.getArguments(configuration.getValue("oni.exclude")),
+            ...RipGrep.getArguments(
+                configuration.getValue("oni.exclude"),
+                configuration.getValue("editor.quickOpen.showHidden"),
+            ),
             // "-e",
             ...(opts.fileFilter ? ["-g", opts.fileFilter] : []),
             "--",
@@ -45,7 +48,10 @@ export class Search implements Oni.Search.ISearch {
     public findInPath(opts: Oni.Search.Options): Oni.Search.Query {
         const commandParts = [
             RipGrep.getCommand(),
-            ...RipGrep.getArguments(configuration.getValue("oni.exclude")),
+            ...RipGrep.getArguments(
+                configuration.getValue("oni.exclude"),
+                configuration.getValue("editor.quickOpen.showHidden"),
+            ),
             "--files",
             "--",
             opts.workspace ? opts.workspace : ".",


### PR DESCRIPTION
This adds a flag for showing hidden files, and files in hidden folders.

By default, you can't see any hidden files, nor any files in hidden folders which can be a pain, since for example in my dotfiles, most of the files are stored in "hidden" folders, such as `.config` folders.

I've left it to disabled for now, but we may want to just always show them?