### PR TITLE
Feature/nightowl theme

### DIFF
--- a/extensions/theme-night-owl/colors/night-owl.json
+++ b/extensions/theme-night-owl/colors/night-owl.json
@@ -12,7 +12,7 @@
         "editor.background": "#011627",
         "editor.foreground": "#d6deeb",
 
-        "tabs.background": "#0b2942",
+        "tabs.background": "#010e1a",
         "tabs.foreground": "#d2dee7",
 
         "toolTip.background": "#011627",
@@ -20,28 +20,28 @@
         "toolTip.border": "#5f7e97",
 
         "menu.background": "#011627",
-        "menu.foreground": "#ffffffcc",
+        "menu.foreground": "#ffffff",
         "menu.border": "#5f7e97",
 
         "contextMenu.background": "#5f7e97",
-        "contextMenu.foreground": "#ffffffcc",
-        "contextMenu.border": "",
+        "contextMenu.foreground": "#ffffff",
         "contextMenu.highlight": "#4373c2",
+        "contextMenu.border": "",
 
         "statusBar.background": "#011627",
         "statusBar.foreground": "#676E95",
 
         "highlight.mode.insert.background": "#9CCC65",
-        "highlight.mode.insert.foreground": "#ffffffcc",
+        "highlight.mode.insert.foreground": "#ffffff",
 
         "highlight.mode.normal.background": "#4373c2",
-        "highlight.mode.normal.foreground": "#ffffffcc",
+        "highlight.mode.normal.foreground": "#ffffff",
 
         "highlight.mode.operator.background": "#b294bb",
         "highlight.mode.operator.foreground": "#1d1f21",
 
         "highlight.mode.visual.background": "#EF5350",
-        "highlight.mode.visual.foreground": "#ffffffcc"
+        "highlight.mode.visual.foreground": "#ffffff"
     },
     "editor.tokenColors": [
         {

--- a/extensions/theme-night-owl/colors/night-owl.json
+++ b/extensions/theme-night-owl/colors/night-owl.json
@@ -1,0 +1,1480 @@
+{
+    "name": "night-owl",
+    "baseVimTheme": "night-owl",
+    "baseVimBackground": "dark",
+    "colors": {
+        "background": "#011627",
+        "foreground": "#d6deeb",
+
+        "title.background": "#011627",
+        "title.foreground": "#eeefff",
+
+        "editor.background": "#011627",
+        "editor.foreground": "#d6deeb",
+
+        "tabs.background": "#0b2942",
+        "tabs.foreground": "#d2dee7",
+
+        "toolTip.background": "#011627",
+        "toolTip.foreground": "#c5c8c6",
+        "toolTip.border": "#5f7e97",
+
+        "menu.background": "#011627",
+        "menu.foreground": "#ffffffcc",
+        "menu.border": "#5f7e97",
+
+        "contextMenu.background": "#5f7e97",
+        "contextMenu.foreground": "#ffffffcc",
+        "contextMenu.border": "",
+        "contextMenu.highlight": "#4373c2",
+
+        "statusBar.background": "#011627",
+        "statusBar.foreground": "#676E95",
+
+        "highlight.mode.insert.background": "#9CCC65",
+        "highlight.mode.insert.foreground": "#ffffffcc",
+
+        "highlight.mode.normal.background": "#4373c2",
+        "highlight.mode.normal.foreground": "#ffffffcc",
+
+        "highlight.mode.operator.background": "#b294bb",
+        "highlight.mode.operator.foreground": "#1d1f21",
+
+        "highlight.mode.visual.background": "#EF5350",
+        "highlight.mode.visual.foreground": "#ffffffcc"
+    },
+    "editor.tokenColors": [
+        {
+            "name": "Changed",
+            "scope": [
+                "markup.changed",
+                "meta.diff.header.git",
+                "meta.diff.header.from-file",
+                "meta.diff.header.to-file"
+            ],
+            "settings": {
+                "foreground": "#a2bffc",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Deleted",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#EF535090",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Inserted",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#addb67ff",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Global settings",
+            "settings": {
+                "background": "#011627",
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "settings": {
+                "foreground": "#637777",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "String",
+            "scope": "string",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "String Quoted",
+            "scope": ["string.quoted", "variable.other.readwrite.js"],
+            "settings": {
+                "foreground": "#ecc48d"
+            }
+        },
+        {
+            "name": "Support Constant Math",
+            "scope": "support.constant.math",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Number",
+            "scope": ["constant.numeric", "constant.character.numeric"],
+            "settings": {
+                "foreground": "#F78C6C",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Built-in constant",
+            "scope": [
+                "constant.language",
+                "punctuation.definition.constant",
+                "variable.other.constant"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "User-defined constant",
+            "scope": ["constant.character", "constant.other"],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Constant Character Escape",
+            "scope": "constant.character.escape",
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "RegExp String",
+            "scope": ["string.regexp", "string.regexp keyword.other"],
+            "settings": {
+                "foreground": "#5ca7e4"
+            }
+        },
+        {
+            "name": "Comma in functions",
+            "scope": "meta.function punctuation.separator.comma",
+            "settings": {
+                "foreground": "#5f7e97"
+            }
+        },
+        {
+            "name": "Variable",
+            "scope": "variable",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Keyword",
+            "scope": ["punctuation.accessor", "keyword"],
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Storage",
+            "scope": [
+                "storage",
+                "meta.var.expr",
+                "meta.class meta.method.declaration meta.var.expr storage.type.js",
+                "storage.type.property.js",
+                "storage.type.property.ts",
+                "storage.type.property.tsx"
+            ],
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Storage type",
+            "scope": "storage.type",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Storage type",
+            "scope": "storage.type.function.arrow.js",
+            "settings": {
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": ["entity.name.class", "meta.class entity.name.type.class"],
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "Inherited class",
+            "scope": "entity.other.inherited-class",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Function name",
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#82AAFF",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Meta Tag",
+            "scope": ["punctuation.definition.tag", "meta.tag"],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "HTML Tag names",
+            "scope": [
+                "entity.name.tag",
+                "meta.tag.other.html",
+                "meta.tag.other.js",
+                "meta.tag.other.tsx",
+                "entity.name.tag.tsx",
+                "entity.name.tag.js",
+                "entity.name.tag",
+                "meta.tag.js",
+                "meta.tag.tsx",
+                "meta.tag.html"
+            ],
+            "settings": {
+                "foreground": "#7fdbca",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Tag attribute",
+            "scope": "entity.other.attribute-name",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Entity Name Tag Custom",
+            "scope": "entity.name.tag.custom",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Library (function & constant)",
+            "scope": ["support.function", "support.constant"],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Support Constant Property Value meta",
+            "scope": "support.constant.meta.property-value",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Library class/type",
+            "scope": ["support.type", "support.class"],
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Support Variable DOM",
+            "scope": "support.variable.dom",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Invalid",
+            "scope": "invalid",
+            "settings": {
+                "background": "#ff2c83",
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Invalid deprecated",
+            "scope": "invalid.deprecated",
+            "settings": {
+                "foreground": "#ffffff",
+                "background": "#d3423e"
+            }
+        },
+        {
+            "name": "Keyword Operator",
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#7fdbca",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Keyword Operator Relational",
+            "scope": "keyword.operator.relational",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Keyword Operator Assignment",
+            "scope": "keyword.operator.assignment",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Keyword Operator Arithmetic",
+            "scope": "keyword.operator.arithmetic",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Keyword Operator Bitwise",
+            "scope": "keyword.operator.bitwise",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Keyword Operator Increment",
+            "scope": "keyword.operator.increment",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Keyword Operator Ternary",
+            "scope": "keyword.operator.ternary",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Double-Slashed Comment",
+            "scope": "comment.line.double-slash",
+            "settings": {
+                "foreground": "#637777"
+            }
+        },
+        {
+            "name": "Object",
+            "scope": "object",
+            "settings": {
+                "foreground": "#cdebf7"
+            }
+        },
+        {
+            "name": "Null",
+            "scope": "constant.language.null",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Meta Brace",
+            "scope": "meta.brace",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Meta Delimiter Period",
+            "scope": "meta.delimiter.period",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Punctuation Definition String",
+            "scope": "punctuation.definition.string",
+            "settings": {
+                "foreground": "#d9f5dd"
+            }
+        },
+        {
+            "name": "Boolean",
+            "scope": "constant.language.boolean",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Object Comma",
+            "scope": "object.comma",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Variable Parameter Function",
+            "scope": "variable.parameter.function",
+            "settings": {
+                "foreground": "#7fdbca",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Support Type Property Name & entity name tags",
+            "scope": [
+                "support.type.vendor.property-name",
+                "support.constant.vendor.property-value",
+                "support.type.property-name",
+                "meta.property-list entity.name.tag"
+            ],
+            "settings": {
+                "foreground": "#80CBC4",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Entity Name tag reference in stylesheets",
+            "scope": "meta.property-list entity.name.tag.reference",
+            "settings": {
+                "foreground": "#57eaf1"
+            }
+        },
+        {
+            "name": "Constant Other Color RGB Value Punctuation Definition Constant",
+            "scope": "constant.other.color.rgb-value punctuation.definition.constant",
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Constant Other Color",
+            "scope": "constant.other.color",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Keyword Other Unit",
+            "scope": "keyword.other.unit",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Meta Selector",
+            "scope": "meta.selector",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Entity Other Attribute Name Id",
+            "scope": "entity.other.attribute-name.id",
+            "settings": {
+                "foreground": "#FAD430"
+            }
+        },
+        {
+            "name": "Meta Property Name",
+            "scope": "meta.property-name",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Doctypes",
+            "scope": ["entity.name.tag.doctype", "meta.tag.sgml.doctype"],
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Punctuation Definition Parameters",
+            "scope": "punctuation.definition.parameters",
+            "settings": {
+                "foreground": "#d9f5dd"
+            }
+        },
+        {
+            "name": "Keyword Control Operator",
+            "scope": "keyword.control.operator",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Keyword Operator Logical",
+            "scope": "keyword.operator.logical",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Variable Instances",
+            "scope": [
+                "variable.instance",
+                "variable.other.instance",
+                "variable.readwrite.instance",
+                "variable.other.readwrite.instance",
+                "variable.other.property"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Variable Property Other object property",
+            "scope": ["variable.other.object.property"],
+            "settings": {
+                "foreground": "#d7dbe0",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Variable Property Other object",
+            "scope": ["variable.other.object.js"],
+            "settings": {
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Entity Name Function",
+            "scope": ["entity.name.function"],
+            "settings": {
+                "foreground": "#82AAFF",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Keyword Operator Comparison, imports, returns and Keyword Operator Ruby",
+            "scope": [
+                "keyword.operator.comparison",
+                "keyword.control.flow.js",
+                "keyword.control.flow.ts",
+                "keyword.control.flow.tsx",
+                "keyword.control.ruby",
+                "keyword.control.module.ruby",
+                "keyword.control.class.ruby",
+                "keyword.control.def.ruby",
+                "keyword.control.loop.js",
+                "keyword.control.loop.ts",
+                "keyword.control.import.js",
+                "keyword.control.import.ts",
+                "keyword.control.import.tsx",
+                "keyword.control.from.js",
+                "keyword.control.from.ts",
+                "keyword.control.from.tsx"
+            ],
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Keyword Control Conditional",
+            "scope": [
+                "keyword.control.conditional.js",
+                "keyword.control.conditional.ts",
+                "keyword.control.switch.js",
+                "keyword.control.switch.ts"
+            ],
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name":
+                "Support Constant, `new` keyword, Special Method Keyword, `debugger`, other keywords",
+            "scope": [
+                "support.constant",
+                "keyword.other.special-method",
+                "keyword.other.new",
+                "keyword.other.debugger",
+                "keyword.control"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Support Function",
+            "scope": "support.function",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Invalid Broken",
+            "scope": "invalid.broken",
+            "settings": {
+                "foreground": "#020e14",
+                "background": "#F78C6C"
+            }
+        },
+        {
+            "name": "Invalid Unimplemented",
+            "scope": "invalid.unimplemented",
+            "settings": {
+                "background": "#8BD649",
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Invalid Illegal",
+            "scope": "invalid.illegal",
+            "settings": {
+                "foreground": "#ffffff",
+                "background": "#ec5f67"
+            }
+        },
+        {
+            "name": "Language Variable",
+            "scope": "variable.language",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Support Variable Property",
+            "scope": "support.variable.property",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Variable Function",
+            "scope": "variable.function",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Variable Interpolation",
+            "scope": "variable.interpolation",
+            "settings": {
+                "foreground": "#ec5f67"
+            }
+        },
+        {
+            "name": "Meta Function Call",
+            "scope": "meta.function-call",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Punctuation Section Embedded",
+            "scope": "punctuation.section.embedded",
+            "settings": {
+                "foreground": "#d3423e"
+            }
+        },
+        {
+            "name": "Punctuation Tweaks",
+            "scope": [
+                "punctuation.terminator.expression",
+                "punctuation.definition.arguments",
+                "punctuation.definition.array",
+                "punctuation.section.array",
+                "meta.array"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "More Punctuation Tweaks",
+            "scope": [
+                "punctuation.definition.list.begin",
+                "punctuation.definition.list.end",
+                "punctuation.separator.arguments",
+                "punctuation.definition.list"
+            ],
+            "settings": {
+                "foreground": "#d9f5dd"
+            }
+        },
+        {
+            "name": "Template Strings",
+            "scope": "string.template meta.template.expression",
+            "settings": {
+                "foreground": "#d3423e"
+            }
+        },
+        {
+            "name": "Backtics(``) in Template Strings",
+            "scope": "string.template punctuation.definition.string",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Italics",
+            "scope": "italic",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "bold",
+            "settings": {
+                "foreground": "#addb67",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Quote",
+            "scope": "quote",
+            "settings": {
+                "foreground": "#697098",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Raw Code",
+            "scope": "raw",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "CoffeScript Variable Assignment",
+            "scope": "variable.assignment.coffee",
+            "settings": {
+                "foreground": "#31e1eb"
+            }
+        },
+        {
+            "name": "CoffeScript Parameter Function",
+            "scope": "variable.parameter.function.coffee",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "CoffeeScript Assignments",
+            "scope": "variable.assignment.coffee",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "C# Readwrite Variables",
+            "scope": "variable.other.readwrite.cs",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "C# Classes & Storage types",
+            "scope": ["entity.name.type.class.cs", "storage.type.cs"],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "C# Namespaces",
+            "scope": "entity.name.type.namespace.cs",
+            "settings": {
+                "foreground": "#B2CCD6"
+            }
+        },
+        {
+            "name": "Tag names in Stylesheets",
+            "scope": [
+                "entity.name.tag.css",
+                "entity.name.tag.less",
+                "entity.name.tag.custom.css",
+                "support.constant.property-value.css"
+            ],
+            "settings": {
+                "foreground": "#ff6363",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Wildcard(*) selector in Stylesheets",
+            "scope": [
+                "entity.name.tag.wildcard.css",
+                "entity.name.tag.wildcard.less",
+                "entity.name.tag.wildcard.scss",
+                "entity.name.tag.wildcard.sass"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "CSS Keyword Other Unit",
+            "scope": "keyword.other.unit.css",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Attribute Name for CSS",
+            "scope": [
+                "meta.attribute-selector.css entity.other.attribute-name.attribute",
+                "variable.other.readwrite.js"
+            ],
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Elixir Classes",
+            "scope": [
+                "source.elixir support.type.elixir",
+                "source.elixir meta.module.elixir entity.name.class.elixir"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Elixir Functions",
+            "scope": "source.elixir entity.name.function",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Elixir Constants",
+            "scope": [
+                "source.elixir constant.other.symbol.elixir",
+                "source.elixir constant.other.keywords.elixir"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Elixir String Punctuations",
+            "scope": "source.elixir punctuation.definition.string",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Elixir",
+            "scope": [
+                "source.elixir variable.other.readwrite.module.elixir",
+                "source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir"
+            ],
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Elixir Binary Punctuations",
+            "scope": "source.elixir .punctuation.binary.elixir",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Go Function Calls",
+            "scope": "source.go meta.function-call.go",
+            "settings": {
+                "foreground": "#DDDDDD"
+            }
+        },
+        {
+            "name": "Go Keywords",
+            "scope": [
+                "source.go keyword.package.go",
+                "source.go keyword.import.go",
+                "source.go keyword.function.go",
+                "source.go keyword.type.go",
+                "source.go keyword.struct.go",
+                "source.go keyword.interface.go",
+                "source.go keyword.const.go",
+                "source.go keyword.var.go",
+                "source.go keyword.map.go",
+                "source.go keyword.channel.go",
+                "source.go keyword.control.go"
+            ],
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Go Constants e.g. nil, string format (%s, %d, etc.)",
+            "scope": ["source.go constant.language.go", "source.go constant.other.placeholder.go"],
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "ID Attribute Name in HTML",
+            "scope": "entity.other.attribute-name.id.html",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "HTML Punctuation Definition Tag",
+            "scope": "punctuation.definition.tag.html",
+            "settings": {
+                "foreground": "#6ae9f0"
+            }
+        },
+        {
+            "name": "HTML Doctype",
+            "scope": "meta.tag.sgml.doctype.html",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "JavaScript Classes",
+            "scope": "meta.class entity.name.type.class.js",
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "JavaScript Method Declaration e.g. `constructor`",
+            "scope": "meta.method.declaration storage.type.js",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "JavaScript Terminator",
+            "scope": "terminator.js",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Meta Punctuation Definition",
+            "scope": "meta.js punctuation.definition.js",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Entity Names in Code Documentations",
+            "scope": ["entity.name.type.instance.jsdoc", "entity.name.type.instance.phpdoc"],
+            "settings": {
+                "foreground": "#5f7e97"
+            }
+        },
+        {
+            "name": "Other Variables in Code Documentations",
+            "scope": ["variable.other.jsdoc", "variable.other.phpdoc"],
+            "settings": {
+                "foreground": "#78ccf0"
+            }
+        },
+        {
+            "name": "JavaScript module imports and exports",
+            "scope": [
+                "variable.other.meta.import.js",
+                "meta.import.js variable.other",
+                "variable.other.meta.export.js",
+                "meta.export.js variable.other"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Variable Parameter Function",
+            "scope": "variable.parameter.function.js",
+            "settings": {
+                "foreground": "#7986E7"
+            }
+        },
+        {
+            "name": "JavaScript[React] Variable Other Object",
+            "scope": [
+                "variable.other.object.js",
+                "variable.other.object.jsx",
+                "variable.object.property.js",
+                "variable.object.property.jsx"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Variables",
+            "scope": ["variable.js", "variable.other.js"],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Entity Name Type",
+            "scope": ["entity.name.type.js", "entity.name.type.module.js"],
+            "settings": {
+                "foreground": "#ffcb8b",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "JavaScript Support Classes",
+            "scope": "support.class.js",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JSON Property Names",
+            "scope": "support.type.property-name.json",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "JSON Support Constants",
+            "scope": "support.constant.json",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "JSON Property values (string)",
+            "scope": "meta.structure.dictionary.value.json string.quoted.double",
+            "settings": {
+                "foreground": "#c789d6"
+            }
+        },
+        {
+            "name": "Strings in JSON values",
+            "scope": "string.quoted.double.json punctuation.definition.string.json",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Specific JSON Property values like null",
+            "scope":
+                "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Ruby Variables",
+            "scope": ["variable.other.ruby"],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Ruby Class",
+            "scope": ["entity.name.type.class.ruby"],
+            "settings": {
+                "foreground": "#ecc48d"
+            }
+        },
+        {
+            "name": "Ruby Hashkeys",
+            "scope": "constant.language.symbol.hashkey.ruby",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "LESS Tag names",
+            "scope": "entity.name.tag.less",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "LESS Keyword Other Unit",
+            "scope": "keyword.other.unit.css",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Attribute Name for LESS",
+            "scope": "meta.attribute-selector.less entity.other.attribute-name.attribute",
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Markdown Headings",
+            "scope": "markup.heading.markdown",
+            "settings": {
+                "foreground": "#82b1ff"
+            }
+        },
+        {
+            "name": "Markdown Italics",
+            "scope": "markup.italic.markdown",
+            "settings": {
+                "foreground": "#c792ea",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Markdown Bold",
+            "scope": "markup.bold.markdown",
+            "settings": {
+                "foreground": "#addb67",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Markdown Quote + others",
+            "scope": "markup.quote.markdown",
+            "settings": {
+                "foreground": "#697098",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Markdown Raw Code + others",
+            "scope": "markup.inline.raw.markdown",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Markdown Links",
+            "scope": ["markup.underline.link.markdown", "markup.underline.link.image.markdown"],
+            "settings": {
+                "foreground": "#ff869a"
+            }
+        },
+        {
+            "name": "Markdown Link Title and Description",
+            "scope": ["string.other.link.title.markdown", "string.other.link.description.markdown"],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Markdown Punctuation",
+            "scope": [
+                "punctuation.definition.string.markdown",
+                "punctuation.definition.string.begin.markdown",
+                "punctuation.definition.string.end.markdown",
+                "meta.link.inline.markdown punctuation.definition.string"
+            ],
+            "settings": {
+                "foreground": "#82b1ff"
+            }
+        },
+        {
+            "name": "Markdown MetaData Punctuation",
+            "scope": ["punctuation.definition.metadata.markdown"],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Markdown List Punctuation",
+            "scope": ["beginning.punctuation.definition.list.markdown"],
+            "settings": {
+                "foreground": "#82b1ff"
+            }
+        },
+        {
+            "name": "PHP Variables",
+            "scope": ["variable.other.php", "variable.other.property.php"],
+            "settings": {
+                "foreground": "#bec5d4"
+            }
+        },
+        {
+            "name": "Support Classes in PHP",
+            "scope": "support.class.php",
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "Punctuations in PHP function calls",
+            "scope": "meta.function-call.php punctuation",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "PHP Global Variables",
+            "scope": "variable.other.global.php",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Declaration Punctuation in PHP Global Variables",
+            "scope": "variable.other.global.php punctuation.definition.variable",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Language Constants in Python",
+            "scope": "constant.language.python",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Python Function Parameter and Arguments",
+            "scope": ["variable.parameter.function.python", "meta.function-call.arguments.python"],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Python Function Call",
+            "scope": ["meta.function-call.python", "meta.function-call.generic.python"],
+            "settings": {
+                "foreground": "#B2CCD6"
+            }
+        },
+        {
+            "name": "Punctuations in Python",
+            "scope": "punctuation.python",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Decorator Functions in Python",
+            "scope": "entity.name.function.decorator.python",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Python Language Variable",
+            "scope": "source.python variable.language.special",
+            "settings": {
+                "foreground": "#8EACE3"
+            }
+        },
+        {
+            "name": "SCSS Variable",
+            "scope": [
+                "variable.scss",
+                "variable.sass",
+                "variable.parameter.url.scss",
+                "variable.parameter.url.sass"
+            ],
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Variables in SASS At-Rules",
+            "scope": [
+                "source.css.scss meta.at-rule variable",
+                "source.css.sass meta.at-rule variable"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Variables in SASS At-Rules",
+            "scope": [
+                "source.css.scss meta.at-rule variable",
+                "source.css.sass meta.at-rule variable"
+            ],
+            "settings": {
+                "foreground": "#bec5d4"
+            }
+        },
+        {
+            "name": "Attribute Name for SASS",
+            "scope": [
+                "meta.attribute-selector.scss entity.other.attribute-name.attribute",
+                "meta.attribute-selector.sass entity.other.attribute-name.attribute"
+            ],
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Tag names in SASS",
+            "scope": ["entity.name.tag.scss", "entity.name.tag.sass"],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "SASS Keyword Other Unit",
+            "scope": ["keyword.other.unit.scss", "keyword.other.unit.sass"],
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "TypeScript[React] Variables and Object Properties",
+            "scope": [
+                "variable.other.readwrite.alias.ts",
+                "variable.other.readwrite.alias.tsx",
+                "variable.other.readwrite.ts",
+                "variable.other.readwrite.tsx",
+                "variable.other.object.ts",
+                "variable.other.object.tsx",
+                "variable.object.property.ts",
+                "variable.object.property.tsx",
+                "variable.other.ts",
+                "variable.other.tsx",
+                "variable.tsx",
+                "variable.ts"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "TypeScript[React] Entity Name Types",
+            "scope": ["entity.name.type.ts", "entity.name.type.tsx"],
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "TypeScript[React] Node Classes",
+            "scope": ["support.class.node.ts", "support.class.node.tsx"],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "TypeScript[React] Entity Name Types as Parameters",
+            "scope": [
+                "meta.type.parameters.ts entity.name.type",
+                "meta.type.parameters.tsx entity.name.type"
+            ],
+            "settings": {
+                "foreground": "#5f7e97"
+            }
+        },
+        {
+            "name": "TypeScript[React] Import/Export Punctuations",
+            "scope": [
+                "meta.import.ts punctuation.definition.block",
+                "meta.import.tsx punctuation.definition.block",
+                "meta.export.ts punctuation.definition.block",
+                "meta.export.tsx punctuation.definition.block"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "TypeScript[React] Punctuation Decorators",
+            "scope": [
+                "meta.decorator punctuation.decorator.ts",
+                "meta.decorator punctuation.decorator.tsx"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "TypeScript[React] Punctuation Decorators",
+            "scope": "meta.tag.js meta.jsx.children.tsx",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "YAML Entity Name Tags",
+            "scope": "entity.name.tag.yaml",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "JavaScript Variable Other ReadWrite",
+            "scope": ["variable.other.readwrite.js", "variable.parameter"],
+            "settings": {
+                "foreground": "#d7dbe0"
+            }
+        },
+        {
+            "name": "Support Class Component",
+            "scope": ["support.class.component.js", "support.class.component.tsx"],
+            "settings": {
+                "foreground": "#f78c6c",
+                "fontStyle": ""
+            }
+        },
+        {
+            "name": "Text nested in React tags",
+            "scope": ["meta.jsx.children", "meta.jsx.children.js", "meta.jsx.children.tsx"],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "TypeScript Classes",
+            "scope": "meta.class entity.name.type.class.tsx",
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "TypeScript Entity Name Type",
+            "scope": ["entity.name.type.tsx", "entity.name.type.module.tsx"],
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "TypeScript Method Declaration e.g. `constructor`",
+            "scope": [
+                "meta.method.declaration storage.type.ts",
+                "meta.method.declaration storage.type.tsx"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "normalize font style of certain components",
+            "scope": [
+                "meta.property-list.css meta.property-value.css variable.other.less",
+                "meta.property-list.scss variable.scss",
+                "meta.property-list.sass variable.sass",
+                "meta.brace",
+                "keyword.operator.operator",
+                "keyword.operator.or.regexp",
+                "keyword.operator.expression.in",
+                "keyword.operator.relational",
+                "keyword.operator.assignment",
+                "keyword.operator.comparison",
+                "keyword.operator.type",
+                "keyword.operator",
+                "keyword",
+                "punctuation.definintion.string",
+                "punctuation",
+                "variable.other.readwrite.js",
+                "storage.type",
+                "source.css",
+                "string.quoted"
+            ],
+            "settings": {
+                "fontStyle": ""
+            }
+        }
+    ]
+}

--- a/extensions/theme-night-owl/colors/night-owl.vim
+++ b/extensions/theme-night-owl/colors/night-owl.vim
@@ -1,0 +1,138 @@
+" ===============================================================
+" night-owl
+" 
+" URL: https://github.com/haishanh/night-owl.vim
+" Author: Haishan
+" License: MIT
+" Last Change: 2018/08/20 21:49
+" ===============================================================
+
+set background=dark
+hi clear
+if exists("syntax_on")
+  syntax reset
+endif
+let g:colors_name="night-owl"
+
+hi Normal guifg=#d6deeb ctermfg=253 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi LineNr guifg=#444444 ctermfg=238 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi CursorLine guifg=#ff5874 ctermfg=204 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi ColorColumn guibg=#222222 ctermbg=235 gui=NONE cterm=NONE
+hi DiffAdd guifg=#011627 ctermfg=233 guibg=#addb67 ctermbg=149 gui=NONE cterm=NONE
+hi DiffChange guifg=#011627 ctermfg=233 guibg=#7fdbca ctermbg=116 gui=NONE cterm=NONE
+hi DiffDelete guifg=#011627 ctermfg=233 guibg=#ff5874 ctermbg=204 gui=NONE cterm=NONE
+hi DiffText guifg=#011627 ctermfg=233 guibg=#7fdbca ctermbg=116 gui=NONE cterm=NONE
+hi VertSplit guifg=#777777 ctermfg=243 gui=NONE cterm=NONE
+hi Folded guifg=#777777 ctermfg=243 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi IncSearch guifg=#eeeeee ctermfg=255 guibg=#ecc48d ctermbg=222 gui=NONE cterm=NONE
+hi MatchParen guifg=#011627 ctermfg=233 guibg=#aaaaaa ctermbg=248 gui=NONE cterm=NONE
+hi NonText guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi PMenu guibg=#2d2c5d ctermbg=236 gui=NONE cterm=NONE
+hi PMenuSel guibg=#c792ea ctermbg=176 gui=NONE cterm=NONE
+hi Search guifg=#011627 ctermfg=233 guibg=#ecc48d ctermbg=222 gui=NONE cterm=NONE
+hi SpecialKey guifg=#444444 ctermfg=238 gui=NONE cterm=NONE
+hi Visual guifg=#d6deeb ctermfg=253 guibg=#2d2c5d ctermbg=236 gui=NONE cterm=NONE
+hi EndOfBuffer guifg=#444444 ctermfg=238 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi Comment guifg=#637777 ctermfg=243 guibg=#011627 ctermbg=233 gui=italic cterm=italic
+hi Constant guifg=#addb67 ctermfg=149 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi String guifg=#ecc48d ctermfg=222 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi Identifier guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi Statement guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi Operator guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi Exception guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi PreProc guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi Type guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi StorageClass guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi Todo guifg=#777777 ctermfg=243 guibg=#ecc48d ctermbg=222 gui=NONE cterm=NONE
+hi jsStorageClass guifg=#82aaff ctermfg=111 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsOperator guifg=#c792ea ctermfg=176 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsArrowFunction guifg=#c792ea ctermfg=176 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsString guifg=#ecc48d ctermfg=222 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsComment guifg=#637777 ctermfg=243 guibg=#011627 ctermbg=233 gui=italic cterm=italic
+hi jsFuncCall guifg=#82aaff ctermfg=111 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsNumber guifg=#f78c6c ctermfg=209 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsSpecial guifg=#f78c6c ctermfg=209 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsObjectProp guifg=#7fdbca ctermfg=116 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsOperatorKeyword guifg=#7fdbca ctermfg=116 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsBooleanFalse guifg=#ff5874 ctermfg=204 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsBooleanTrue guifg=#ff5874 ctermfg=204 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsRegexpString guifg=#5ca7e4 ctermfg=74 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi jsConditional guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi jsFunction guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi jsReturn guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi jsFuncName guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi link jsParensError jsFuncParens
+hi jsClassDefinition guifg=#ecc48d ctermfg=222 gui=NONE cterm=NONE
+hi jsExport guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi jsExportDefault guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi javaScriptReserved guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi javaScriptConditional guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi javaScriptStringS guifg=#ecc48d ctermfg=222 gui=NONE cterm=NONE
+hi javaScriptBoolean guifg=#ff5874 ctermfg=204 gui=NONE cterm=NONE
+hi javaScriptBraces guifg=#d6deeb ctermfg=253 gui=NONE cterm=NONE
+hi javaScriptLineComment guifg=#637777 ctermfg=243 gui=italic cterm=italic
+hi javaScriptSpecial guifg=#f78c6c ctermfg=209 gui=NONE cterm=NONE
+hi javaScriptFunction guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi javaScriptStatement guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi jsExtendsKeyword guifg=#c792ea ctermfg=176 gui=NONE cterm=NONE
+hi javaScriptException guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi scssSelectorName guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi cssPositioningProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssBoxProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssDimensionProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssTransitionProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssTextProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssFontProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssBorderProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssBackgroundProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssUIProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssIEUIProp guifg=#ff5874 ctermfg=204 gui=NONE cterm=NONE
+hi scssFunctionName guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi cssPositioningAttr guifg=#ff5874 ctermfg=204 gui=NONE cterm=NONE
+hi cssUnitDecorators guifg=#ecc48d ctermfg=222 gui=NONE cterm=NONE
+hi cssTableAttr guifg=#ff5874 ctermfg=204 gui=NONE cterm=NONE
+hi cssCommonAttr guifg=#ff5874 ctermfg=204 gui=NONE cterm=NONE
+hi cssColorProp guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssIncludeKeyword guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi cssKeyFrameSelector guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi cssPseudoClassId guifg=#addb67 ctermfg=149 gui=NONE cterm=NONE
+hi markdownHeadingDelimiter guifg=#637777 ctermfg=243 gui=NONE cterm=NONE
+hi markdownCodeDelimiter guifg=#ecc48d ctermfg=222 gui=NONE cterm=NONE
+hi markdownCode guifg=#aaaaaa ctermfg=248 gui=NONE cterm=NONE
+hi htmlH1 guifg=#82aaff ctermfg=111 gui=bold cterm=bold
+hi link htmlH2 htmlH1
+hi link htmlH3 htmlH1
+hi htmlH4 guifg=#82aaff ctermfg=111 gui=NONE cterm=NONE
+hi link htmlH5 htmlH4
+hi htmlBold guifg=#c792ea ctermfg=176 guibg=#011627 ctermbg=233 gui=bold cterm=bold
+hi mkdCodeStart guifg=#d6deeb ctermfg=253 gui=NONE cterm=NONE
+hi mkdCodeEnd guifg=#d6deeb ctermfg=253 gui=NONE cterm=NONE
+hi shComment guifg=#637777 ctermfg=243 guibg=#011627 ctermbg=233 gui=italic cterm=italic
+hi mkdLinkDef guifg=#7fdbca ctermfg=116 gui=NONE cterm=NONE
+hi NERDTreeDir guifg=#5f7e97 ctermfg=66 gui=NONE cterm=NONE
+hi NERDTreeOpenable guifg=#ff5874 ctermfg=204 gui=NONE cterm=NONE
+hi NERDTreeClosable guifg=#ecc48d ctermfg=222 gui=NONE cterm=NONE
+hi NERDTreeHelp guifg=#444444 ctermfg=238 guibg=#011627 ctermbg=233 gui=italic cterm=italic
+hi NERDTreeUp guifg=#637777 ctermfg=243 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi NERDTreeDirSlash guifg=#637777 ctermfg=243 gui=NONE cterm=NONE
+hi gitcommitSummary guifg=#d6deeb ctermfg=253 guibg=#011627 ctermbg=233 gui=NONE cterm=NONE
+hi IndentGuidesOdd guibg=#444444 ctermbg=238 gui=NONE cterm=NONE
+hi IndentGuidesEven guibg=#777777 ctermbg=243 gui=NONE cterm=NONE
+
+let g:terminal_color_foreground = "#d6deeb"
+let g:terminal_color_background = "#011627"
+let g:terminal_color_0 = "#011627"
+let g:terminal_color_8 = "#637777"
+let g:terminal_color_1 = "#ff5874"
+let g:terminal_color_2 = "#addb67"
+let g:terminal_color_10 = "#addb67"
+let g:terminal_color_3 = "#f78c6c"
+let g:terminal_color_11 = "#f78c6c"
+let g:terminal_color_4 = "#82aaff"
+let g:terminal_color_12 = "#82aaff"
+let g:terminal_color_5 = "#c792ea"
+let g:terminal_color_13 = "#c792ea"
+let g:terminal_color_6 = "#7fdbca"
+let g:terminal_color_14 = "#7fdbca"
+let g:terminal_color_7 = "#aaaaaa"
+let g:terminal_color_15 = "#eeeeee"

--- a/extensions/theme-night-owl/package.json
+++ b/extensions/theme-night-owl/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "onivim-theme-night-owl",
+    "version": "0.0.1",
+    "description": "Night Owl theme, ported to Oni (Original by Sarah Drasner)",
+    "engines": {
+        "oni": "0.3.7"
+    },
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "contributes": {
+        "themes": [
+            {
+                "name": "night-owl",
+                "path": "colors/night-owl.json"
+            }
+        ]
+    },
+    "author": "Akin Sowemimo",
+    "license": "MIT"
+}


### PR DESCRIPTION
Port of [the Night Owl theme](https://github.com/sdras/night-owl-vscode-theme)  not exact but as close as I could get it with Oni's current theme setup. Vim port is by https://github.com/haishanh/night-owl.vim

Follow up tweak PRs to Oni incoming, as we currently lack a few nice to have themeing options e.g. the scrollbar, active Menu selection, activeTab

I would still like to tweak this to better match the vscode theme but atm there are quite a few areas where Oni doesn't provide the same elements for theming, although can do that in follow up PRs