### PR TITLE
OSX: reduce threshold (getting a much more fluid scrolling) 

### DIFF
--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events"
 
 import { IScreen } from "./../neovim"
 
-const SCROLL_THRESHOLD_IN_PIXELS = 100
+const SCROLL_THRESHOLD_IN_PIXELS = 10
 
 // TODO
 // Handle modifier keys


### PR DESCRIPTION
I'm honestly not sure how scrolling is behaving for other platforms/operative systems, but it's been working a little oddly these past months for OSX, after some digging in my local I found that having a small value like `10` improves things a lot getting me a more fluid scrolling experience.

Note: I didn't have so much time to poke with this, so I don't know how your building system works, when tested in my local I just made the change to the minified file (`/Applications/Oni.app/Contents/Resources/app/lib/browser/vendor.bundle.js`), so please let me know if i'm missing to push any bundle or something else.

Thanks.