### PR TITLE
Upgrade electron to 2.0.8 to fix glibc version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -939,7 +939,7 @@
         "cross-env": "3.1.3",
         "css-loader": "0.28.4",
         "detect-indent": "^5.0.0",
-        "electron": "2.0.2",
+        "electron": "2.0.8",
         "electron-builder": "^20.5.1",
         "electron-devtools-installer": "^2.2.3",
         "electron-mocha": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,9 +3551,9 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.2.tgz#b77e05f83419cc5ec921a2d21f35b55e4bfc3d68"
+electron@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
This should fix #2497, but I haven't encountered the issue on my Ubuntu machine as 18.04 is still on glibc 2.27.