### PR TITLE
[WIP] Feature/omni completion oni

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -283,12 +283,13 @@ export const start = async (args: string[]): Promise<void> => {
 
     const CompletionProviders = await completionProvidersPromise
     CompletionProviders.activate(languageManager)
+    const completionProviders = CompletionProviders.getInstance()
 
     const initializeAllEditors = async () => {
         await startEditors(
             filesToOpen,
             Colors.getInstance(),
-            CompletionProviders.getInstance(),
+            completionProviders,
             configuration,
             diagnostics,
             languageManager,

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -97,6 +97,9 @@ import WildMenu from "./../../UI/components/WildMenu"
 import { CanvasRenderer } from "../../Renderer/CanvasRenderer"
 import { WebGLRenderer } from "../../Renderer/WebGL/WebGLRenderer"
 import { getInstance as getNotificationsInstance } from "./../../Services/Notifications"
+import NeovimCompletionsRequestor, {
+    INeovimWithCompletions,
+} from "../../Services/Completion/NeovimCompletionsRequestor"
 
 type NeovimError = [number, string]
 
@@ -727,6 +730,13 @@ export class NeovimEditor extends Editor implements Oni.Editor {
             this._languageIntegration.onHideDefinition.subscribe(definition => {
                 this._actions.hideDefinition()
             }),
+        )
+
+        const neovimCompletion = new NeovimCompletionsRequestor(this
+            .neovim as INeovimWithCompletions)
+        this._completionProviders.registerCompletionProvider(
+            "oni.completions.neovim",
+            neovimCompletion,
         )
 
         this._commands = new NeovimEditorCommands(

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -243,13 +243,13 @@ export class NeovimEditor extends Editor implements Oni.Editor {
             </Provider>,
         )
 
-        this._popupMenu = new NeovimPopupMenu(
-            this._neovimInstance.onShowPopupMenu,
-            this._neovimInstance.onHidePopupMenu,
-            this._neovimInstance.onSelectPopupMenu,
-            this.onBufferEnter,
-            this._toolTipsProvider,
-        )
+        // this._popupMenu = new NeovimPopupMenu(
+        //     this._neovimInstance.onShowPopupMenu,
+        //     this._neovimInstance.onHidePopupMenu,
+        //     this._neovimInstance.onSelectPopupMenu,
+        //     this.onBufferEnter,
+        //     this._toolTipsProvider,
+        // )
 
         const notificationManager = getNotificationsInstance()
         this._neovimInstance.onMessage.subscribe(messageInfo => {

--- a/browser/src/Services/Completion/NeovimCompletionsRequestor.ts
+++ b/browser/src/Services/Completion/NeovimCompletionsRequestor.ts
@@ -20,13 +20,8 @@ export default class NeovimCompletionsRequestor implements ICompletionsRequestor
 
     private _setupSubscriptions() {
         this._subscriptions = [
-            this._neovim.onShowPopupMenu.subscribe(completionInfo => {
-                console.log("completionsInfo: ", completionInfo)
-                this._addNeovimCompletion(completionInfo)
-            }),
-            this._neovim.onHidePopupMenu.subscribe(() => {
-                this._clearNeovimCompletions()
-            }),
+            this._neovim.onShowPopupMenu.subscribe(this._addNeovimCompletion),
+            this._neovim.onHidePopupMenu.subscribe(this._clearNeovimCompletions),
         ]
     }
 

--- a/browser/src/Services/Completion/NeovimCompletionsRequestor.ts
+++ b/browser/src/Services/Completion/NeovimCompletionsRequestor.ts
@@ -1,0 +1,60 @@
+import { NeovimEditorCapability } from "oni-api"
+import { CompletionItem, CompletionItemKind } from "vscode-languageserver-types"
+import { CompletionsRequestContext, ICompletionsRequestor } from "./CompletionsRequestor"
+import { INeovimCompletionInfo } from "../../neovim"
+import { IEvent, IDisposable } from "oni-types"
+
+export interface INeovimWithCompletions extends NeovimEditorCapability {
+    onHidePopupMenu: IEvent<void>
+    onShowPopupMenu: IEvent<INeovimCompletionInfo>
+}
+
+export default class NeovimCompletionsRequestor implements ICompletionsRequestor {
+    private _completions: CompletionItem[] = []
+    // @ts-ignore
+    private _subscriptions: IDisposable[]
+
+    constructor(private _neovim: INeovimWithCompletions) {
+        this._setupSubscriptions()
+    }
+
+    private _setupSubscriptions() {
+        this._subscriptions = [
+            this._neovim.onShowPopupMenu.subscribe(completionInfo => {
+                console.log("completionsInfo: ", completionInfo)
+                this._addNeovimCompletion(completionInfo)
+            }),
+            this._neovim.onHidePopupMenu.subscribe(() => {
+                this._clearNeovimCompletions()
+            }),
+        ]
+    }
+
+    public async getCompletions(context: CompletionsRequestContext) {
+        console.log("this._completions: ", this._completions)
+        return this._completions
+    }
+
+    public async getCompletionDetails(
+        fileLanguage: string,
+        filePath: string,
+        completionItem: CompletionItem,
+    ): Promise<CompletionItem> {
+        return null
+    }
+
+    private _addNeovimCompletion(completionInfo: INeovimCompletionInfo) {
+        const items = completionInfo.items.map(item => {
+            return {
+                label: item.word,
+                kind: CompletionItemKind.Keyword,
+                detail: item.info,
+            }
+        })
+        this._completions = items
+    }
+
+    public _clearNeovimCompletions() {
+        this._completions = []
+    }
+}

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -839,7 +839,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     break
                 case "popupmenu_show":
                     const [items, selected, row, col] = a[0]
-                    // console.log("ITEMS!!!!!: ", items)
+                    console.log("ITEMS!!!!!: ", items)
 
                     const mappedItems = items.map((item: string[]) => {
                         const [word, kind, menu, info] = item

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -839,6 +839,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     break
                 case "popupmenu_show":
                     const [items, selected, row, col] = a[0]
+                    // console.log("ITEMS!!!!!: ", items)
 
                     const mappedItems = items.map((item: string[]) => {
                         const [word, kind, menu, info] = item


### PR DESCRIPTION
Looking into merging lsp completions with neovim source completions using the completion requestor interface @bryphe mentioned on discord, still early days currently this populates the menu though there are a few issues

- [ ] currently not clear that completions are sourced from vim, ?icon
- [ ] how to render the list aka 50% split user specified/configurable amount, double the list size
- [ ] create a new mode for this option? `editor.completions.mode: "both/omni"`