### PR TITLE
Bugfix/fix tabs focus state border regression

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -193,14 +193,31 @@ interface ITabWrapperProps {
     shouldShowHighlight: boolean
 }
 
-type TabStyledProps = ITabWrapperProps & { theme: IThemeColors }
+const sanitizedModeForColors = (mode: string): string => {
+    switch (mode) {
+        case "showmatch":
+            return "insert"
+        case "cmdline_normal":
+            return "normal"
+        default:
+            return mode
+    }
+}
 
-const highlight = (props: TabStyledProps) =>
-    props.shouldShowHighlight &&
-    `border-top: 2px solid ${getHighlightColor(props.theme, props.mode)}`
+export const getHighlightColor = (props: {
+    isSelected: boolean
+    shouldShowHighlight: boolean
+    theme: IThemeColors
+    mode: string
+}) => {
+    if (!props.shouldShowHighlight || !props.isSelected) {
+        return "transparent"
+    }
+    const sanitizedMode = sanitizedModeForColors(props.mode)
+    return props.theme[`highlight.mode.${sanitizedMode}.background`]
+}
 
 const active = css`
-    ${highlight};
     ${boxShadowUp};
     opacity: 1;
 `
@@ -229,6 +246,7 @@ const TabWrapper = styled<ITabWrapperProps, "div">("div")`
     animation: ${tabEntranceKeyFrames} 0.1s ease-in forwards;
     ${props => (props.isSelected ? active : inactive)};
 
+    border-top: 2px solid ${getHighlightColor};
     background-color: ${themeGet("tabs.active.background", "tabs.background", "isSelected")};
     color: ${themeGet("tabs.active.foreground", "tabs.foreground", "isSelected")};
 `
@@ -418,22 +436,6 @@ export const getTabName = (name: string, isDuplicate?: boolean): string => {
 }
 
 const getTabState = (state: State.IState) => state.tabState
-
-const sanitizedModeForColors = (mode: string): string => {
-    switch (mode) {
-        case "showmatch":
-            return "insert"
-        case "cmdline_normal":
-            return "normal"
-        default:
-            return mode
-    }
-}
-
-export const getHighlightColor = (theme: IThemeColors, mode: string) => {
-    const sanitizedMode = sanitizedModeForColors(mode)
-    return theme[`highlight.mode.${sanitizedMode}.background`]
-}
 
 export const showTabId = (state: State.IState) => {
     return state.configuration["tabs.showIndex"]

--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -18,6 +18,10 @@ describe("<Tabs /> Tests", () => {
         render: () => props.children,
     }))
 
+    const testTheme: any = {
+        "highlight.mode.normal.background": "green",
+    }
+
     const tabCloseFunction = jest.fn()
     const tabSelectFunction = jest.fn()
 
@@ -221,7 +225,7 @@ describe("<Tabs /> Tests", () => {
 
     it("should have a transparent border if not selected", () => {
         const highlight = getHighlightColor({
-            theme: { "highlight.mode.normal.background": "green" } as any,
+            theme: testTheme,
             isSelected: false,
             shouldShowHighlight: true,
             mode: "normal",
@@ -231,7 +235,7 @@ describe("<Tabs /> Tests", () => {
 
     it("should highlight the active tab with the mode color", () => {
         const highlight = getHighlightColor({
-            theme: { "highlight.mode.normal.background": "green" } as any,
+            theme: testTheme,
             isSelected: true,
             shouldShowHighlight: true,
             mode: "normal",
@@ -241,7 +245,7 @@ describe("<Tabs /> Tests", () => {
 
     it("should highlight the active tab with the normal mode color if the mode is a commandline mode", () => {
         const highlight = getHighlightColor({
-            theme: { "highlight.mode.normal.background": "green" } as any,
+            theme: testTheme,
             isSelected: true,
             shouldShowHighlight: true,
             mode: "cmdline_normal",

--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -20,6 +20,7 @@ describe("<Tabs /> Tests", () => {
 
     const testTheme: any = {
         "highlight.mode.normal.background": "green",
+        "highlight.mode.insert.background": "blue",
     }
 
     const tabCloseFunction = jest.fn()
@@ -250,6 +251,18 @@ describe("<Tabs /> Tests", () => {
             shouldShowHighlight: true,
             mode: "cmdline_normal",
         })
+
         expect(highlight).toBe("green")
+    })
+
+    it("should highlight the active tab with the normal mode color if the mode is in showmatch mode", () => {
+        const highlight = getHighlightColor({
+            theme: testTheme,
+            isSelected: true,
+            shouldShowHighlight: true,
+            mode: "showmatch",
+        })
+
+        expect(highlight).toBe("blue")
     })
 })

--- a/ui-tests/Tabs.test.tsx
+++ b/ui-tests/Tabs.test.tsx
@@ -7,7 +7,7 @@ import { FileIcon } from "../browser/src/Services/FileIcon"
 jest.mock("../browser/src/UI/components/Sneakable")
 import { Sneakable } from "../browser/src/UI/components/Sneakable"
 
-import { Corner, Name, Tab, Tabs } from "../browser/src/UI/components/Tabs"
+import { Corner, getHighlightColor, Name, Tab, Tabs } from "../browser/src/UI/components/Tabs"
 
 const MockFileIcon = FileIcon as jest.Mock<{}>
 const MockSneakable = Sneakable as jest.Mock<Sneakable>
@@ -77,6 +77,20 @@ describe("<Tabs /> Tests", () => {
         <Tabs
             fontSize="1.2em"
             shouldShowHighlight
+            mode="normal"
+            maxWidth="20em"
+            height="2em"
+            fontFamily="inherit"
+            shouldWrap={false}
+            visible={false}
+            tabs={[tab1]}
+        />
+    )
+
+    const unfocusedTab = (
+        <Tabs
+            fontSize="1.2em"
+            shouldShowHighlight={false}
             mode="normal"
             maxWidth="20em"
             height="2em"
@@ -203,5 +217,35 @@ describe("<Tabs /> Tests", () => {
         expect(fileIcon.props().fileName).toEqual(tab.props().iconFileName)
 
         wrapper.unmount()
+    })
+
+    it("should have a transparent border if not selected", () => {
+        const highlight = getHighlightColor({
+            theme: { "highlight.mode.normal.background": "green" } as any,
+            isSelected: false,
+            shouldShowHighlight: true,
+            mode: "normal",
+        })
+        expect(highlight).toBe("transparent")
+    })
+
+    it("should highlight the active tab with the mode color", () => {
+        const highlight = getHighlightColor({
+            theme: { "highlight.mode.normal.background": "green" } as any,
+            isSelected: true,
+            shouldShowHighlight: true,
+            mode: "normal",
+        })
+        expect(highlight).toBe("green")
+    })
+
+    it("should highlight the active tab with the normal mode color if the mode is a commandline mode", () => {
+        const highlight = getHighlightColor({
+            theme: { "highlight.mode.normal.background": "green" } as any,
+            isSelected: true,
+            shouldShowHighlight: true,
+            mode: "cmdline_normal",
+        })
+        expect(highlight).toBe("green")
     })
 })


### PR DESCRIPTION
@CrossR seems there was one small-ish regression with the tabs the border top of the inactive tabs is supposed to be transparent so there isnt a resizing flicker this PR fixes it and adds some test cases for the functionality.

I'll avoid using cherry pick commits from #1915 in the future, since it was a WIP and its hard to know what bits were converted or how, makes it hard for me to find the regressions, but think this was it for that branch will create one from scratch for the menu components and later the other bits