### PR TITLE
Bugfix/fix hero screenshot test

### DIFF
--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -8,8 +8,8 @@ import * as path from "path"
 
 import { remote } from "electron"
 
-import { getDistPath, getRootPath } from "./DemoCommon"
 import { getCompletionElement } from "../ci/Common"
+import { getDistPath, getRootPath } from "./DemoCommon"
 
 // tslint:disable:no-console
 const getNotificationText = () => {

--- a/test/demo/HeroScreenshot.ts
+++ b/test/demo/HeroScreenshot.ts
@@ -9,18 +9,9 @@ import * as path from "path"
 import { remote } from "electron"
 
 import { getDistPath, getRootPath } from "./DemoCommon"
+import { getCompletionElement } from "../ci/Common"
 
 // tslint:disable:no-console
-
-const getCompletionElement = () => {
-    const elements = document.body.getElementsByClassName("autocompletion")
-    if (!elements || !elements.length) {
-        return null
-    } else {
-        return elements[0]
-    }
-}
-
 const getNotificationText = () => {
     const elements = document.body.getElementsByClassName("notification-description")
 


### PR DESCRIPTION
The `HeroDemo.ts` is currently failing on mac as it was using the `className` autocompletion -> which was changed when the `contextMenu` was changed to a styled-component, this fixes it to use the method created for the purpose of testing the autocompletion component in `ci/Common.ts`