### PR TITLE
Fix #2466 by increasing MAX_CHORD_SIZE to prevent key swallowing

### DIFF
--- a/browser/src/Services/InputManager.ts
+++ b/browser/src/Services/InputManager.ts
@@ -18,7 +18,7 @@ export interface KeyBindingMap {
 }
 
 const MAX_DELAY_BETWEEN_KEY_CHORD = 250 /* milliseconds */
-const MAX_CHORD_SIZE = 4
+const MAX_CHORD_SIZE = 6
 
 import { KeyboardResolver } from "./../Input/Keyboard/KeyboardResolver"
 


### PR DESCRIPTION
The issue is in getRecentKeyPresses of the InputManager, this returns the first 4 key presses and swallows newer key presses when typing quickly. The swallowing of the keys is based on the MAX_CHORD_SIZE, setting this to 5 fixed the issue for me. To be sure I increased MAX_CHORD_SIZE to 6.