### PR TITLE
Fixed problem when some visual artifacts may appear after resize

### DIFF
--- a/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimRenderer.tsx
@@ -64,7 +64,8 @@ export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, {}
         const width = this._element.offsetWidth
         const height = this._element.offsetHeight
 
-        this.props.neovimInstance.resize(width, height)
-        this.props.renderer.redrawAll(this.props.screen)
+        this.props.neovimInstance
+            .resize(width, height)
+            .then(() => this.props.renderer.redrawAll(this.props.screen))
     }
 }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -683,13 +683,13 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         })
     }
 
-    public resize(widthInPixels: number, heightInPixels: number): void {
+    public resize(widthInPixels: number, heightInPixels: number): Promise<{}> {
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
 
         const size = this._getSize()
 
-        this._resizeInternal(size.rows, size.cols)
+        return this._resizeInternal(size.rows, size.cols)
     }
 
     public async getApiVersion(): Promise<INeovimApiVersion> {
@@ -742,7 +742,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         })
     }
 
-    private _resizeInternal(rows: number, columns: number): void {
+    private _resizeInternal(rows: number, columns: number): Promise<{}> {
         if (this._configuration.hasValue("debug.fixedSize")) {
             const fixedSize = this._configuration.getValue("debug.fixedSize")
             rows = fixedSize.rows
@@ -751,7 +751,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         }
 
         if (rows === this._rows && columns === this._cols) {
-            return
+            return Promise.resolve({})
         }
 
         this._rows = rows
@@ -760,10 +760,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         // If _initPromise isn't initialized, it means the UI hasn't attached to NeoVim
         // yet. In that case, we don't need to call uiTryResize
         if (!this._initPromise) {
-            return
+            return Promise.resolve({})
         }
 
-        this._initPromise.then(() => {
+        return this._initPromise.then(() => {
             return this._neovim.request("nvim_ui_try_resize", [columns, rows])
         })
     }


### PR DESCRIPTION
I have menu hidden by default and observed visual artifacts after pressing Alt. Menu appears after I press Alt and editor area is resized, but not the whole area is redrawn, so I see 2 neovim's status bars. I also can reproduce similar behaviour by resizing Oni window.
[See video with this problem](https://youtu.be/3rmkU2MQlk8)

After investigation I've found that method `CanvasRenderer.redrawAll` is called before neovim is really resized so it draws state of neovim before resize. So I've changed code so it called only when Promise returned by `NeovimInstance.resize` method is resolved. Which is actually Promise returned by `Session.request` method, so should be resolved when neovim finished resizing itself.