### PR TITLE
Feature/Add vue textmate grammar

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -181,6 +181,14 @@ const BaseConfiguration: IConfigurationValues = {
     "language.go.languageServer.command": "go-langserver",
     "language.go.textMateGrammar": path.join(__dirname, "extensions", "go", "syntaxes", "go.json"),
 
+    "language.vue.textMateGrammar": path.join(
+        __dirname,
+        "extensions",
+        "vue",
+        "syntaxes",
+        "vue.json",
+    ),
+
     "language.python.languageServer.command": "pyls",
     "language.cpp.languageServer.command": "clangd",
     "language.c.languageServer.command": "clangd",

--- a/extensions/vue/syntaxes/vue.json
+++ b/extensions/vue/syntaxes/vue.json
@@ -1,0 +1,1007 @@
+{
+    "uuid": "5512c10d-4cc5-434c-b8fc-53b912f55ab3",
+    "repository": {
+        "entities": {
+            "patterns": [
+                {
+                    "captures": {
+                        "3": {
+                            "name": "punctuation.definition.entity.html"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.entity.html"
+                        }
+                    },
+                    "match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+                    "name": "constant.character.entity.html"
+                },
+                {
+                    "match": "&",
+                    "name": "invalid.illegal.bad-ampersand.html"
+                }
+            ]
+        },
+        "string-single-quoted": {
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.html"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#vue-interpolations"
+                },
+                {
+                    "include": "#entities"
+                }
+            ],
+            "begin": "'",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.html"
+                }
+            },
+            "end": "'",
+            "name": "string.quoted.single.html"
+        },
+        "string-double-quoted": {
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.html"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#vue-interpolations"
+                },
+                {
+                    "include": "#entities"
+                }
+            ],
+            "begin": "\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.html"
+                }
+            },
+            "end": "\"",
+            "name": "string.quoted.double.html"
+        },
+        "vue-interpolations": {
+            "patterns": [
+                {
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.generic.begin.html"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "source.js"
+                        }
+                    ],
+                    "begin": "\\{\\{\\{?",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.generic.end.html"
+                        }
+                    },
+                    "end": "\\}\\}\\}?",
+                    "name": "expression.embbeded.vue"
+                }
+            ]
+        },
+        "vue-directives": {
+            "captures": {
+                "2": {
+                    "name": "punctuation.separator.key-value.html"
+                },
+                "3": {
+                    "name": "entity.other.attribute-name.html"
+                },
+                "1": {
+                    "name": "entity.other.attribute-name.html"
+                },
+                "6": {
+                    "name": "punctuation.separator.key-value.html"
+                },
+                "4": {
+                    "name": "entity.other.attribute-name.html"
+                },
+                "5": {
+                    "name": "entity.other.attribute-name.html"
+                }
+            },
+            "begin":
+                "(?:\\b(v-)|(:|@))([a-zA-Z\\-_]+)(?:\\:([a-zA-Z\\-_]+))?(?:\\.([a-zA-Z\\-_]+))*\\s*(=)",
+            "end": "(?<='|\")",
+            "name": "meta.directive.vue",
+            "patterns": [
+                {
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.html"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "source.js"
+                        }
+                    ],
+                    "begin": "\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.html"
+                        }
+                    },
+                    "end": "\"",
+                    "name": "source.directive.vue"
+                },
+                {
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.html"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "source.js"
+                        }
+                    ],
+                    "begin": "'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.html"
+                        }
+                    },
+                    "end": "'",
+                    "name": "source.directive.vue"
+                }
+            ]
+        },
+        "tag-generic-attribute": {
+            "match": "\\b([a-zA-Z\\-:_]+)",
+            "name": "entity.other.attribute-name.html"
+        },
+        "tag-id-attribute": {
+            "captures": {
+                "2": {
+                    "name": "punctuation.separator.key-value.html"
+                },
+                "1": {
+                    "name": "entity.other.attribute-name.id.html"
+                }
+            },
+            "begin": "\\b(id)\\b\\s*(=)",
+            "end": "(?<='|\")",
+            "name": "meta.attribute-with-value.id.html",
+            "patterns": [
+                {
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.html"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#vue-interpolations"
+                        },
+                        {
+                            "include": "#entities"
+                        }
+                    ],
+                    "begin": "\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.html"
+                        }
+                    },
+                    "end": "\"",
+                    "name": "string.quoted.double.html",
+                    "contentName": "meta.toc-list.id.html"
+                },
+                {
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.html"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#vue-interpolations"
+                        },
+                        {
+                            "include": "#entities"
+                        }
+                    ],
+                    "begin": "'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.html"
+                        }
+                    },
+                    "end": "'",
+                    "name": "string.quoted.single.html",
+                    "contentName": "meta.toc-list.id.html"
+                }
+            ]
+        },
+        "tag-stuff": {
+            "patterns": [
+                {
+                    "include": "#vue-directives"
+                },
+                {
+                    "include": "#tag-id-attribute"
+                },
+                {
+                    "include": "#tag-generic-attribute"
+                },
+                {
+                    "include": "#string-double-quoted"
+                },
+                {
+                    "include": "#string-single-quoted"
+                }
+            ]
+        }
+    },
+    "patterns": [
+        {
+            "captures": {
+                "0": {
+                    "name": "punctuation.definition.comment.html"
+                }
+            },
+            "begin": "<!--",
+            "end": "--\\s*>",
+            "name": "comment.block.html",
+            "patterns": [
+                {
+                    "match": "--",
+                    "name": "invalid.illegal.bad-comments-or-CDATA.html"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(template)\\b(?=[^/>]*/>\\s*$)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.end.html"
+                }
+            },
+            "end": "(/>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(template)(?=[^>]*>[^/>]*</template>)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(template)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</template>)"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin":
+                "(<)(template)\\b(?=[^>]*lang=('jade'|\"jade\"|'pug'|\"pug\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(template)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</template>)",
+                    "patterns": [
+                        {
+                            "include": "text.pug"
+                        }
+                    ],
+                    "contentName": "text.pug"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(template)\\b(?=[^>]*lang=('haml'|\"haml\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(template)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</template>)",
+                    "patterns": [
+                        {
+                            "include": "text.haml"
+                        }
+                    ],
+                    "contentName": "text.haml"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(template)\\b(?=[^>]*lang=('slm'|\"slm\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(template)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</template>)",
+                    "patterns": [
+                        {
+                            "include": "text.pug.slm"
+                        }
+                    ],
+                    "contentName": "text.pug.slm"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(template)(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.template.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(template)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</template>)",
+                    "patterns": [
+                        {
+                            "include": "text.html.vue-html"
+                        }
+                    ],
+                    "contentName": "text.html.vue-html"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)\\b(?=[^/>]*/>\\s*$)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.end.html"
+                }
+            },
+            "end": "(/>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)(?=[^>]*>[^/>]*</style>)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)\\b(?=[^>]*lang=('sass'|\"sass\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)",
+                    "patterns": [
+                        {
+                            "include": "source.sass"
+                        }
+                    ],
+                    "contentName": "source.sass"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)\\b(?=[^>]*lang=('scss'|\"scss\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)",
+                    "patterns": [
+                        {
+                            "include": "source.css.scss"
+                        }
+                    ],
+                    "contentName": "source.css.scss"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)\\b(?=[^>]*lang=('less'|\"less\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)",
+                    "patterns": [
+                        {
+                            "include": "source.css.less"
+                        }
+                    ],
+                    "contentName": "source.css.less"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)\\b(?=[^>]*lang=('stylus'|\"stylus\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)",
+                    "patterns": [
+                        {
+                            "include": "source.stylus"
+                        }
+                    ],
+                    "contentName": "source.stylus"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)\\b(?=[^>]*lang=('postcss'|\"postcss\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)",
+                    "patterns": [
+                        {
+                            "include": "source.css.postcss"
+                        }
+                    ],
+                    "contentName": "source.css.postcss"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(style)(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(style)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</style>)",
+                    "patterns": [
+                        {
+                            "include": "source.css"
+                        }
+                    ],
+                    "contentName": "source.css"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(script)\\b(?=[^>]*/>$)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.end.html"
+                }
+            },
+            "end": "(/>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(script)(?=[^>]*>[^/>]*</script>)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(script)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</script>)"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(script)\\b(?=[^>]*lang=('ts'|\"ts\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(script)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</script>)",
+                    "patterns": [
+                        {
+                            "include": "source.ts"
+                        }
+                    ],
+                    "contentName": "source.ts"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(script)\\b(?=[^>]*lang=('coffee'|\"coffee\"))(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(script)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</script>)",
+                    "patterns": [
+                        {
+                            "include": "source.coffee"
+                        }
+                    ],
+                    "contentName": "source.coffee"
+                }
+            ]
+        },
+        {
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "begin": "(<)(script)(?![^/>]*/>\\s*$)",
+            "endCaptures": {
+                "2": {
+                    "name": "entity.name.tag.script.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                }
+            },
+            "end": "(</)(script)(>)",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                },
+                {
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.end.html"
+                        }
+                    },
+                    "begin": "(>)",
+                    "end": "(?=</script>)",
+                    "patterns": [
+                        {
+                            "include": "source.js"
+                        }
+                    ],
+                    "contentName": "source.js"
+                }
+            ]
+        }
+    ],
+    "fileTypes": ["vue"],
+    "name": "Vue Component",
+    "scopeName": "source.vue"
+}


### PR DESCRIPTION
This PR adds a language grammar for vue js, relates to #1927, where the absence of a textmate grammar was discussed.
The grammar was sourced from [here](
    https://github.com/vuejs/vetur/blob/master/syntaxes/vue.json)