### PR TITLE
Feature/remeasure window on commandline hide and show

### DIFF
--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -75,6 +75,12 @@ export class NeovimWindowManager extends Utility.Disposable {
         this._scrollObservable = new Subject<EventContext>()
 
         const updateScroll = (evt: EventContext) => this._scrollObservable.next(evt)
+
+        const handleCommandLineEvent = async () => {
+            const ctx = await this._neovimInstance.getContext()
+            updateScroll(ctx)
+        }
+
         // First element of the BufEnter event is the current buffer
         this.trackDisposable(
             this._neovimInstance.autoCommands.onBufEnter.subscribe(bufs =>
@@ -94,10 +100,10 @@ export class NeovimWindowManager extends Utility.Disposable {
             this._neovimInstance.autoCommands.onCursorMoved.subscribe(updateScroll),
         )
         this.trackDisposable(
-            this._neovimInstance.onCommandLineShow.subscribe(async () => {
-                const context = await this._neovimInstance.getContext()
-                updateScroll(context)
-            }),
+            this._neovimInstance.onCommandLineShow.subscribe(handleCommandLineEvent),
+        )
+        this.trackDisposable(
+            this._neovimInstance.onCommandLineHide.subscribe(handleCommandLineEvent),
         )
         this.trackDisposable(this._neovimInstance.autoCommands.onVimResized.subscribe(updateScroll))
         this.trackDisposable(this._neovimInstance.onScroll.subscribe(updateScroll))


### PR DESCRIPTION
This relates to #2612, the commandline can cause the window/viewport to be repositioned if `incsearch` is enabled and so the window will shift to the next available match if this is off screen the window will reposition but this isn't passed on to the buffer layer render context so things like the indent lines remain incorrectly placed.

This change causes the window to remeasure when this changes (the observable is essentially already throttled using `distinctUntil` so don't think this should cause a performance issue as it will remeasure if the context changes i.e. if a reposition occurred.

Unfortunately there isn't a more specific event to hook into if the window moves