### PR TITLE
[WIP] Feature/add csv renderer extension

### DIFF
--- a/extensions/oni-plugin-csv-reader/package.json
+++ b/extensions/oni-plugin-csv-reader/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "oni-plugin-csv-reader",
+    "version": "1.0.0",
+    "description": "A CSV Reader plugin for Oni",
+    "main": "lib/index.js",
+    "author": "A. Sowemimo",
+    "license": "MIT",
+    "engines": {
+        "oni": "^0.2.6"
+    },
+    "scripts": {
+        "build": "rimraf lib && tsc",
+        "test": "jest"
+    },
+    "dependencies": {
+        "oni-api": "^0.0.46",
+        "oni-types": "^0.0.8",
+        "papaparse": "^4.6.0",
+        "react": "^16.4.2"
+    },
+    "devDependencies": {
+        "rimraf": "^2.6.2",
+        "typescript": "^2.9.2"
+    },
+    "peerDependencies": {
+        "jest": "^23.5.0",
+        "styled-components": "^3.2.6"
+    }
+}

--- a/extensions/oni-plugin-csv-reader/package.json
+++ b/extensions/oni-plugin-csv-reader/package.json
@@ -19,11 +19,13 @@
         "react": "^16.4.2"
     },
     "devDependencies": {
+        "@types/papaparse": "^4.5.4",
         "rimraf": "^2.6.2",
         "typescript": "^2.9.2"
     },
     "peerDependencies": {
         "jest": "^23.5.0",
-        "styled-components": "^3.2.6"
+        "styled-components": "^3.2.6",
+        "react-virtualized": "^9.19.1"
     }
 }

--- a/extensions/oni-plugin-csv-reader/src/index.tsx
+++ b/extensions/oni-plugin-csv-reader/src/index.tsx
@@ -1,0 +1,59 @@
+import * as Oni from "oni-api"
+import * as React from "react"
+import * as path from "path"
+
+import { parseCsvToRowsAndColumn } from "./utils"
+
+const isCompatible = (buf: Oni.EditorBufferEventArgs) => {
+    const ext = path.extname(buf.filePath)
+    return ext === ".csv"
+}
+
+interface IProps {
+    context: Oni.BufferLayerRenderContext
+}
+
+interface IState {
+    csv: string[][]
+}
+
+class CSVReader extends React.Component<IProps, IState> {
+    state = {
+        csv: null,
+    }
+
+    componentDidMount() {
+        this.convertLines()
+    }
+
+    convertLines() {
+        const lines = this.props.context.visibleLines.join("\n")
+        const csv = parseCsvToRowsAndColumn(lines)
+        this.setState({ csv })
+    }
+    render() {
+        console.log("csv: ", this.state.csv)
+        return <div>Reader</div>
+    }
+}
+
+class CSVReaderLayer implements Oni.BufferLayer {
+    public get id() {
+        return "oni.csv.reader"
+    }
+
+    render(context: Oni.BufferLayerRenderContext) {
+        return <CSVReader context={context} />
+    }
+}
+
+export const activate = (oni: Oni.Plugin.Api) => {
+    oni.editors.activeEditor.onBufferEnter.subscribe(buf => {
+        const layer = new CSVReaderLayer()
+        if (isCompatible(buf)) {
+            oni.editors.activeEditor.activeBuffer.addLayer(layer)
+        } else {
+            oni.editors.activeEditor.activeBuffer.removeLayer(layer)
+        }
+    })
+}

--- a/extensions/oni-plugin-csv-reader/src/index.tsx
+++ b/extensions/oni-plugin-csv-reader/src/index.tsx
@@ -1,8 +1,10 @@
 import * as Oni from "oni-api"
 import * as React from "react"
 import * as path from "path"
+import { ParseResult } from "papaparse"
+import { Table, Column } from "react-virtualized"
 
-import { parseCsvToRowsAndColumn } from "./utils"
+import { parseCsvString } from "./utils"
 
 const isCompatible = (buf: Oni.EditorBufferEventArgs) => {
     const ext = path.extname(buf.filePath)
@@ -14,26 +16,52 @@ interface IProps {
 }
 
 interface IState {
-    csv: string[][]
+    csv: ParseResult["data"]
 }
 
 class CSVReader extends React.Component<IProps, IState> {
     state = {
-        csv: null,
+        csv: [],
     }
 
-    componentDidMount() {
-        this.convertLines()
+    async componentDidMount() {
+        await this.convertLines()
     }
 
-    convertLines() {
+    async convertLines() {
         const lines = this.props.context.visibleLines.join("\n")
-        const csv = parseCsvToRowsAndColumn(lines)
-        this.setState({ csv })
+        try {
+            const { data, errors } = await parseCsvString(lines)
+            console.log("data: ", data)
+            this.setState({ csv: data })
+        } catch (e) {
+            console.log("[Oni-CSV-Reader Error]: ", e)
+        }
     }
     render() {
-        console.log("csv: ", this.state.csv)
-        return <div>Reader</div>
+        return (
+            <Table
+                width={300}
+                height={300}
+                rowHeight={30}
+                headerHeight={20}
+                rowCount={this.state.csv.length}
+                rowGetter={this._getDatum}
+            >
+                <Column dataKey="name" width={90} />
+                <Column
+                    width={210}
+                    disableSort
+                    dataKey="random"
+                    cellRenderer={({ cellData }) => console.log({ cellData }) || cellData}
+                    flexGrow={1}
+                />
+            </Table>
+        )
+    }
+    _getDatum = ({ index }) => {
+        console.log("this.state.csv[index]: ", this.state.csv[index])
+        return this.state.csv[index]
     }
 }
 
@@ -48,12 +76,14 @@ class CSVReaderLayer implements Oni.BufferLayer {
 }
 
 export const activate = (oni: Oni.Plugin.Api) => {
-    oni.editors.activeEditor.onBufferEnter.subscribe(buf => {
+    oni.editors.activeEditor.onBufferEnter.subscribe(async buf => {
         const layer = new CSVReaderLayer()
         if (isCompatible(buf)) {
+            // const ext = path.extname(buf.filePath)
+            // const bufferName = buf.filePath.replace("ext", "")
+            // const preview = await oni.editors.activeEditor.openFile(`CSV PREVIEW`)
+            // preview.addLayer(layer)
             oni.editors.activeEditor.activeBuffer.addLayer(layer)
-        } else {
-            oni.editors.activeEditor.activeBuffer.removeLayer(layer)
         }
     })
 }

--- a/extensions/oni-plugin-csv-reader/src/utils.ts
+++ b/extensions/oni-plugin-csv-reader/src/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Converts CSV to HTML Table
+ *
+ */
+
+export function parseCsvToRowsAndColumn(csvText: string, csvColumnDelimiter = "\t") {
+    const rows = csvText.split("\n")
+    const rowsWithColumns = rows.map(row => {
+        return row.split(csvColumnDelimiter)
+    })
+
+    return rowsWithColumns
+}

--- a/extensions/oni-plugin-csv-reader/src/utils.ts
+++ b/extensions/oni-plugin-csv-reader/src/utils.ts
@@ -1,3 +1,5 @@
+import * as Papa from "papaparse"
+
 /**
  * Converts CSV to HTML Table
  *
@@ -10,4 +12,19 @@ export function parseCsvToRowsAndColumn(csvText: string, csvColumnDelimiter = "\
     })
 
     return rowsWithColumns
+}
+
+export function parseCsvString(csvString: string) {
+    return new Promise<Papa.ParseResult>((resolve, reject) => {
+        const result = Papa.parse(csvString, {
+            header: true,
+            skipEmptyLines: true,
+            complete: results => {
+                resolve(results)
+            },
+            error(error) {
+                reject(error)
+            },
+        })
+    })
 }

--- a/extensions/oni-plugin-csv-reader/tsconfig.json
+++ b/extensions/oni-plugin-csv-reader/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "preserveConstEnums": true,
+        "outDir": "./lib",
+        "jsx": "react",
+        "lib": ["dom", "es2017"],
+        "declaration": true,
+        "sourceMap": true,
+        "target": "es2015",
+        "skipLibCheck": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx"],
+    "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -5,14 +5,7 @@
     "homepage": "https://www.onivim.io",
     "version": "0.3.7",
     "description": "Code editor with a modern twist on modal editing - powered by neovim.",
-    "keywords": [
-        "vim",
-        "neovim",
-        "text",
-        "editor",
-        "ide",
-        "vim"
-    ],
+    "keywords": ["vim", "neovim", "text", "editor", "ide", "vim"],
     "main": "./lib/main/src/main.js",
     "bin": {
         "oni": "./lib/cli/src/cli.js",
@@ -50,39 +43,23 @@
         "mac": {
             "artifactName": "${productName}-${version}-osx.${ext}",
             "category": "public.app-category.developer-tools",
-            "target": [
-                "dmg"
-            ],
-            "files": [
-                "bin/osx/**/*"
-            ]
+            "target": ["dmg"],
+            "files": ["bin/osx/**/*"]
         },
         "linux": {
             "artifactName": "${productName}-${version}-${arch}-linux.${ext}",
             "maintainer": "bryphe@outlook.com",
-            "target": [
-                "tar.gz",
-                "deb",
-                "rpm"
-            ]
+            "target": ["tar.gz", "deb", "rpm"]
         },
         "win": {
-            "target": [
-                "zip",
-                "dir"
-            ],
-            "files": [
-                "bin/x86/**/*"
-            ]
+            "target": ["zip", "dir"],
+            "files": ["bin/x86/**/*"]
         },
         "fileAssociations": [
             {
                 "name": "ADA source",
                 "role": "Editor",
-                "ext": [
-                    "adb",
-                    "ads"
-                ]
+                "ext": ["adb", "ads"]
             },
             {
                 "name": "Compiled AppleScript",
@@ -102,20 +79,12 @@
             {
                 "name": "ASP document",
                 "role": "Editor",
-                "ext": [
-                    "asp",
-                    "asa"
-                ]
+                "ext": ["asp", "asa"]
             },
             {
                 "name": "ASP.NET document",
                 "role": "Editor",
-                "ext": [
-                    "aspx",
-                    "ascx",
-                    "asmx",
-                    "ashx"
-                ]
+                "ext": ["aspx", "ascx", "asmx", "ashx"]
             },
             {
                 "name": "BibTeX bibliography",
@@ -130,13 +99,7 @@
             {
                 "name": "C++ source",
                 "role": "Editor",
-                "ext": [
-                    "cc",
-                    "cp",
-                    "cpp",
-                    "cxx",
-                    "c++"
-                ]
+                "ext": ["cc", "cp", "cpp", "cxx", "c++"]
             },
             {
                 "name": "C# source",
@@ -161,10 +124,7 @@
             {
                 "name": "Clojure source",
                 "role": "Editor",
-                "ext": [
-                    "clj",
-                    "cljs"
-                ]
+                "ext": ["clj", "cljs"]
             },
             {
                 "name": "Comma separated values",
@@ -179,20 +139,12 @@
             {
                 "name": "CGI script",
                 "role": "Editor",
-                "ext": [
-                    "cgi",
-                    "fcgi"
-                ]
+                "ext": ["cgi", "fcgi"]
             },
             {
                 "name": "Configuration file",
                 "role": "Editor",
-                "ext": [
-                    "cfg",
-                    "conf",
-                    "config",
-                    "htaccess"
-                ]
+                "ext": ["cfg", "conf", "config", "htaccess"]
             },
             {
                 "name": "Cascading style sheet",
@@ -217,10 +169,7 @@
             {
                 "name": "Erlang source",
                 "role": "Editor",
-                "ext": [
-                    "erl",
-                    "hrl"
-                ]
+                "ext": ["erl", "hrl"]
             },
             {
                 "name": "F-Script source",
@@ -230,32 +179,17 @@
             {
                 "name": "Fortran source",
                 "role": "Editor",
-                "ext": [
-                    "f",
-                    "for",
-                    "fpp",
-                    "f77",
-                    "f90",
-                    "f95"
-                ]
+                "ext": ["f", "for", "fpp", "f77", "f90", "f95"]
             },
             {
                 "name": "Header",
                 "role": "Editor",
-                "ext": [
-                    "h",
-                    "pch"
-                ]
+                "ext": ["h", "pch"]
             },
             {
                 "name": "C++ header",
                 "role": "Editor",
-                "ext": [
-                    "hh",
-                    "hpp",
-                    "hxx",
-                    "h++"
-                ]
+                "ext": ["hh", "hpp", "hxx", "h++"]
             },
             {
                 "name": "Go source",
@@ -265,28 +199,17 @@
             {
                 "name": "GTD document",
                 "role": "Editor",
-                "ext": [
-                    "gtd",
-                    "gtdlog"
-                ]
+                "ext": ["gtd", "gtdlog"]
             },
             {
                 "name": "Haskell source",
                 "role": "Editor",
-                "ext": [
-                    "hs",
-                    "lhs"
-                ]
+                "ext": ["hs", "lhs"]
             },
             {
                 "name": "HTML document",
                 "role": "Editor",
-                "ext": [
-                    "htm",
-                    "html",
-                    "phtml",
-                    "shtml"
-                ]
+                "ext": ["htm", "html", "phtml", "shtml"]
             },
             {
                 "name": "Include file",
@@ -326,10 +249,7 @@
             {
                 "name": "JavaScript source",
                 "role": "Editor",
-                "ext": [
-                    "js",
-                    "htc"
-                ]
+                "ext": ["js", "htc"]
             },
             {
                 "name": "Java Server Page",
@@ -354,14 +274,7 @@
             {
                 "name": "Lisp source",
                 "role": "Editor",
-                "ext": [
-                    "lisp",
-                    "cl",
-                    "l",
-                    "lsp",
-                    "mud",
-                    "el"
-                ]
+                "ext": ["lisp", "cl", "l", "lsp", "mud", "el"]
             },
             {
                 "name": "Log file",
@@ -381,12 +294,7 @@
             {
                 "name": "Markdown document",
                 "role": "Editor",
-                "ext": [
-                    "markdown",
-                    "mdown",
-                    "markdn",
-                    "md"
-                ]
+                "ext": ["markdown", "mdown", "markdn", "md"]
             },
             {
                 "name": "Makefile source",
@@ -396,29 +304,17 @@
             {
                 "name": "Mediawiki document",
                 "role": "Editor",
-                "ext": [
-                    "wiki",
-                    "wikipedia",
-                    "mediawiki"
-                ]
+                "ext": ["wiki", "wikipedia", "mediawiki"]
             },
             {
                 "name": "MIPS assembler source",
                 "role": "Editor",
-                "ext": [
-                    "s",
-                    "mips",
-                    "spim",
-                    "asm"
-                ]
+                "ext": ["s", "mips", "spim", "asm"]
             },
             {
                 "name": "Modula-3 source",
                 "role": "Editor",
-                "ext": [
-                    "m3",
-                    "cm3"
-                ]
+                "ext": ["m3", "cm3"]
             },
             {
                 "name": "MoinMoin document",
@@ -438,28 +334,17 @@
             {
                 "name": "OCaml source",
                 "role": "Editor",
-                "ext": [
-                    "ml",
-                    "mli",
-                    "mll",
-                    "mly"
-                ]
+                "ext": ["ml", "mli", "mll", "mly"]
             },
             {
                 "name": "Mustache document",
                 "role": "Editor",
-                "ext": [
-                    "mustache",
-                    "hbs"
-                ]
+                "ext": ["mustache", "hbs"]
             },
             {
                 "name": "Pascal source",
                 "role": "Editor",
-                "ext": [
-                    "pas",
-                    "p"
-                ]
+                "ext": ["pas", "p"]
             },
             {
                 "name": "Patch file",
@@ -469,11 +354,7 @@
             {
                 "name": "Perl source",
                 "role": "Editor",
-                "ext": [
-                    "pl",
-                    "pod",
-                    "perl"
-                ]
+                "ext": ["pl", "pod", "perl"]
             },
             {
                 "name": "Perl module",
@@ -483,80 +364,47 @@
             {
                 "name": "PHP source",
                 "role": "Editor",
-                "ext": [
-                    "php",
-                    "php3",
-                    "php4",
-                    "php5"
-                ]
+                "ext": ["php", "php3", "php4", "php5"]
             },
             {
                 "name": "PostScript source",
                 "role": "Editor",
-                "ext": [
-                    "ps",
-                    "eps"
-                ]
+                "ext": ["ps", "eps"]
             },
             {
                 "name": "Property list",
                 "role": "Editor",
-                "ext": [
-                    "dict",
-                    "plist",
-                    "scriptSuite",
-                    "scriptTerminology"
-                ]
+                "ext": ["dict", "plist", "scriptSuite", "scriptTerminology"]
             },
             {
                 "name": "Python source",
                 "role": "Editor",
-                "ext": [
-                    "py",
-                    "rpy",
-                    "cpy",
-                    "python"
-                ]
+                "ext": ["py", "rpy", "cpy", "python"]
             },
             {
                 "name": "R source",
                 "role": "Editor",
-                "ext": [
-                    "r",
-                    "s"
-                ]
+                "ext": ["r", "s"]
             },
             {
                 "name": "Ragel source",
                 "role": "Editor",
-                "ext": [
-                    "rl",
-                    "ragel"
-                ]
+                "ext": ["rl", "ragel"]
             },
             {
                 "name": "Remind document",
                 "role": "Editor",
-                "ext": [
-                    "rem",
-                    "remind"
-                ]
+                "ext": ["rem", "remind"]
             },
             {
                 "name": "reStructuredText document",
                 "role": "Editor",
-                "ext": [
-                    "rst",
-                    "rest"
-                ]
+                "ext": ["rst", "rest"]
             },
             {
                 "name": "HTML with embedded Ruby",
                 "role": "Editor",
-                "ext": [
-                    "rhtml",
-                    "erb"
-                ]
+                "ext": ["rhtml", "erb"]
             },
             {
                 "name": "SQL with embedded Ruby",
@@ -566,28 +414,17 @@
             {
                 "name": "Ruby source",
                 "role": "Editor",
-                "ext": [
-                    "rb",
-                    "rbx",
-                    "rjs",
-                    "rxml"
-                ]
+                "ext": ["rb", "rbx", "rjs", "rxml"]
             },
             {
                 "name": "Sass source",
                 "role": "Editor",
-                "ext": [
-                    "sass",
-                    "scss"
-                ]
+                "ext": ["sass", "scss"]
             },
             {
                 "name": "Scheme source",
                 "role": "Editor",
-                "ext": [
-                    "scm",
-                    "sch"
-                ]
+                "ext": ["scm", "sch"]
             },
             {
                 "name": "Setext document",
@@ -635,10 +472,7 @@
             {
                 "name": "SWIG source",
                 "role": "Editor",
-                "ext": [
-                    "i",
-                    "swg"
-                ]
+                "ext": ["i", "swg"]
             },
             {
                 "name": "Tcl source",
@@ -648,20 +482,12 @@
             {
                 "name": "TeX document",
                 "role": "Editor",
-                "ext": [
-                    "tex",
-                    "sty",
-                    "cls"
-                ]
+                "ext": ["tex", "sty", "cls"]
             },
             {
                 "name": "Plain text document",
                 "role": "Editor",
-                "ext": [
-                    "text",
-                    "txt",
-                    "utf8"
-                ]
+                "ext": ["text", "txt", "utf8"]
             },
             {
                 "name": "Textile document",
@@ -681,32 +507,17 @@
             {
                 "name": "XML document",
                 "role": "Editor",
-                "ext": [
-                    "xml",
-                    "xsd",
-                    "xib",
-                    "rss",
-                    "tld",
-                    "pt",
-                    "cpt",
-                    "dtml"
-                ]
+                "ext": ["xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml"]
             },
             {
                 "name": "XSL stylesheet",
                 "role": "Editor",
-                "ext": [
-                    "xsl",
-                    "xslt"
-                ]
+                "ext": ["xsl", "xslt"]
             },
             {
                 "name": "Electronic business card",
                 "role": "Editor",
-                "ext": [
-                    "vcf",
-                    "vcard"
-                ]
+                "ext": ["vcf", "vcard"]
             },
             {
                 "name": "Visual Basic source",
@@ -716,10 +527,7 @@
             {
                 "name": "YAML document",
                 "role": "Editor",
-                "ext": [
-                    "yaml",
-                    "yml"
-                ]
+                "ext": ["yaml", "yml"]
             },
             {
                 "name": "Text document",
@@ -781,8 +589,10 @@
     "scripts": {
         "precommit": "pretty-quick --staged",
         "prepush": "yarn run build && yarn run lint",
-        "build": "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
-        "build-debug": "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
+        "build":
+            "yarn run build:browser && yarn run build:webview_preload && yarn run build:main && yarn run build:plugins && yarn run build:cli",
+        "build-debug":
+            "yarn run build:browser-debug && yarn run build:main  && yarn run build:plugins",
         "build:browser": "webpack --config browser/webpack.production.config.js",
         "build:browser-debug": "webpack --config browser/webpack.debug.config.js",
         "build:main": "cd main && tsc -p tsconfig.json",
@@ -790,66 +600,96 @@
         "build:cli": "cd cli && tsc -p tsconfig.json",
         "build:plugin:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && yarn run build",
         "build:plugin:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn run build",
-        "build:plugin:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn run build",
+        "build:plugin:oni-plugin-markdown-preview":
+            "cd extensions/oni-plugin-markdown-preview && yarn run build",
         "build:plugin:oni-plugin-quickopen": "cd extensions/oni-plugin-quickopen && yarn run build",
+        "build:plugin:oni-plugin-csv-reader":
+            "cd extensions/oni-plugin-csv-reader && yarn run build",
         "build:test": "yarn run build:test:unit && yarn run build:test:integration",
         "build:test:integration": "cd test && tsc -p tsconfig.json",
         "build:test:unit": "run-s build:test:unit:*",
-        "build:test:unit:browser": "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
+        "build:test:unit:browser":
+            "rimraf lib_test/browser && cd browser && tsc -p tsconfig.test.json",
         "build:test:unit:main": "rimraf lib_test/main && cd main && tsc -p tsconfig.test.json",
         "build:webview_preload": "cd webview_preload && tsc -p tsconfig.json",
         "check-cached-binaries": "node build/script/CheckBinariesForBuild.js",
         "copy-icons": "node build/CopyIcons.js",
-        "debug:test:unit:browser": "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "demo:screenshot": "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
-        "demo:video": "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
-        "dist:win:x86": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
-        "dist:win:x64": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
-        "pack:win": "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
+        "debug:test:unit:browser":
+            "cd browser && tsc -p tsconfig.test.json && electron-mocha --interactive --debug --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "demo:screenshot":
+            "yarn run build:test && cross-env DEMO_TEST=HeroScreenshot mocha -t 30000000 lib_test/test/Demo.js",
+        "demo:video":
+            "yarn run build:test && cross-env DEMO_TEST=HeroDemo mocha -t 30000000 lib_test/test/Demo.js",
+        "dist:win:x86":
+            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch ia32 --publish never",
+        "dist:win:x64":
+            "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --arch x64 --publish never",
+        "pack:win":
+            "node build/BuildSetupTemplate.js && innosetup-compiler dist/setup.iss --verbose --O=dist",
         "test": "yarn run test:unit && yarn run test:integration",
-        "test:setup": "yarn run build:test:integration && mocha -t 120000 --recursive lib_test/test/setup",
-        "test:integration": "yarn run build:test:integration && mocha -t 120000 lib_test/test/CiTests.js --bail",
+        "test:setup":
+            "yarn run build:test:integration && mocha -t 120000 --recursive lib_test/test/setup",
+        "test:integration":
+            "yarn run build:test:integration && mocha -t 120000 lib_test/test/CiTests.js --bail",
         "test:unit:react": "jest --config ./jest.config.js ./ui-tests",
         "test:unit:react:watch": "jest --config ./jest.config.js ./ui-tests --watch",
         "test:unit:react:coverage": "jest --config ./jest.config.js ./ui-tests --coverage",
-        "test:unit:browser": "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
-        "test:unit": "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:unit:react",
-        "test:unit:main": "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
+        "test:unit:browser":
+            "yarn run build:test:unit:browser && cd browser && electron-mocha --renderer --require testHelpers.js --recursive ../lib_test/browser/test",
+        "test:unit":
+            "yarn run test:unit:browser && yarn run test:unit:main && yarn run test:unit:react",
+        "test:unit:main":
+            "yarn run build:test:unit:main && cd main && electron-mocha --renderer --recursive ../lib_test/main/test",
         "upload:dist": "node build/script/UploadDistributionBuildsToAzure",
         "fix-lint": "run-p fix-lint:*",
-        "fix-lint:browser": "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "fix-lint:browser":
+            "tslint --fix --project browser/tsconfig.json --exclude **/node_modules/**/* --config tslint.json && tslint --fix --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --fix --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "fix-lint:cli": "tslint --fix --project cli/tsconfig.json --config tslint.json",
         "fix-lint:main": "tslint --fix --project main/tsconfig.json --config tslint.json",
         "fix-lint:test": "tslint --fix --project test/tsconfig.json --config tslint.json",
         "lint": "yarn run lint:browser && yarn run lint:main && yarn run lint:test",
-        "lint:browser": "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
+        "lint:browser":
+            "tslint --project browser/tsconfig.json --config tslint.json && tslint --project vim/core/oni-plugin-typescript/tsconfig.json --config tslint.json && tslint --project extensions/oni-plugin-markdown-preview/tsconfig.json --config tslint.json",
         "lint:cli": "tslint --project cli/tsconfig.json --config tslint.json",
         "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
-        "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
+        "lint:test":
+            "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts && tslint extensions/oni-plugin-markdown-preview/src/**/*.ts",
         "pack": "cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 build --publish never",
-        "ccov:instrument": "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
-        "ccov:test:browser": "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
-        "ccov:remap:browser:html": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
-        "ccov:remap:browser:lcov": "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
+        "ccov:instrument":
+            "nyc instrument --all true --sourceMap false lib_test/browser/src lib_test/browser/src_ccov",
+        "ccov:test:browser":
+            "cross-env ONI_CCOV=1 electron-mocha --renderer --require browser/testHelpers.js -R browser/testCoverageReporter --recursive lib_test/browser/test",
+        "ccov:remap:browser:html":
+            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output html-report --type html",
+        "ccov:remap:browser:lcov":
+            "cd lib_test/browser/src && remap-istanbul --input ../../../coverage/coverage-final.json --output lcov.info --type lcovonly",
         "ccov:clean": "rimraf coverage",
         "ccov:upload:jest": "cd ./coverage/jest && codecov",
         "ccov:upload": "codecov",
         "launch": "electron lib/main/src/main.js",
-        "start": "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
-        "start-hot": "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
+        "start":
+            "concurrently --kill-others \"yarn run start-hot\" \"yarn run watch:browser\" \"yarn run watch:plugins\"",
+        "start-hot":
+            "cross-env ONI_WEBPACK_LOAD=1 NODE_ENV=development electron lib/main/src/main.js",
         "start-not-dev": "cross-env electron main.js",
-        "watch:browser": "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
+        "watch:browser":
+            "webpack-dev-server --config browser/webpack.development.config.js --host localhost --port 8191",
         "watch:plugins": "run-p --race watch:plugins:*",
         "watch:plugins:oni-plugin-typescript": "cd vim/core/oni-plugin-typescript && tsc --watch",
-        "watch:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && tsc --watch",
+        "watch:plugins:oni-plugin-markdown-preview":
+            "cd extensions/oni-plugin-markdown-preview && tsc --watch",
         "watch:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && tsc --watch",
         "watch:plugins:oni-plugin-quickopen": "cd extensions/oni-plugin-quickopen && tsc --watch",
+        "watch:plugins:oni-plugin-csv-reader": "cd extensions/oni-plugin-csv-reader && tsc --watch",
         "install:plugins": "run-s install:plugins:*",
-        "install:plugins:oni-plugin-markdown-preview": "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
-        "install:plugins:oni-plugin-prettier": "cd extensions/oni-plugin-prettier && yarn install --prod",
+        "install:plugins:oni-plugin-markdown-preview":
+            "cd extensions/oni-plugin-markdown-preview && yarn install --prod",
+        "install:plugins:oni-plugin-prettier":
+            "cd extensions/oni-plugin-prettier && yarn install --prod",
         "install:plugins:oni-plugin-git": "cd vim/core/oni-plugin-git && yarn install --prod",
         "postinstall": "yarn run install:plugins && electron-rebuild && opencollective postinstall",
-        "profile:webpack": "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
+        "profile:webpack":
+            "webpack --config browser/webpack.production.config.js --profile --json > stats.json && webpack-bundle-analyzer browser/stats.json"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Very initial implementation of a csv previewer the idea is similar functionality (but more basic) as vscode `excel preview` i.e. like the markdown preview open a split and render a csv in a tabular format -> thats the end goal, fancier functionality can come later.

Current Issues:
- [ ] Figure out how to render a table with react virtualized