### PR TITLE
Feature/add workerize utility

### DIFF
--- a/browser/src/Workerize.ts
+++ b/browser/src/Workerize.ts
@@ -2,10 +2,6 @@ interface IArgs<T> {
     data: T
 }
 
-interface IContext {
-    [key: string]: any
-}
-
 type Callback<T> = (args?: T) => void
 
 /**
@@ -13,41 +9,27 @@ type Callback<T> = (args?: T) => void
  * passes it off to a dynamically generated WebWorker
  * and returns a promise to resolve the return value of the function
  *
+ * limitations: function has to be Pure! -> no external dependencies etc.
  * @name workerize
  * @function
  * @param Callback<T>
  * @param args?: T
- * @param context?: any
  * @returns Promise<R>
  */
-export function workerize<T, R>(work: Callback<T>, args?: T, context?: IContext) {
+export function workerize<T, R>(work: Callback<T>, args?: T) {
     const handleResult = ({ data }: IArgs<T>) => {
         const result = work(data)
         const worker: Worker = self as any
         return worker.postMessage(result)
     }
 
-    const globalVars = createContextVars(context)
     // courtesy of this gem -
     // https://stackoverflow.com/questions/42773714/is-async-await-truly-non-blocking-in-the-browser
     // writes the contents of the string passed in to a file and executes it.
-    const blob = new Blob(
-        [`var work = ${work};\n ${globalVars} onmessage = ${handleResult.toString()}`],
-        {
-            type: "text/javascript",
-        },
-    )
+    const blob = new Blob([`var work = ${work};\n onmessage = ${handleResult.toString()}`], {
+        type: "text/javascript",
+    })
     const worker = new Worker(URL.createObjectURL(blob))
     worker.postMessage(args)
     return new Promise<R>(resolve => (worker.onmessage = evt => resolve(evt.data)))
-}
-
-const createContextVars = (context: IContext) => {
-    if (!context) {
-        return ""
-    }
-    return Object.keys(context).reduce((acc, key) => {
-        acc += `var ${key} = ${context[key]};\n`
-        return acc
-    }, "")
 }

--- a/browser/src/Workerize.ts
+++ b/browser/src/Workerize.ts
@@ -1,0 +1,53 @@
+interface IArgs<T> {
+    data: T
+}
+
+interface IContext {
+    [key: string]: any
+}
+
+type Callback<T> = (args?: T) => void
+
+/**
+ * Takes a CPU intensive function
+ * passes it off to a dynamically generated WebWorker
+ * and returns a promise to resolve the return value of the function
+ *
+ * @name workerize
+ * @function
+ * @param Callback<T>
+ * @param args?: T
+ * @param context?: any
+ * @returns Promise<R>
+ */
+export function workerize<T, R>(work: Callback<T>, args?: T, context?: IContext) {
+    const handleResult = ({ data }: IArgs<T>) => {
+        const result = work(data)
+        const worker: Worker = self as any
+        return worker.postMessage(result)
+    }
+
+    const globalVars = createContextVars(context)
+    // courtesy of this gem -
+    // https://stackoverflow.com/questions/42773714/is-async-await-truly-non-blocking-in-the-browser
+    // writes the contents of the string passed in to a file and executes it.
+    const blob = new Blob(
+        [`var work = ${work};\n ${globalVars} onmessage = ${handleResult.toString()}`],
+        {
+            type: "text/javascript",
+        },
+    )
+    const worker = new Worker(URL.createObjectURL(blob))
+    worker.postMessage(args)
+    return new Promise<R>(resolve => (worker.onmessage = evt => resolve(evt.data)))
+}
+
+const createContextVars = (context: IContext) => {
+    if (!context) {
+        return ""
+    }
+    return Object.keys(context).reduce((acc, key) => {
+        acc += `var ${key} = ${context[key]};\n`
+        return acc
+    }, "")
+}

--- a/browser/src/Workerize.ts
+++ b/browser/src/Workerize.ts
@@ -19,8 +19,8 @@ type Callback<T> = (args?: T) => void
 export function workerize<T, R>(work: Callback<T>, args?: T) {
     const handleResult = ({ data }: IArgs<T>) => {
         const result = work(data)
-        const worker: Worker = self as any
-        return worker.postMessage(result)
+        const webWorker: Worker = self as any
+        return webWorker.postMessage(result)
     }
 
     // courtesy of this gem -


### PR DESCRIPTION
cc @bryphe

I've been experimenting with worker support still, and discovered a very minimal way to execute a *pure* function in a separate thread, this is similar to the `greenlet` library just even smaller.

It takes a function, and its arguments and runs the code in a separate thread, unfortunately I can't find any expensive *pure* functions to use it on.


I'm working on the syntaxHighlightingPeriodicJob on another branch, unfortunately it has quite a few external dependencies, currently blocked by the fact that `vscode-textmate` references the process variable which is undefined in the worker thread so causes errors