### PR TITLE
added a full-text search plugin I made in the Available Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Some available plugins created by Oni users are listed below (if you'd like to a
 plugin to this list please create a PR updating this **README** with the details).
 
 *   [Oni Touchbar Plugin](https://github.com/jordan-arenstein/oni-plugin-touchbar) - by [jordan-arenstein](https://github.com/jordan-arenstein?tab=overview&from=2018-07-01&to=2018-07-31)
+*   [quickFind](https://github.com/marene/quickFind) - by [marene](https://github.com/marene)
     *   Themes
         *   [Night Owl](https://github.com/Akin909/oni-theme-night-owl)
 


### PR DESCRIPTION
Hi!

As a disclaimer, I'd like to say this is my first contribution to Oni (and my first contribution to an open source project, as a matter of fact) ever.
So I want to apologize in advance if I'm doing and/or getting anything wrong here, and I'll be glad to correct it! :)

This pr adds the plugin [quickFind](https://github.com/marene/quickFind) to the `Available Plugins` section of the readme

To have more details about how the plugin work, please read its [readme](https://github.com/marene/quickFind/blob/master/README.md)

I made this pr because I was suggested to do so on the project's discord by Ryan C (couldn't find his github account to tag him in there), so here it is!