### PR TITLE
De-deduplicate completion items + improve sorting

### DIFF
--- a/browser/src/Services/Completion/CompletionSelectors.ts
+++ b/browser/src/Services/Completion/CompletionSelectors.ts
@@ -3,7 +3,8 @@
  *
  * Selectors are functions that take a state and derive a value from it.
  */
-import * as _ from "lodash"
+import * as isEqual from "lodash/isEqual"
+import * as omit from "lodash/omit"
 
 import { ICompletionState } from "./CompletionState"
 
@@ -125,9 +126,9 @@ const _uniq = (array: types.CompletionItem[]) => {
 
     while (++index < length) {
         const value = array[index]
-        const reduced = _.omit(value, "sortText")
         // Omit the `sortText` which can be different even if all other attributes are the same.
-        if (!index || !_.isEqual(reduced, seenReduced)) {
+        const reduced = omit(value, "sortText")
+        if (!index || !isEqual(reduced, seenReduced)) {
             seenReduced = reduced
             result[resIndex++] = value
         }

--- a/browser/test/Services/Completion/CompletionSelectorsTests.ts
+++ b/browser/test/Services/Completion/CompletionSelectorsTests.ts
@@ -1,0 +1,60 @@
+import * as assert from "assert"
+import { CompletionItem } from "vscode-languageserver-types"
+
+import { filterCompletionOptions } from "../../../src/Services/Completion/CompletionSelectors"
+
+describe("filterCompletionOptions", () => {
+    it("strips duplicates and sorts in order of abbreviation=>label=>sortText", () => {
+        const item1: CompletionItem = {
+            label: "mock duplicate",
+            detail: "mock detail",
+            sortText: "c",
+        }
+        const item2: CompletionItem = {
+            label: "mock duplicate",
+            detail: "mock detail",
+            sortText: "b",
+        }
+        const item3: CompletionItem = {
+            label: "mock duplicate",
+            detail: "mock not duplicate detail",
+            sortText: "a",
+        }
+        const item4: CompletionItem = {
+            label: "maaaaoaaaacaaaak abbreviation",
+        }
+        const item5: CompletionItem = {
+            label: "mock cherry",
+            filterText: "mock cherry",
+        }
+        const item6: CompletionItem = {
+            label: "mock cherry",
+            filterText: "mock banana",
+        }
+        const item7: CompletionItem = {
+            label: "mock apple",
+        }
+        const item8: CompletionItem = {
+            label: "doesnt match",
+        }
+        const item9: CompletionItem = {
+            label: "mock apple",
+            filterText: "doesnt match either",
+        }
+        const items: CompletionItem[] = [
+            item1,
+            item2,
+            item3,
+            item4,
+            item5,
+            item6,
+            item7,
+            item8,
+            item9,
+        ]
+
+        const filteredItems = filterCompletionOptions(items, "mock")
+
+        assert.deepStrictEqual(filteredItems, [item7, item6, item5, item3, item2, item4])
+    })
+})


### PR DESCRIPTION
* Remove duplicate completion items.  This seems to happen a lot with `cquery` (C++) completions.
* Continue to sort abbreviations below full matches.
* Sort matching `filterText`/`labels` so they appear next to each other.
* Otherwise use `sortText` given by the language server.