### PR TITLE
Feature/fix buffer opening closing

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -147,6 +147,8 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.quickOpen.alternativeOpenMode": Oni.FileOpenMode.ExistingTab,
     "editor.quickOpen.showHidden": true,
 
+    "quickOpen.defaultOpenMode": Oni.FileOpenMode.Edit,
+
     "editor.split.mode": "native",
 
     "editor.typingPrediction": true,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -165,6 +165,9 @@ export interface IConfigurationValues {
     "editor.quickOpen.alternativeOpenMode": Oni.FileOpenMode
     "editor.quickOpen.showHidden": boolean
 
+    // this is new command to replace the above legacy editor prefixed command
+    "quickOpen.defaultOpenMode": Oni.FileOpenMode
+
     "editor.errors.slideOnFocus": boolean
     "editor.formatting.formatOnSwitchToNormalMode": boolean // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
 

--- a/extensions/oni-plugin-quickopen/src/QuickOpen.ts
+++ b/extensions/oni-plugin-quickopen/src/QuickOpen.ts
@@ -343,7 +343,7 @@ export class QuickOpen {
 
     private getDefaultOpenMode(): Oni.FileOpenMode {
         const legacy = this._oni.configuration.getValue("editor.quickOpen.defaultOpenMode", null)
-        // the valude of the defaultOpenMode is an enum that includes 0 so we check that the value
+        // the valid of the defaultOpenMode is an enum that includes 0 so we check that the value
         // is a number and that number is an opetion in the file open mode enum
         if (!isNaN(legacy) && legacy in Oni.FileOpenMode) {
             return legacy

--- a/extensions/oni-plugin-quickopen/src/QuickOpen.ts
+++ b/extensions/oni-plugin-quickopen/src/QuickOpen.ts
@@ -343,8 +343,8 @@ export class QuickOpen {
 
     private getDefaultOpenMode(): Oni.FileOpenMode {
         const legacy = this._oni.configuration.getValue("editor.quickOpen.defaultOpenMode", null)
-        // the valid of the defaultOpenMode is an enum that includes 0 so we check that the value
-        // is a number and that number is an opetion in the file open mode enum
+        // the value of the defaultOpenMode is a numerical enum that includes 0 so we check that the value
+        // is a number and that number is an option in the file open mode enum
         if (!isNaN(legacy) && legacy in Oni.FileOpenMode) {
             return legacy
         }

--- a/extensions/oni-plugin-quickopen/src/QuickOpen.ts
+++ b/extensions/oni-plugin-quickopen/src/QuickOpen.ts
@@ -343,13 +343,18 @@ export class QuickOpen {
 
     private getDefaultOpenMode(): Oni.FileOpenMode {
         const legacy = this._oni.configuration.getValue("editor.quickOpen.defaultOpenMode", null)
-        if (legacy) {
+        // the valude of the defaultOpenMode is an enum that includes 0 so we check that the value
+        // is a number and that number is an opetion in the file open mode enum
+        if (!isNaN(legacy) && legacy in Oni.FileOpenMode) {
             return legacy
         }
-        return this._oni.configuration.getValue(
+
+        const defaultOpenMode = this._oni.configuration.getValue(
             "quickOpen.defaultOpenMode",
             Oni.FileOpenMode.NewTab,
         )
+
+        return defaultOpenMode
     }
 
     private isInstallDirectoryOrHome() {


### PR DESCRIPTION
Fixes #2639, the issue here was that during the refactor of the quick open menu we now check against the `Oni.FileOpenMode` enum for the *legacy* setting `editor.quickOpen.fileOpenMode` which is set to `Edit` which in the enum is represented by `O` so the legacy check `if(legacy //which is 0)` coerces to false and this fails.

The fn then looks for the new setting `quickOpen.fileOpenMode` which isn't set in the default config so that fails and the default value it is passed is `Oni.FileOpenMode.NewTab` so it calls `tabnew!`

this PR fixes the legacy check so it works and also adds a default config for the new command and sets it to edit by default