### PR TITLE
editsToUse are deeper in LSP WorkspaceEdit response

### DIFF
--- a/browser/src/Services/Workspace/Workspace.ts
+++ b/browser/src/Services/Workspace/Workspace.ts
@@ -71,10 +71,9 @@ export class Workspace implements Oni.Workspace.Api {
     }
 
     public async applyEdits(edits: types.WorkspaceEdit): Promise<void> {
-        let editsToUse = edits
-        if (edits.documentChanges) {
-            editsToUse = convertTextDocumentChangesToFileMap(edits.documentChanges)
-        }
+        const editsToUse = edits.documentChanges
+            ? convertTextDocumentChangesToFileMap(edits.documentChanges)
+            : edits.changes
 
         const files = Object.keys(editsToUse)
 


### PR DESCRIPTION
Edits are actually stored in `changes` field in WorkspaceEdit; see:
https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#workspaceedit

Resolves: #2646