### PR TITLE
React/Redux DevTools no longer working

### DIFF
--- a/package.json
+++ b/package.json
@@ -944,7 +944,7 @@
         "detect-indent": "^5.0.0",
         "electron": "2.0.8",
         "electron-builder": "^20.5.1",
-        "electron-devtools-installer": "^2.2.3",
+        "electron-devtools-installer": "^2.2.4",
         "electron-mocha": "5.0.0",
         "electron-rebuild": "^1.7.3",
         "enzyme": "^3.3.0",


### PR DESCRIPTION
add new dev dependency to solve problem

I think latest commit of 'electron-devtools-installer' solve problem. Here is link to [issue](https://github.com/MarshallOfSound/electron-devtools-installer/pull/88)