### PR TITLE
Fix "upath@1.0.4": The engine "node" is incompaible with this module.

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--add.ignore-engines true


### PR DESCRIPTION
This is a very small fix that prevents yarn from aborting the installation on
newer versions of NodeJS. It is merely a temporary fix; the real fix should be
to upgrade all of the dependencies.

Closes #2430.