### PR TITLE
Fix #2669 & #2396 - Failure to start Neovim on OSX 10.14 Mojave

### DIFF
--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -155,12 +155,26 @@ export class Process implements Oni.Process {
             existingPath = process.env.Path || process.env.PATH
         }
 
+        let additionalEnvironmentVariables =
+            configuration.getValue("environment.additionalVariables") || {}
+
         const requiredOptions = {
             env: {
                 ...process.env,
                 ...this._env,
                 ...originalSpawnOptions.env,
+                ...additionalEnvironmentVariables,
             },
+        }
+
+        // TODO: Workaround for the bug fix here:
+        // https://github.com/neovim/neovim/pull/9345
+        // Once 0.3.2 is available and we've switched, we won't need this anymore.
+        if (Platform.isMac() && !requiredOptions.env["LANG"]) {
+            requiredOptions.env["LANG"] = "en_us.UTF-8"
+            Log.warn(
+                "'LANG' environment variable not set, using default value of 'en_us.UTF-8'. Consider setting environment.additionalVariables['LANG'].",
+            )
         }
 
         requiredOptions.env.PATH = this.mergePathEnvironmentVariable(

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -155,7 +155,7 @@ export class Process implements Oni.Process {
             existingPath = process.env.Path || process.env.PATH
         }
 
-        let additionalEnvironmentVariables =
+        const additionalEnvironmentVariables =
             configuration.getValue("environment.additionalVariables") || {}
 
         const requiredOptions = {
@@ -170,8 +170,8 @@ export class Process implements Oni.Process {
         // TODO: Workaround for the bug fix here:
         // https://github.com/neovim/neovim/pull/9345
         // Once 0.3.2 is available and we've switched, we won't need this anymore.
-        if (Platform.isMac() && !requiredOptions.env["LANG"]) {
-            requiredOptions.env["LANG"] = "en_us.UTF-8"
+        if (Platform.isMac() && !requiredOptions.env.LANG) {
+            requiredOptions.env.LANG = "en_us.UTF-8"
             Log.warn(
                 "'LANG' environment variable not set, using default value of 'en_us.UTF-8'. Consider setting environment.additionalVariables['LANG'].",
             )

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -176,6 +176,7 @@ const BaseConfiguration: IConfigurationValues = {
     "explorer.maxUndoFileSizeInBytes": 500_000,
 
     "environment.additionalPaths": [],
+    "environment.additionalVariables": {},
 
     "keyDisplayer.showInInsertMode": false,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -214,6 +214,9 @@ export interface IConfigurationValues {
     // (and available in terminal integration, later)
     "environment.additionalPaths": string[]
 
+    // Additional environment variables that override the default settings
+    "environment.additionalVariables": any
+
     // User configurable array of files for which
     // the image layer opens
     "editor.imageLayerExtensions": string[]


### PR DESCRIPTION
__Issue:__ Oni was hitting https://github.com/neovim/neovim/issues/9134 when launched from finder in OSX Mojave, causing Neovim not to load.

__Defect:__ Prior to the fix in Neovim, if the `LANG` environment variable was not set in OSX, Neovim would crash. Resiliency on the Neovim side is added here: https://github.com/neovim/neovim/commit/57acfceabeb349377ce244de9b67732b21ed1d18

__Fix:__ For now - we'll just set a default (overridable) value in the case where `LANG` is not set. Once we pick up the `0.3.2` binaries, we won't need that anymore.

Fixes #2669 & #2396 