### PR TITLE
[WIP] Fix #2690 - Allow extra args to pass directly to Neovim

### DIFF
--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -105,11 +105,13 @@ export const start = async (args: string[]): Promise<void> => {
     const cssPromise = import("./CSS")
     const completionProvidersPromise = import("./Services/Completion/CompletionProviders")
 
-    const parsedArgs = minimist(args, { string: "_" })
+    const parsedArgs = minimist(args, { "--": true, string: "_" })
     const currentWorkingDirectory = process.cwd()
     const normalizedFiles = parsedArgs._.map(
         arg => (path.isAbsolute(arg) ? arg : path.join(currentWorkingDirectory, arg)),
     )
+
+    const additionalArgs = parsedArgs["--"] || [];
 
     const filesToOpen = normalizedFiles.filter(f => {
         if (fs.existsSync(f)) {
@@ -293,6 +295,7 @@ export const start = async (args: string[]): Promise<void> => {
     const initializeAllEditors = async () => {
         await startEditors(
             filesToOpen,
+            additionalArgs,
             Colors.getInstance(),
             CompletionProviders.getInstance(),
             configuration,

--- a/browser/src/App.ts
+++ b/browser/src/App.ts
@@ -111,7 +111,7 @@ export const start = async (args: string[]): Promise<void> => {
         arg => (path.isAbsolute(arg) ? arg : path.join(currentWorkingDirectory, arg)),
     )
 
-    const additionalArgs = parsedArgs["--"] || [];
+    const additionalArgs = parsedArgs["--"] || []
 
     const filesToOpen = normalizedFiles.filter(f => {
         if (fs.existsSync(f)) {

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -1001,8 +1001,13 @@ export class NeovimEditor extends Editor implements Oni.Editor {
         additionalArgs?: string[],
         startOptions?: Partial<INeovimStartOptions>,
     ): Promise<void> {
-        Log.info("[NeovimEditor::init] Called with filesToOpen: " + filesToOpen + " and args: " + additionalArgs);
-        additionalArgs = additionalArgs || [];
+        Log.info(
+            "[NeovimEditor::init] Called with filesToOpen: " +
+                filesToOpen +
+                " and args: " +
+                additionalArgs,
+        )
+        additionalArgs = additionalArgs || []
         const defaultOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
             transport: this._configuration.getValue("experimental.neovim.transport"),

--- a/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor/NeovimEditor.tsx
@@ -998,15 +998,18 @@ export class NeovimEditor extends Editor implements Oni.Editor {
 
     public async init(
         filesToOpen: string[],
+        additionalArgs?: string[],
         startOptions?: Partial<INeovimStartOptions>,
     ): Promise<void> {
-        Log.info("[NeovimEditor::init] Called with filesToOpen: " + filesToOpen)
+        Log.info("[NeovimEditor::init] Called with filesToOpen: " + filesToOpen + " and args: " + additionalArgs);
+        additionalArgs = additionalArgs || [];
         const defaultOptions: INeovimStartOptions = {
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
             transport: this._configuration.getValue("experimental.neovim.transport"),
             neovimPath: this._configuration.getValue("debug.neovimPath"),
             loadInitVim: this._configuration.getValue("oni.loadInitVim"),
             useDefaultConfig: this._configuration.getValue("oni.useDefaultConfig"),
+            additionalArgs: additionalArgs,
         }
 
         const combinedOptions = {

--- a/browser/src/Editor/OniEditor/OniEditor.tsx
+++ b/browser/src/Editor/OniEditor/OniEditor.tsx
@@ -331,10 +331,10 @@ export class OniEditor extends Utility.Disposable implements Oni.Editor {
         this._neovimEditor.bufferDelete(bufferId)
     }
 
-    public async init(filesToOpen: string[]): Promise<void> {
+    public async init(filesToOpen: string[], additionalArgs?: string[]): Promise<void> {
         Log.info("[OniEditor::init] Called with filesToOpen: " + filesToOpen)
 
-        return this._neovimEditor.init(filesToOpen)
+        return this._neovimEditor.init(filesToOpen, additionalArgs)
     }
 
     public async input(key: string): Promise<void> {

--- a/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
+++ b/browser/src/Services/Learning/Tutorial/TutorialBufferLayer.tsx
@@ -132,7 +132,7 @@ export class TutorialBufferLayer implements Oni.BufferLayer {
             alert("quit!")
         })
 
-        this._initPromise = this._editor.init([], {
+        this._initPromise = this._editor.init([], [], {
             loadInitVim: false,
         })
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -128,15 +128,15 @@ export const startNeovim = async (
 
     const argsToPass = initVimArg
         .concat([
-        "--cmd",
-        `let &rtp.=',${joinedRuntimePaths}'`,
-        "--cmd",
-        "let g:gui_oni = 1",
-        "-N",
-        "--embed",
+            "--cmd",
+            `let &rtp.=',${joinedRuntimePaths}'`,
+            "--cmd",
+            "let g:gui_oni = 1",
+            "-N",
+            "--embed",
         ])
         .concat(options.additionalArgs)
-        .concat(["--"]);
+        .concat(["--"])
 
     Log.verbose(
         "[NeovimProcessSpawner::startNeovim] Sending these args to Neovim: " +

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -32,6 +32,9 @@ export interface INeovimStartOptions {
     // Explicitly specify the path to Neovim. If not specified,
     // the default path will be used.
     neovimPath?: string
+
+    // Additional arguments to pass directly to Neovim
+    additionalArgs: string[]
 }
 
 const DefaultStartOptions: INeovimStartOptions = {
@@ -39,6 +42,7 @@ const DefaultStartOptions: INeovimStartOptions = {
     transport: "stdio",
     loadInitVim: true,
     useDefaultConfig: true,
+    additionalArgs: [],
 }
 
 const getSessionFromProcess = async (
@@ -122,15 +126,17 @@ export const startNeovim = async (
         initVimArg = ["-u", loadInitVimConfigOption]
     }
 
-    const argsToPass = initVimArg.concat([
+    const argsToPass = initVimArg
+        .concat([
         "--cmd",
         `let &rtp.=',${joinedRuntimePaths}'`,
         "--cmd",
         "let g:gui_oni = 1",
         "-N",
         "--embed",
-        "--",
-    ])
+        ])
+        .concat(options.additionalArgs)
+        .concat(["--"]);
 
     Log.verbose(
         "[NeovimProcessSpawner::startNeovim] Sending these args to Neovim: " +

--- a/browser/src/neovim/SharedNeovimInstance.ts
+++ b/browser/src/neovim/SharedNeovimInstance.ts
@@ -167,6 +167,7 @@ class SharedNeovimInstance implements SharedNeovimInstance {
 
     public async start(): Promise<void> {
         const startOptions: INeovimStartOptions = {
+            additionalArgs: [],
             runtimePaths: this._pluginManager.getAllRuntimePaths(),
             loadInitVim: false,
             useDefaultConfig: true,

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -53,5 +53,5 @@ export const startEditors = async (
     )
     windowManager.createSplit("horizontal", editor)
 
-    await editor.init(filesToOpen, additionalArgs);
+    await editor.init(filesToOpen, additionalArgs)
 }

--- a/browser/src/startEditors.ts
+++ b/browser/src/startEditors.ts
@@ -22,7 +22,8 @@ import { windowManager } from "./Services/WindowManager"
 import { Workspace } from "./Services/Workspace"
 
 export const startEditors = async (
-    args: any,
+    filesToOpen: string[],
+    additionalArgs: string[],
     colors: Colors,
     completionProviders: CompletionProviders,
     configuration: Configuration,
@@ -52,5 +53,5 @@ export const startEditors = async (
     )
     windowManager.createSplit("horizontal", editor)
 
-    await editor.init(args)
+    await editor.init(filesToOpen, additionalArgs);
 }


### PR DESCRIPTION
This is a fix proposed by @CrossR for #2690 - we can pass any additional arguments after a `--` directly to Neovim. For example, `oni some-file.js -- -S my-session.vim`

Still needs to be tested / validated.