### PR TITLE
Use `.some` to short circuit & native `.includes`

### DIFF
--- a/main/src/Log.ts
+++ b/main/src/Log.ts
@@ -9,7 +9,7 @@ const logs = []
 let _isVerbose = false
 
 const isVerbose = () =>
-    process.argv.filter(arg => arg.indexOf("--verbose") >= 0).length > 0 || _isVerbose
+    process.argv.some(arg => arg.includes("--verbose")) || _isVerbose
 
 export const setVerbose = (verbose: boolean) => {
     _isVerbose = verbose


### PR DESCRIPTION
`Array.prototype.some` short-circuits when a value is true which is better for performance and makes the intention more clear. Native `String.prototype.includes` is easier to read.

Now reading it as English, "if some argument includes 'verbose'"...