### PR TITLE
Fix typo in plugin name targets.vim

### DIFF
--- a/browser/src/Services/Learning/Tutorial/Tutorials/TargetsVimPluginTutorial.tsx
+++ b/browser/src/Services/Learning/Tutorial/Tutorials/TargetsVimPluginTutorial.tsx
@@ -157,9 +157,9 @@ export class TargetsVimPluginTutorial implements ITutorial {
     public get metadata(): ITutorialMetadata {
         return {
             id: "oni.tutorials.targets_plugin",
-            name: "Target.vim plugin",
+            name: "Targets.vim plugin",
             description:
-                'Target.vim is a plugin installed by default to help move between pairs of characters such as (), {}, or "".  It does this by adding various text objects to operate on and expand simple commands like \'di"\'.',
+                'Targets.vim is a plugin installed by default to help move between pairs of characters such as (), {}, or "".  It does this by adding various text objects to operate on and expand simple commands like \'di"\'.',
             level: 300,
         }
     }


### PR DESCRIPTION
Hey there!

As the author of targets.vim I'm honoured and want to thank you for including targets.vim as a default plugin! That really means a lot to me! ❤️

I just tried to check it out, but ran into the same issue reported in https://github.com/onivim/oni/issues/2688.

But I also noticed that the plugin was referred to `targets.vim` as `target.vim` in two places. This PR should fix that.

Thanks again, and good luck for the Oni project!