### PR TITLE
Fix NeoVIM >= 0.3.2

### DIFF
--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -129,6 +129,7 @@ export const startNeovim = async (
         "let g:gui_oni = 1",
         "-N",
         "--embed",
+        "--headless",
         "--",
     ])
 


### PR DESCRIPTION
* NeoVIM 0.3.2 changed the command line options so that --embed no
  longer implies --headless. This adds it back to be explicitly set.
* See neovim/neovim@4da5cb38d396d76d8072815d150725f7c9a85078

https://github.com/onivim/oni/issues/2704#issuecomment-453270503 @CrossR mentions working on what's probably a more proper update based on the new behavior for neovim>=0.3.2. This PR just restores the previous behavior.

I believe this closes #2706 and also closes #2704