### PR TITLE
Dependency: Remove bs-platform dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -935,7 +935,6 @@
         "azure-storage": "^2.8.1",
         "babel-minify-webpack-plugin": "^0.3.1",
         "babel-plugin-dynamic-import-node": "^1.2.0",
-        "bs-platform": "2.1.0",
         "codecov": "^3.0.0",
         "color": "2.0.0",
         "concurrently": "3.1.0",

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -76,7 +76,7 @@ const WindowsOnlyTests = [
     "Regression.1819.AutoReadCheckTimeTest",
 ]
 
-const OSXOnlyTests = ["AutoCompletionTest-Reason", "OSX.WindowTitleTest"]
+const OSXOnlyTests = ["OSX.WindowTitleTest"]
 
 // tslint:disable:no-console
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1961,10 +1961,6 @@ browserslist@~1.3.5:
   dependencies:
     caniuse-db "^1.0.30000525"
 
-bs-platform@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.1.0.tgz#63560ff8f7142c9c0631559df1c35590b9f6d8b2"
-
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"


### PR DESCRIPTION
This removes the `bs-platform` dependency, which is blocking investigation of #2732 